### PR TITLE
Add /aidocs/ cleanup analysis for the GitHub mirror

### DIFF
--- a/aidocs/cleanup-plan.md
+++ b/aidocs/cleanup-plan.md
@@ -1,0 +1,95 @@
+# Cleanup Plan — shepard
+
+Executive summary. Snapshot date: 2026-05-04. Detail in the other `/aidocs/` documents.
+
+## Repository at a glance
+
+shepard is a multi-database research-data platform from DLR (Augsburg). Backend: Quarkus 3.27 / Java 21. Frontend: Nuxt 3 / Vuetify. Persistence: Neo4j, MongoDB, Postgres+TimescaleDB, Postgres+PostGIS. Auth: external OIDC + long-lived API keys.
+
+GitHub `noheton/shepard` is a mirror of GitLab `dlr-shepard/shepard`. **GitLab is authoritative.** The mirror is in sync at the issue level (zero state mismatches across 973 GH ↔ 693 GL items, 99.9% match), but **MR mirroring stopped on 2024-09-16** so ~23 open + 80-100 closed/merged GitLab MRs are not represented on GitHub.
+
+The project is in a **handover / wind-down phase**: active milestones include `Handover period` and `Interim`; multiple `xit-*` external-contractor assignees; many `staus::longterm` (sic) and `stale` labels; 79% of open issues are stale or very stale.
+
+## Findings at a glance
+
+| Area | Headline |
+|---|---|
+| **Security** | 5 CRITICAL findings, 8 HIGH — none tracked in GitLab. Most pressing: SQL injection in spatial query builder, CORS wildcard, permissions-fallback that grants full access to entities without a Permissions node, SSRF/ReDoS in subscription webhooks, Cypher injection in search query builder. |
+| **CI/CD** | SpotBugs + findsecbugs configured but never run by CI (live in `<reporting>` only). No SAST, no container image scanning, no E2E tests, no frontend tests. Main branch pipeline only runs `check`. |
+| **Test coverage** | Backend overall 0.74 ratio. HIGH risk: timeseries 0.37, spatialdata 0.26, neo4j 0.29, search 0.38, labJournal 0.20. **Frontend has zero tests.** |
+| **Dependencies** | 19 open Renovate MRs. `dotenv` (PyPI orphan) declared in `scripts/` — supply-chain risk. jjwt 0.11 (EOL) still in use. JWT API-key tokens minted without expiration. Nuxt 4, ESLint 9 not adopted. Renovate config has a silent typo (`natchUpdateTypes`). |
+| **Issues / MRs** | 166 open issues (35 fresh, 86 stale, 45 very stale). 23 open MRs (only !498 bit-rotted at 402 days). Sprint 23 / shepard 5.4.2 milestone is in flight (timeseries refactor). |
+| **Mirror** | 1 issue gap (#557), 23 open + many closed MR gaps; 4 PRs closed on GitHub while their GitLab MR is still open; 1 orphan GH issue (gh#683). |
+
+## Critical security findings (no remediation tracked anywhere)
+
+| ID | Severity | Where | One-line |
+|---|---|---|---|
+| C1 | Critical | `data/spatialdata/repositories/NativeQueryStringBuilder.java` | SQL injection via `'%s'` interpolation of JSON metadata |
+| C2 | Critical | `application.properties:18-21` | CORS `origins=*` with state-changing methods + Authorization header |
+| C3 | Critical | `auth/permission/services/PermissionsService.java:258-262` | Permissions fallback grants full read/write/manage when an entity has no Permissions node |
+| C4 | Critical | `common/filters/SubscriptionFilter.java:63-78` | SSRF (no URL allowlist) + ReDoS (no regex timeout) on every successful response |
+| C5 | Critical | `common/search/query/Neo4jQueryBuilder.java` | Cypher injection via user-controlled property names and IRI types |
+
+See `security-issues.md` for full detail and remediations.
+
+## Phased plan (high level)
+
+| Phase | Focus | Outcome |
+|---|---|---|
+| **0** | Housekeeping | Mirror re-sync (#557 + MR mirror); file untracked findings; trivial config/doc fixes (Renovate typo, ADR index) |
+| **1** | Security fixes | Ship C1-C5 (CRITICAL), then H1-H8 (HIGH); activate SpotBugs+findsecbugs in CI; add Trivy + lint-security |
+| **2** | First issues | Verify-close #710 / #711; fix #721 race condition, #717 metadata permission, #667 permission bug; replace `dotenv`; scaffold Vitest; ship #720 frontend column export |
+| **3** | Core improvements | Permissions Hardening epic; Subscription Hardening; close out Sprint 23 / 5.4.2; medium security findings |
+| **4** | Larger work | Cluster E (Neo4j refactor); Cluster D (semantics, gated on E); product decision on spatial; Cluster B versioning frontend |
+| **5** | Dependency / code quality | Drain 19 Renovate MRs in batches sequenced around feature work; close code-quality TODOs |
+| **6** | Backlog closure | Bulk-close UX cluster #642-#645, ~70 long-tail research/refactoring items, !498 bit-rotted MR, low-value versioning items |
+
+See `implementation-plan.md` for full detail.
+
+## Recommended immediate actions
+
+1. **File the 5 critical security findings as GitHub issues** (C1-C5). They are not tracked anywhere today.
+2. **Activate SpotBugs + findsecbugs in CI** by moving the plugins from `<reporting>` to `<build>`. This is a small change with the biggest leverage in Phase 1.
+3. **Fix the `renovate.json` typo** (`natchUpdateTypes` → `matchUpdateTypes`); replace `dotenv` with `python-dotenv` in `scripts/`.
+4. **Verify-and-close #710 and #711** to confirm Sprint 23 progress.
+5. **Re-enable MR mirroring** so the GitHub mirror reflects GitLab MRs again.
+6. **Assign explicit ownership** for the Permissions Hardening epic (C3 + #41/#62/#424/#483/#667 + H1/H2/H7) and the Cluster E Neo4j refactor — both are at risk of indefinite slip in the handover phase.
+
+## Recommended bulk-closure pass (maintainer sign-off required)
+
+Consolidating ~80-90 issues to recover backlog signal:
+
+- ~70 long-tail research / refactoring items (very stale, no owner, project in wind-down)
+- 4 UX-triage items (#642-#645)
+- 9 spatial backlog items if product decision is "deprecate"
+- 2-3 low-value versioning items (#150, #155, #271)
+- 1 bit-rotted MR (!498)
+- 1-2 likely-superseded drafts (!80)
+
+Closing comments and confidence levels in `ready-to-close.md`.
+
+## Risks worth flagging to stakeholders
+
+1. **Five critical untracked security findings** — first priority.
+2. **Frontend has zero tests** — every frontend change is a regression risk; this needs to change before any meaningful frontend feature work is committed.
+3. **Cluster E (Neo4j refactor) is foundational and ownerless** — every month it slips, semantic-annotation work and parts of timeseries slip with it.
+4. **Permissions Hardening epic is ownerless** — the cluster has been long-standing; C3 elevates it from tech-debt to security priority.
+5. **Renovate vs feature-MR collisions** — Quarkus !723 vs !808/!809; nuxt !722/!758 vs #720. Sequence carefully.
+6. **Handover phase reduces capacity** — favour scope reduction and closure over ambitious new starts.
+
+## Documents in `/aidocs/`
+
+| File | Contents |
+|---|---|
+| `repo-overview.md` | Codebase structure, tech stack, CI/CD baseline, architecture + wiki synthesis, gaps |
+| `issues-status.md` | Full open-issue gauging by cluster (effort / complexity / value / confidence / test risk / staleness / impl status) |
+| `reconciliation.md` | GitHub vs GitLab table, mirror gaps, sync actions |
+| `security-issues.md` | All findings by severity (5 critical, 8 high, 12 medium, ~8 low/info) |
+| `dependency-report.md` | Outdated, deprecated, CVE-affected packages with recommended actions; Renovate analysis |
+| `code-quality.md` | Dead code, TODOs, test coverage map, frontend zero-tests, cross-references |
+| `cluster-map.md` | Issue/MR clusters with dependency graph, epics, sequencing recommendations, risk callouts |
+| `ready-to-close.md` | Items to close on GitHub with evidence and closing-comment drafts |
+| `first-issues.md` | Ranked entry-point shortlist for new contributors |
+| `implementation-plan.md` | Full phased plan with effort totals, risks, cluster references, suggested order |
+| `cleanup-plan.md` | This document — executive summary |

--- a/aidocs/cluster-map.md
+++ b/aidocs/cluster-map.md
@@ -1,0 +1,197 @@
+# Cluster Map — shepard
+
+Snapshot date: 2026-05-04. Synthesized from Wave 1-3 outputs.
+
+## Cluster summary
+
+| Cluster | Items | Primary modules | Depends on | Blocks | Status |
+|---|---|---|---|---|---|
+| **A. Timeseries Active (5.4.2)** | #710 (DONE), #711 (DONE), #712-#716 + !808/!809, #717, #720, #721 | `data/timeseries`; frontend timeseries pages | E (long-term); J (Quarkus !723) | #720 blocked on #711 backend shape | **Active** (lettfe, mvistein) |
+| **B. Versioning Frontend** | #46, #127, #150, #155, #271 | `frontend/components/version/*` (missing); backend `context/version` (done) | Frontend test infra (none today) | Nothing critical | **Stale** |
+| **C. Spatial Data** | #441-#447, #530, #557; security C1 | `data/spatialdata`; feature flag `SHEPARD_SPATIAL_DATA_ENABLED` | C1 SQL injection fix; spatial test investment | Removing feature flag / GA | **Stale, gated** |
+| **D. Semantic Annotations** | #43, #553, #656, #660 | `data/semantic`; `common/neo4j` | E (Neo4j refactor) | — | **Stale, blocked** |
+| **E. Neo4j Refactor** | #274, #577, #660 | `common/neo4j` | — | D fully; A long-term; H partially | **Stale, foundational** |
+| **F. Permissions / Admin** | #41, #62, #424, #483, #667; tech-debt #1, #2 | `auth/permission`, `auth/users`, `auth/security` | C3 fix; H1; H2 | #717 (perm leak in A); compliance posture | **Long-standing, NOT_IMPL** |
+| **G. UX Triage (2025-06-06)** | #642-#645 | Frontend (cross-cutting) | — | — | **Stale, triage-eligible** |
+| **H. Recent Bugs / Search** | #696-#707; security C5 | `common/search`; `data/timeseries` (plot); audit trail | E (partially) | — | **Mixed** (some likely DONE) |
+| **I. Long-tail Research** | Aras, Nexus, Object Storage, Workflow Mgmt evals (~90 items) | Cross-cutting / external | — | — | **Very stale, SUPERSEDED candidates** |
+| **J. Renovate Deps** | !636, !647, !695, !722, !723, !734, !740, !758, !766, !779, !780, !803-!806, !810; #718 meta | All; build & runtime | — | Conflicts with A (Quarkus !723) and #720 (nuxt !722/!758) | **Active, mechanical** |
+| **K. Bit-rotted MR** | !498 (402d idle) | Frontend versioning (cluster B) | B's frontend infra | — | **Close or rebase** |
+
+### Cross-cluster items
+
+- **#660** sits in both D and E (semantics depend on Neo4j model change).
+- **#717** is in A but is fundamentally an F (permissions) bug.
+- **C3** (permissions fallback) cross-cuts F and tech-debt #1.
+- **C5** (Cypher injection) sits in H but touches every search-using module (timeseries, semantic, references, collections).
+- **C2** (CORS wildcard) and **H4** (ExceptionMapper leaks) cross-cut everything (Common.Configuration / Common.Exceptions).
+- **H6** (`dotenv` supply chain) belongs to J but materially affects scripts and developer onboarding.
+- **H7** (jjwt 0.11 EOL) lives in J but lands in F (auth code paths).
+
+## Cross-cluster dependency graph
+
+```
+                 ┌────────────────────────────────────┐
+                 │ E. Neo4j Refactor                  │
+                 │   #274 #577 #660                   │
+                 └────────┬──────────────┬────────────┘
+                          │              │
+                          ▼              ▼
+                  ┌──────────────┐  ┌─────────────────┐
+                  │ D. Semantic  │  │ H. Search/Bugs  │
+                  │ #43 #553     │  │ #696-#707, C5   │
+                  │ #656 #660    │  │                 │
+                  └──────────────┘  └─────────────────┘
+                          ┊
+                          ┊  long-term
+                          ▼
+                  ┌────────────────────────────────────┐
+                  │ A. Timeseries Active                │
+                  │  #710-#721, !808/!809               │
+                  └─────┬─────────────────┬─────────────┘
+                        │                 │
+                        ▼                 ▼
+              ┌──────────────────┐ ┌─────────────────┐
+              │ #717 perm leak   │ │ #720 frontend   │
+              │   ── into ──>F   │ │   needs FE test │
+              └──────────────────┘ │   infra (Epic 6)│
+                                   └─────────────────┘
+
+      ┌────────────────────────────────────────────┐
+      │ F. Permissions / Admin                     │
+      │   #41 #62 #424 #483 #667                   │
+      │   + C3 (CRITICAL), H1, H2, H7              │
+      │   + tech-debt #1, #2                       │
+      └────────────────────────────────────────────┘
+
+      ┌─────────────────────────┐  ┌──────────────────────┐
+      │ C. Spatial (gated)      │  │ Subscriptions: C4    │
+      │  #441-447, #530, #557   │  │  (independent module)│
+      │  + C1 (CRITICAL SQLi)   │  └──────────────────────┘
+      └─────────────────────────┘
+
+      ┌────────────────────────────────────────────┐
+      │ J. Renovate (collides with A and #720)     │
+      │  !723 Quarkus  ↔  !808/!809                │
+      │  !722/!758 nuxt ↔ #720                     │
+      └────────────────────────────────────────────┘
+
+      ┌─────────────────────────┐  ┌──────────────────────┐
+      │ B. Versioning Frontend  │  │ K. !498 (bit-rotted) │
+      │  #46 #127 #150 #155 #271│  │   close or rebase    │
+      └────────────┬────────────┘  └──────────────────────┘
+                   │
+                   ▼
+       ┌──────────────────────────────┐
+       │ Frontend Test Infra (none)   │
+       │   prerequisite for B, #720, K│
+       │   ↳ Epic 6                   │
+       └──────────────────────────────┘
+```
+
+### Reading the graph
+
+- **E** is the deepest blocker (D fully, parts of H, long-term A).
+- **F** is the deepest *security* blocker — C3, H1, H2, H7, tech-debt #1, #2, and one A-cluster issue (#717) all converge here.
+- **Frontend test infrastructure** is a missing prerequisite node for any meaningful frontend work (B, #720, K).
+- **CI/SAST enabling** does not block specific issues but materially de-risks every security cluster.
+- **J's Renovate MRs** are mechanically independent but practically collide with A (Quarkus !723 ↔ !808/!809) and #720 (nuxt !722/!758).
+
+### Module hot-spots (broad blast radius)
+
+- `common/neo4j` — touched by A (long-term), D, E, H. Change here cascades.
+- `auth/permission` — touched by A (#717), F, tech-debt #1. Single biggest hot-spot beyond Neo4j.
+- `common/search` — touched by H + every cluster that queries data. C5 fix has the broadest blast radius.
+- `common/configuration` — touched by C2, H8. CORS / credential changes land here.
+
+## Logical feature-sets (epics)
+
+### Epic 1 — Timeseries Column Export, full-stack
+- **Rationale**: #711 backend done; #720 frontend stranded. Timeseries module test coverage 0.37 (HIGH risk). Shipping these together prevents partial-feature drift and forces test investment in the riskiest backend module.
+- **Items**: #711 (verify-close), #720 (frontend), regression tests for column-export endpoint, frontend Vitest scaffolding for the export page (kicks off frontend test infra).
+- **Sequencing**: finish !808/!809 → cut 5.4.2 → start #720 → land Vitest scaffolding alongside.
+- **Tests**: backend integration tests for column-export endpoint shape; first frontend component tests in the codebase.
+
+### Epic 2 — Permissions Hardening
+- **Rationale**: F + C3 + H1 + H2 + #717 + tech-debt #1, #2 are one logical entity. C3 (permissions fallback) is critical and a single fix cascades.
+- **Items**: C3 fallback fix → H1 + H7 (JWT expiry + jjwt upgrade together) → H2 (cache TTL one-liner) → #717 → triage of #41/#62/#424/#483/#667 → tech-debt #1.
+- **Sequencing**: C3 first (severity); H1 + H7 paired; H2 simultaneously; then #717; then permissions-cluster review.
+- **Tests**: Auth.Permissions module needs negative-path coverage *before* C3 fix to lock in current behaviour, then refactor.
+
+### Epic 3 — Spatial Data Decision (graduate or deprecate)
+- **Rationale**: Cluster C is gated behind a feature flag with critical SQL injection (C1). Test coverage 0.26. Decision needed before further investment.
+- **Items**: C1 SQL injection fix; product decision on graduation; if graduate, batch #441-#447 / #530 / #557 + spatial integration tests + remove feature flag; if deprecate, document and remove.
+- **Sequencing**: C1 first (security regardless); then product decision; then either graduation or deprecation work.
+- **Tests**: Geometry encoding edge cases, SRID handling, parameterised SQL coverage.
+
+### Epic 4 — Subscription Hardening
+- **Rationale**: C4 (SSRF + ReDoS) is self-contained in `common/subscription`; module-isolated, no current test investment.
+- **Items**: C4 SSRF allowlist; C4 ReDoS regex bound; subscription unit + integration tests.
+- **Sequencing**: Independent — can run in parallel with anything.
+- **Tests**: Adversarial URL fixtures, regex catastrophic-backtracking benchmarks.
+
+### Epic 5 — Search & Neo4j Hardening
+- **Rationale**: C5 (Cypher injection) cross-cuts cluster H; cluster E is the structural fix that makes C5 robust rather than patched. Search test coverage 0.38.
+- **Items**: C5 Cypher parameterisation; cluster E (#274, #577, #660); affected H bugs (#696-#707 search-related); search regression test suite.
+- **Sequencing**: C5 patch first as defence-in-depth → start E refactor (long, foundational) → land #660 (semantic, depends on E) as the proof point → close out D in its wake.
+- **Tests**: Cypher query parameterisation tests; Neo4j contract tests for the refactored model.
+
+### Epic 6 — Frontend Foundation (enabler, not feature)
+- **Rationale**: Zero frontend tests. Cluster B + #720 + K cannot be safely refactored without a baseline. This epic produces test infra, not features.
+- **Items**: Vitest + Vue Test Utils setup; Playwright e2e for one critical flow (login + collection list); component tests for any component touched by Epic 1's #720.
+- **Sequencing**: Begins concurrent with Epic 1's frontend work — first tests land *with* #720.
+- **Tests**: Self-meta — this is the test investment.
+
+### Epic 7 — CI Security Plumbing (enabler)
+- **Rationale**: SAST + dependency scanning + secret scanning in CI converts every future PR into a security-aware one. De-risks all of F, C, H, Subscription work.
+- **Items**: Activate SpotBugs+findsecbugs in `<build>` (move from `<reporting>`, fail on Medium); enable GitLab SAST template; add Trivy for container scanning; add `bandit` or `semgrep` for `scripts/`; extend secret scanning to fail on default values like `shepard_secret`.
+- **Sequencing**: Land before Epic 2 starts shipping fixes (so fixes are validated by automated checks).
+
+### Epic 8 — Dependency Update Hygiene
+- **Rationale**: Cluster J + #718 meta-issue. 19 open Renovate MRs is debt and a collision risk. H6 (`dotenv`) and H7 (jjwt) are security-flavoured.
+- **Items**: Drain J in batches; replace `dotenv` with `python-dotenv`; fix `renovate.json` typo (`natchUpdateTypes`); prune stale Vue 2-era pins; relax `<0.12` jjwt and `<5.11` junit pins.
+- **Sequencing**: Non-colliding MRs (build tooling, frontend libs not touching #720) first, in parallel with everything; Quarkus !723 *after* !808/!809 land; nuxt !722/!758 *after* #720 lands; H6 and H7 prioritised within their batches.
+
+## Sequencing recommendations
+
+### MUST go first (blocking or critical)
+1. **C3 permissions fallback fix** — critical severity, simplest blocker to ship.
+2. **C5 Cypher injection patch** — critical, defence-in-depth before any E refactor.
+3. **C1 SQL injection (spatial)** — critical even if cluster C is deprecated.
+4. **Finish A's #712-#716 refactor (!808/!809)** — already in flight; blocks 5.4.2 cut and creates merge-conflict surface for J.
+5. **Epic 7 CI plumbing** — enables every later security fix.
+
+### SHOULD be parallel (independent)
+- **Epic 4 (Subscription)** — module-isolated.
+- **Epic 6 (Frontend foundation)** — enables but doesn't block; can start anytime.
+- **Renovate non-colliding batch** — mechanical, parallelisable.
+- **Epic 2 sub-items H1, H2, H7** — small, low-conflict; can land while A is still in flight.
+- **Cluster G (UX triage)** — pure triage, no engineering dependency; close or schedule.
+
+### Can-defer (low value or blocked)
+- **Cluster I (long-tail research)** — most are SUPERSEDED candidates; close en masse.
+- **Cluster K (!498)** — close unless reviver volunteers; rebase cost > value.
+- **Cluster B feature work** — defer until Epic 6 frontend test infra exists; otherwise risks the same bit-rot as !498.
+- **Cluster D feature work** — gated on E's refactor; queue behind Epic 5.
+- **Cluster C feature work** beyond C1 — gate on product graduation decision.
+
+### Depends on infrastructure improvements
+- **Frontend feature work (B, #720, G)** ← Epic 6 (test infra).
+- **All security epics** ← Epic 7 (CI SAST/dep scanning).
+- **Epic 5 long-term** ← Cluster E completion (Neo4j model).
+- **Test coverage gates on critical modules** ← coverage CI thresholds (timeseries, semantic, search, labJournal HIGH risk).
+
+## Risk callouts
+
+1. **Quarkus update !723 vs A's !808/!809** — both touch backend dependency surface. Mitigation: freeze !723 until !808/!809 merge and 5.4.2 ships; rebase !723 after.
+2. **Nuxt updates !722/!758 vs #720 frontend export** — same Nuxt 3 / Vuetify surface. Mitigation: decide order — either land Renovate first and rebuild #720 against new versions, or land #720 first; do not interleave.
+3. **Cluster E Neo4j refactor is foundational and stale** — every month it slips, D, parts of A, and Epic 5's deep fix slip with it. Mitigation: explicit owner assignment.
+4. **C5 Cypher injection patch must NOT be conflated with E** — patch first as parameterisation, refactor later. Conflating delays the security fix behind a multi-month effort.
+5. **Permissions Epic 2 has no current owner** — F has been long-standing. C3 is critical. Mitigation: assign Epic 2 explicitly.
+6. **Frontend zero tests + active feature work (#720)** — every frontend MR is a regression risk. Mitigation: Epic 6 must start *with* #720, not after.
+7. **`dotenv` supply chain in scripts/** — low-effort to remove; high impact if compromised. Do not let it sit in J's queue.
+8. **jjwt 0.11 EOL + JWT no-expiry entanglement** — fixing H1 on EOL'd jjwt is wasted work; bundle H1+H7 in one MR.
+9. **`UserLastSeenCache` 30 min vs documented 5 min (H2)** — small fix but the doc/code drift signals Auth.Users lacks tests; treat as a coverage signal.
+10. **Renovate volume (19 MRs) creates review fatigue** — batch by risk class (frontend libs / build tooling / runtime / security-relevant) and review per batch.
+11. **Cluster I (research) eats backlog signal** — closing SUPERSEDED issues materially improves the ability to read the remaining 100ish issues. Do this before next planning round.
+12. **Test coverage HIGH-risk modules align with active feature work** (timeseries 0.37 ↔ A; search 0.38 ↔ Epic 5; labJournal 0.20 ↔ no current cluster but a latent bomb). Tie test investment to feature work; do not let A ship more code without coverage gain.

--- a/aidocs/code-quality.md
+++ b/aidocs/code-quality.md
@@ -1,0 +1,122 @@
+# Code Quality — shepard
+
+Snapshot date: 2026-05-04. Scope: `/home/user/shepard` at branch `claude/cleanup-github-mirror-f2bsP`.
+
+## Summary signals
+
+Positive:
+- Lombok consistently used (reduced boilerplate).
+- Modern testing stack (JUnit 5, Mockito 5, WireMock, JaCoCo).
+- Prettier formatting (JS/TS/YAML) and Ruff linting on Python scripts enforced in CI.
+- AsciiDoc Arc42 architectural documentation (well-structured even where chapters are stubs).
+- Renovate bot drives dependency hygiene with grouping and minimum release age 14 days.
+
+Concerns:
+- No Java linting in CI (CheckStyle / PMD / SpotBugs not invoked).
+- SpotBugs + findsecbugs configured but only in `<reporting>` (`backend/pom.xml:476-490`) — never run by `mvn verify`.
+- No frontend tests at all (Nuxt 3 app, zero `*.spec.*` / `*.test.*`).
+- ADR index file `architecture/src/09_architecture_decisions/index.adoc` does not include ADRs 019 and 020 (which exist on disk).
+- Architecture chapters that are TBD/stubs: `06_runtime_view`, `07_deployment_view`, the Solution Strategy quality table, `10_quality_requirements`, the Risks table.
+- Active label typo `staus::longterm` (vs intended `status::longterm`) is in use across multiple GitLab issues.
+
+## TODO / FIXME / HACK / XXX comments
+
+Total: **10**, all in backend Java; no TypeScript / Python technical-debt markers found.
+
+| File:line | Category | Note |
+|---|---|---|
+| `backend/src/test/java/de/dlr/shepard/auth/permission/services/PermissionsServiceSecondTest.java:36` | test consolidation | Merge with existing `PermissionsServiceTest` |
+| `backend/src/test/java/de/dlr/shepard/common/util/PKIHelperTest.java:22` | test methodology | "How to test filesystem interactions?" |
+| `backend/src/test/java/de/dlr/shepard/data/file/services/FileContainerServiceTest.java:309` | coverage gap | "Unit test doesn't test anything; needs partial mocking" |
+| `backend/src/test/java/de/dlr/shepard/data/structureddata/services/StructuredDataContainerServiceTest.java:258` | coverage gap | "Test doesn't properly test anything" |
+| `backend/src/main/java/de/dlr/shepard/auth/permission/io/PermissionsIO.java:43` | versioning/architecture | "Multiple entities post versioning (design issue)" |
+| `backend/src/main/java/de/dlr/shepard/data/structureddata/services/StructuredDataSearchService.java:87` | tech debt / migration | Deprecate MongoDB queries |
+| `backend/src/main/java/de/dlr/shepard/common/filters/SubscriptionFilter.java:62` | performance | "This could become a bottleneck" — see security finding C4 |
+| `backend/src/main/java/de/dlr/shepard/context/collection/services/DataObjectService.java:358` | performance | Inefficient loop generating `referencedIds` |
+| `backend/src/main/java/de/dlr/shepard/context/labjournal/endpoints/LabJournalEntryRest.java:41` | code organization | Refactor endpoint logic to service layer |
+| `backend/src/main/java/de/dlr/shepard/context/export/services/ExportService.java:92` | feature/design | "Add more export types, improve strategy pattern" |
+
+None of these reference an issue number; they are not visibly tracked in GitLab.
+
+## Test coverage map
+
+Backend: 315 production files, 232 test files (0.74 ratio overall), 183 unit tests + 42 integration tests.
+
+| Module | Prod | Tests | Ratio | Risk |
+|---|---|---|---|---|
+| **Data** |
+| timeseries | 30 | 11 | 0.37 | **HIGH** |
+| structureddata | 14 | 11 | 0.79 | MEDIUM |
+| spatialdata | 27 | 7 | 0.26 | **HIGH** |
+| file | 13 | 12 | 0.92 | LOW |
+| **Context** |
+| references | 47 | 37 | 0.79 | MEDIUM |
+| semantic | 22 | 13 | 0.59 | MEDIUM |
+| collection | 12 | 13 | 1.08 | LOW |
+| version | 7 | 10 | 1.43 | LOW |
+| export | 3 | 3 | 1.00 | LOW |
+| labJournal | 5 | 1 | 0.20 | **HIGH** |
+| **Auth** |
+| apikey | 6 | 5 | 0.83 | LOW |
+| permission | 5 | 6 | 1.20 | LOW |
+| users | 11 | 9 | 0.82 | LOW |
+| security | 10 | 4 | 0.40 | MEDIUM |
+| **Common** |
+| neo4j | 24 | 7 | 0.29 | **HIGH** |
+| search | 37 | 14 | 0.38 | **HIGH** |
+| subscription | 6 | 5 | 0.83 | LOW |
+| exceptions | 10 | 8 | 0.80 | LOW |
+| filters | 9 | 3 | 0.33 | MEDIUM |
+| mongoDB | 3 | 3 | 1.00 | LOW |
+| util | 17 | 9 | 0.53 | MEDIUM |
+
+### High-risk modules — gap detail
+
+- **timeseries (0.37)** — `TimeseriesDataPointRepository` and `TimeseriesRepository` have **no test classes**. Aggregation, grouping, fill-option logic untested in isolation. Active feature work (Sprint 23 #712-#716) lands in this module.
+- **spatialdata (0.26)** — `SpatialDataPointRest` has no test class; geometric models (`BoundingSphere`, `OrientedBoundingBox`, `KNearestNeighbor`) untested. Houses security finding C1 (SQL injection).
+- **neo4j (0.29)** — Core graph layer. `GenericDAO` has basic tests; relationship mapping and transaction handling lack depth.
+- **search (0.38)** — Houses security finding C5 (Cypher injection). Edge cases in query validation, semantic search, and Neo4jQueryBuilder are thinly covered.
+- **labJournal (0.20)** — Only `LabJournalTest.java` exists; no dedicated service tests.
+
+### Frontend tests
+
+**None.** No `*.spec.*` or `*.test.*` files anywhere under `frontend/`. No vitest / Jest / Playwright configuration. Zero unit, component, or e2e tests for a substantial Nuxt 3 + Vuetify app.
+
+### Load tests
+
+`load-tests/` contains 16 TypeScript k6 files. **Not integrated into CI** — runs manually only.
+
+### Scripts
+
+`scripts/` is a Poetry project with **no test files** (Ruff lint only).
+
+## Top 5 places to invest in tests
+
+1. **Timeseries repositories** — add `TimeseriesRepositoryTest` and `TimeseriesDataPointRepositoryTest`. Cover pagination, aggregation queries, time-range filtering. Aligns with Sprint 23 work.
+2. **Spatial REST endpoint** — add `SpatialDataPointRestTest` covering CRUD + query-param parsing. Mandatory before fixing security finding C1 (SQL injection) so behavior can be locked down.
+3. **Search query builders** — Neo4j and MongoDB query-builder edge cases. Required before / alongside security finding C5 (Cypher injection) fix.
+4. **LabJournal** — add `LabJournalServiceTest` and integration tests for end-to-end workflows.
+5. **Frontend Vitest scaffolding** — set up Vitest + Vue Test Utils; first targets: components touched by issue #720 (frontend column export) so the new feature can land alongside its tests, not after.
+
+## Code-organisation observations
+
+- `architecture/src/09_architecture_decisions/index.adoc` does not include ADRs 019 and 020. Minor doc bug.
+- `LabJournalEntryRest.java:41` flags endpoint logic that should move to the service layer — code-organisation drift.
+- `DataObjectService.java:358` flags an inefficient loop in `referencedIds` generation — performance smell flagged but unfiled.
+- `StructuredDataSearchService.java:87` flags MongoDB query deprecation — connects to the long-term Neo4j refactor cluster (#274, #577, #660).
+- Duplicate test class `PermissionsServiceSecondTest` should be merged into `PermissionsServiceTest`.
+
+## Cross-reference with open issues
+
+| Code-quality item | Related open issue | Action |
+|---|---|---|
+| `SubscriptionFilter.java:62` "could become a bottleneck" | (untracked) — also security C4 | File issue; bundle with C4 fix |
+| `DataObjectService.java:358` inefficient loop | (untracked) | Low-priority perf issue |
+| `LabJournalEntryRest.java:41` move logic to service | (untracked) | Refactor candidate |
+| `ExportService.java:92` strategy pattern | possibly relates to general export work | Triage |
+| `PermissionsIO.java:43` versioning/permissions | overlaps with versioning cluster (#46/#127/#150/#155/#271) and permissions cluster (#41/#62/#424/#483/#667) | Defer until Permissions Hardening epic |
+| `StructuredDataSearchService.java:87` deprecate MongoDB queries | overlaps with Neo4j refactor cluster (#274/#577/#660) | Defer / fold into refactor |
+| `FileContainerServiceTest.java:309` "doesn't test anything" | (untracked) | Test debt; pair with #721 race-condition fix |
+| `StructuredDataContainerServiceTest.java:258` "doesn't test anything" | (untracked) | Test debt |
+| `PermissionsServiceSecondTest.java:36` merge tests | (untracked) | Cleanup |
+| `PKIHelperTest.java:22` test filesystem | overlaps with security M2 (`0600` perms) | Bundle |

--- a/aidocs/dependency-report.md
+++ b/aidocs/dependency-report.md
@@ -1,0 +1,141 @@
+# Dependency Report — shepard
+
+Audit date: 2026-05-04. Manifests inspected:
+- `backend/pom.xml`
+- `clients/java/pom.xml` (parent only, no deps)
+- `package.json` (root tooling)
+- `frontend/package.json`
+- `backend-client/package.json` (generated)
+- `load-tests/package.json`
+- `clients/tests/typescript/package.json`
+- `scripts/pyproject.toml` (+ `scripts/poetry.lock`)
+- `clients/tests/python/requirements.txt`
+- `renovate.json`
+
+No `go.mod`, `Gemfile`, or `Cargo.toml`.
+
+## Top 10 priority upgrades
+
+1. **Replace `dotenv` with `python-dotenv`** in `scripts/pyproject.toml` — confirmed in `scripts/poetry.lock`. The PyPI `dotenv` package is a low-quality orphan re-export owned by a single account; supply-chain risk. Effort XS.
+2. **Verify `jinja2` lock ≥ 3.1.6** — `scripts/poetry.lock` resolves to 3.1.6 (good). Confirm in CI. CVE-2025-27516 (sandbox bypass), CVE-2024-22195/34064/56326 patched. Effort XS.
+3. **Fix `renovate.json` typo `natchUpdateTypes`** (line 21) — silently breaks the intended automerge filter for the `ruff` rule. Effort XS.
+4. **`jjwt` 0.11.5 → 0.12.x** — 0.11 branch is EOL; security patches now only land in 0.12+. Remove the `<0.12` Renovate pin. Effort S. Bundle with security finding H1 (JWT no-expiry).
+5. **Nuxt 3.20.2 → Nuxt 4.x** — Nuxt 4 released 2025; plan migration. Effort L. Coordinate with active frontend feature work.
+6. **ESLint 8 → 9** — 8.x is end-of-life; remove `eslint<9` Renovate pin and update ecosystem (`eslint-plugin-vue`, `@vue/eslint-config-*`). Effort M.
+7. **JUnit Jupiter 5.10.5 → 5.12+** — relax `<5.11` Renovate pin; small upgrade. Effort XS.
+8. **Quarkus 3.27.2 → latest LTS** — keep current with security patches. Effort S.
+9. **Python `^3.11` → `^3.12`** in `scripts/pyproject.toml` — align with ruff's `py312` target. Effort XS.
+10. **`@dlr-shepard/shepard-client` 5.1.2 → 5.2.0** in `clients/tests/typescript`; **`typescript` 5.5.3 → 5.6+** there. Sync with frontend & Python client. Effort XS.
+
+Bonus cleanup: prune stale Vue 2-era Renovate pins (`vue<3`, `vuex<4`, `vue-router<4`, `portal-vue<3`, `typescript<5`, `neo4j-ogm<4`, `bootstrap`, `@vue/tsconfig<0.2`) — these no longer match real dependencies.
+
+## Backend (Maven, Java 21, Quarkus)
+
+| Package | Current | Latest | Severity | Notes |
+|---|---|---|---|---|
+| `io.quarkus.platform:quarkus-bom` | 3.27.2 | LTS or 3.30.x | low | Recent; Renovate restricts to LTS |
+| `maven.compiler.release` | 21 | 21 LTS | none | Modern |
+| `hibernate-spatial` | 7.2.6.Final | 7.2.x | none | Aligned with Quarkus 3.27 |
+| `jjwt-api/impl/jackson` | 0.11.5 | 0.13.x | **medium** | EOL branch; remove `<0.12` Renovate pin |
+| `neo4j-ogm-core / bolt-driver` | 5.0.3 | 5.0.x latest patch | low | Renovate `<4` pin is stale (already on 5) |
+| `neo4j-cypher-dsl` | 2025.2.4 | 2025.x | none | Recent |
+| `org.codehaus.janino:janino` | 3.1.12 | 3.1.x | none | Current |
+| `junit-jupiter` | 5.10.5 | 5.12+ | low | Relax `<5.11` Renovate pin |
+| `org.mockito:mockito-core` | 5.22.0 | 5.x | none | Modern |
+| `org.projectlombok:lombok` | 1.18.44 | 1.18.x | none | Recent |
+| `org.assertj:assertj-core` | 3.27.7 | 3.27.x | none | Current (recent SECURITY bump) |
+| `nl.jqno.equalsverifier` | 4.4.1 | 4.x | none | Current |
+| `com.opencsv:opencsv` | 5.12.0 | 5.x | none | Up to date |
+| `commons-lang3` | 3.20.0 | 3.x | none | CVE-2025-48924 fixed in 3.18.0 — safe |
+| `commons-io` | 2.21.0 | 2.21.x | none | CVE-2024-47554 fixed in 2.18.0 — safe |
+| `org.jsoup:jsoup` | 1.22.1 | 1.20.x | low | CVE-2022-36033 fixed in 1.15.3 — safe |
+| `eu.michael-simons.neo4j:neo4j-migrations` | 3.2.1 | 3.x (4.x via MR !810) | none | Recent |
+| `edu.kit.datamanager:ro-crate-java` | 2.1.0 | 2.x | none | Current |
+| `io.quarkiverse.wiremock:quarkus-wiremock-test` | 1.5.3 | 1.x | none | Current |
+| `jakarta.servlet-api` | 6.1.0 | 6.1.x | none | Current |
+| `jacoco-maven-plugin` | 0.8.14 | 0.8.x | none | Current |
+| `spotbugs-maven-plugin` | 4.9.8.2 | 4.9.x | none | Configured but **not invoked in CI** — see security report |
+| `findsecbugs-plugin` | 1.14.0 | 1.14.x | none | Same — not invoked in CI |
+| `maven-pmd-plugin` | 3.28.0 | 3.28.x | none | Current |
+| `versions-maven-plugin` | 2.17.1 | 2.17.x | none | Renovate pin `<2.18` |
+| `license-maven-plugin` | 2.4.0 | 2.x | none | Renovate pin `<2.5` |
+
+Transitive dependencies (Jackson, Netty, Logback, Hibernate, Resteasy) are pulled at versions managed by Quarkus BOM 3.27.2. No direct `log4j-core`, no Spring Boot, no `jackson-databind <2.15`. None of the historical critical CVEs (Log4Shell, Spring4Shell, Jackson 2.9.x) are reachable.
+
+## Frontend (Nuxt 3 / Vue 3)
+
+| Package | Current | Latest | Severity | Notes |
+|---|---|---|---|---|
+| `nuxt` | 3.20.2 | Nuxt 4.x | medium | Plan migration within 6-12 months |
+| `vue` | 3.5.13 | 3.5.x | none | Recent |
+| `vuetify` | 3.12.1 | 3.x | none | Recent |
+| `@sidebase/nuxt-auth` | 0.10.1 | 0.10.x / 1.x | low | Pre-1.0 |
+| `@nuxt/fonts` | 0.14.0 | 0.x | low | Pre-1.0 |
+| `chart.js` | 4.5.1 | 4.x | none | Current |
+| `highlight.js` | 11.11.1 | 11.x | none | Current |
+| `@tiptap/*` | 3.20.0 | 3.x | none | Pinned consistently |
+| `vite` | ^6.0.0 | 6.x (Vite 7 available) | low | Vite 7 in 2025 |
+| `typescript` | ^5.6.2 | 5.6.x+ | none | Modern |
+| `vue-tsc` | 2.2.12 | 2.x/3.x | low | Track Vue tooling |
+| `eslint` (transitive) | restricted `<9` | 9.x | medium | Pin needs lifting; 8.x EOL |
+| `@nuxt/eslint` | 1.15.2 | 1.x | none | Recent |
+| `@types/node` | 24.11.0 | matches Node 24 | none | Modern |
+| `vite-plugin-vuetify` | 2.1.3 | 2.x | none | Current |
+| `sass / sass-loader` | ^1.81.0 / ^16.0.3 | current | none | Recent |
+
+## Root tooling (`/package.json`)
+
+| Package | Current | Severity | Notes |
+|---|---|---|---|
+| `@openapitools/openapi-generator-cli` | 2.19.1 | none | Current |
+| `concurrently` | 9.1.2 | none | Current |
+| `prettier` | 3.5.3 | none | Current |
+| `prettier-plugin-java` | 2.6.7 | none | Current |
+| `prettier-plugin-organize-imports` | 3.2.4 | low | Pinned `<4` (TS5 compat); revisit |
+| `rimraf` | 6.0.1 | none | Current |
+
+## Load tests (`/load-tests/package.json`)
+
+All current: `@types/k6` 1.6.0, `core-js` 3.48, `webpack` 5.105, `webpack-cli` 6.0.1 (MR !806 wants v7), `ts-loader` 9.5.4, `typescript` 5.6.3, `rimraf` 6.1.3.
+
+## clients/tests/typescript
+
+| Package | Current | Severity | Notes |
+|---|---|---|---|
+| `@dlr-shepard/shepard-client` | 5.1.2 | low | Lagging Python client (5.2.0); align |
+| `ts-node` | 10.9.2 | none | Current |
+| `typescript` | 5.5.3 | low | Behind frontend's 5.6.x |
+
+## Python (scripts + clients/tests/python)
+
+| Package | Declared | Severity | Notes |
+|---|---|---|---|
+| Python | `^3.11` (declared); ruff target `py312` | low | Bump to `^3.12` for consistency |
+| `python-gitlab` | 5.6.0 | none | Current |
+| `ruff` | 0.15.4 | none | Modern; `renovate.json` typo silently disables automerge filter |
+| `jinja2` | `^3.1.2` (lock 3.1.6) | none | All known 3.1.x CVEs patched in 3.1.6 |
+| `click` | `^8.1.7` | none | Current |
+| `ruamel-yaml` | `^0.19.0` | none | Current |
+| `pandas` | `^2.3.3` | none | Current |
+| `numpy` | `^2.3.5` | none | Modern (numpy 2) |
+| **`dotenv`** | `^0.9.9` | **medium** | Replace with `python-dotenv`; supply-chain risk |
+| `shepard-client` | 5.2.0 | none | In sync |
+
+## Renovate config summary (`renovate.json`)
+
+- Extends `config:recommended`, ignores `node_modules`/`bower_components`, runs config migration.
+- Base branch: `develop`.
+- OSV vulnerability alerts enabled, dependency dashboard enabled, label `dependencies`, minimum release age 14 days.
+- Grouping: develop, frontend ("nuxtend"), backend, infrastructure, scripts, load-tests, openapi-generator, shepard-client.
+- Quarkus updates grouped with custom PR body advising LTS-only.
+- Many legacy `<` pins for npm Vue 2 ecosystem (likely obsolete) and Java pins (`jjwt<0.12`, `neo4j-ogm<4`, `junit-jupiter<5.11`).
+- Image pins: `chronograf<1.10`, `neo4j<5`, `mongo<5`, `timescaledb` disabled.
+- **Bug**: typo `natchUpdateTypes` (line 21) breaks the intended automerge filter for ruff.
+
+## Open Renovate MRs (snapshot)
+
+The following GitLab MRs are in flight (mostly automerge-pending; not bit-rotted):
+
+`!636 develop`, `!647 openapi-generator-cli v7`, `!695 scripts (major)`, `!722 nuxtend (major)`, `!723 backend Quarkus`, `!734 python Docker tag v3.14.3`, `!740 timescaledb v2.26.3`, `!758 nuxtend`, `!766 infrastructure`, `!779 vuetify`, `!780 vue-tsc`, `!803 backend`, `!804 scripts`, `!805 load-tests`, `!806 webpack-cli v7`, `!810 neo4j-migrations v4`.
+
+**Sequencing risk**: `!723` (Quarkus) collides with active backend refactor MRs `!808/!809` (#712); `!722/!758` (nuxtend) collide with planned frontend work for #720. Hold dependency MRs touching the same surface area until the feature MR lands.

--- a/aidocs/first-issues.md
+++ b/aidocs/first-issues.md
@@ -1,0 +1,125 @@
+# First Issues — shepard
+
+Snapshot date: 2026-05-04. Ranked entry-points for new contributors. Excludes security findings (handled separately in `security-issues.md` and Phase 1 of `implementation-plan.md`).
+
+## Selection criteria
+
+Each pick is one or more of:
+- XS or S effort and low complexity
+- High value relative to effort
+- Partially implemented (clear next step)
+- Unblocks a cluster
+- Suitable for an outside contributor (well-scoped, no architectural debate required)
+
+## Ranked shortlist
+
+### 1. Verify-and-close #710 ("timeseries reference parameters")
+- **Status**: DONE — `TimeseriesReferenceRest.java:267-275` already exposes the requested parameters.
+- **Effort**: XS (read code, add a test if missing, close on GitLab with a one-line comment).
+- **Value**: medium — clears stale-but-fresh issue; confirms feature delivery.
+- **Why first**: zero-risk, builds reviewer trust, exercises the close-as-done flow.
+
+### 2. Verify-and-close #711 ("column-based CSV export")
+- **Status**: DONE — `CsvFormat.java`, `CsvColumnLineProvider.java`, commit `c4980a6`.
+- **Effort**: XS.
+- **Value**: medium — Sprint 23 / 5.4.2 milestone hygiene.
+- **Why**: same as #710; confirms backend completion to motivate #720 frontend work.
+
+### 3. #721 — Race condition in default file container
+- **Status**: NOT_IMPLEMENTED.
+- **Files**: `backend/src/main/java/de/dlr/shepard/data/file/services/FileContainerService.java` (no synchronization currently).
+- **Acceptance**: concurrent creation of a default file container does not produce duplicate `default` relations; integration test demonstrates fix.
+- **Effort**: S.
+- **Value**: high — data-integrity bug; fresh issue.
+- **Tests needed**: new integration test using `@QuarkusIntegrationTest` with concurrent calls.
+
+### 4. #717 — Timeseries metadata accessible without permissions
+- **Status**: NOT_IMPLEMENTED.
+- **Files**: `backend/src/main/java/de/dlr/shepard/data/timeseries/services/TimeseriesService.java:80` (`getTimeseriesById`), `getTimeseries`.
+- **Acceptance**: metadata access path enforces appropriate permission check (likely a metadata-only role distinct from container-read).
+- **Effort**: S.
+- **Value**: high — security-adjacent, fresh, in active milestone.
+- **Tests needed**: negative-path tests for unauthenticated and unprivileged access to metadata endpoints.
+- **Dependencies**: aligns with Permissions Hardening epic (`cluster-map.md` Epic 2).
+
+### 5. #667 — Recent permission bug (fresh)
+- **Status**: NOT_IMPLEMENTED, fresh.
+- **Effort**: S.
+- **Value**: high — fresh permission bug; aligns with C3 fallback work.
+- **Why**: Pairs naturally with C3 fix; small enough to land first as a unit-test-driven fix.
+
+### 6. !800 — Draft documentation update
+- **Status**: in flight, fresh draft MR.
+- **Effort**: S.
+- **Value**: medium — documentation hygiene; assigned RolandGlueck/kauf_pt/lettfe.
+- **Why**: ready to ship after review; low-risk merge.
+
+### 7. #722 — Search/UX bug (kauf_pt)
+- **Status**: NOT_IMPLEMENTED, fresh.
+- **Effort**: S.
+- **Value**: medium — owner already assigned.
+
+### 8. #688 / #683 — Fresh search bugs
+- **Status**: NOT_IMPLEMENTED, fresh.
+- **Effort**: S each.
+- **Value**: medium — search module test coverage is HIGH risk (0.38), so fixing these with tests adds doubled value.
+- **Tests needed**: regression tests in `common/search` module.
+
+### 9. Replace `dotenv` with `python-dotenv` in scripts
+- **Status**: H6 dependency security finding.
+- **Files**: `scripts/pyproject.toml:18`, `scripts/poetry.lock:158-169`.
+- **Acceptance**: `dotenv` removed from manifest and lock; CLI continues to work; smoke-tested locally.
+- **Effort**: XS.
+- **Value**: medium — supply-chain risk.
+- **Why**: trivial diff; obvious documented win.
+
+### 10. Fix `renovate.json` typo (`natchUpdateTypes`)
+- **Files**: `renovate.json:21`.
+- **Acceptance**: ruff Renovate rule's `matchUpdateTypes` filter applies as intended.
+- **Effort**: XS.
+- **Value**: low/medium — silently broken automerge filter is restored.
+
+### 11. Update ADR index
+- **Files**: `architecture/src/09_architecture_decisions/index.adoc` — add ADR 019 and ADR 020 entries.
+- **Acceptance**: rendered architecture docs include all ADRs that exist on disk.
+- **Effort**: XS.
+- **Value**: low — documentation hygiene.
+
+### 12. Reduce `UserLastSeenCache` TTL from 30 min to 5 min (or update docs)
+- **Files**: `backend/src/main/java/de/dlr/shepard/auth/security/UserLastSeenCache.java:8`.
+- **Acceptance**: TTL matches documented "5-minute grace period" — or, if 30 min is intentional, architecture docs and `auth.adoc` are updated to match.
+- **Effort**: XS.
+- **Value**: medium — security finding H2; clears doc/code drift.
+
+### 13. Move `#642`/`#643`/`#644`/`#645` UX-cluster items into a triage decision
+- **Effort**: S total.
+- **Value**: medium — backlog hygiene; enables clearer reading of remaining issues.
+- **Why**: not engineering work but pure triage; ideal for a maintainer pass.
+
+### 14. Add a Vitest scaffold to the frontend (paired with #720 work)
+- **Acceptance**: `frontend` has Vitest configured; one example component test passes; CI runs `npm test` in MR pipeline.
+- **Effort**: M (scaffolding) + per-MR cost thereafter.
+- **Value**: high — unlocks Cluster B and #720 safely.
+- **Why**: enabler; do this *with* the first frontend feature MR (#720), not after.
+
+### 15. Activate SpotBugs/findsecbugs in CI
+- **Files**: `backend/pom.xml:476-490` (move plugins from `<reporting>` to `<build>`); `.gitlab/ci/test_backend.yml`.
+- **Acceptance**: `mvn -P ci verify` runs SpotBugs+findsecbugs and fails on Medium-severity security categories.
+- **Effort**: S.
+- **Value**: high — converts every future PR into a security-aware one.
+
+## Quick-pick by archetype
+
+- **First-time contributor, weekend afternoon**: #710 verify-close, #711 verify-close, ADR-index fix, `renovate.json` typo.
+- **Backend Java developer**: #721 race condition, #717 metadata permissions, #667 permission bug, SpotBugs activation.
+- **Python developer**: replace `dotenv` with `python-dotenv`, audit `scripts/poetry.lock`.
+- **Frontend developer**: Vitest scaffolding paired with #720 column export UI.
+- **Maintainer triage**: bulk-close UX cluster #642-#645, bulk-close research/refactoring backlog, decide spatial-graduation question.
+
+## Items deliberately excluded from "first issues"
+
+- All security CRITICAL findings (C1, C2, C3, C4, C5) — too high blast radius for first-issue work; tracked in `security-issues.md` and Phase 1 of the implementation plan.
+- Cluster E (Neo4j refactor) — XL effort, foundational.
+- Cluster B versioning frontend — gated on Epic 6 frontend test infra.
+- Anything in cluster D (semantic) — blocked on E.
+- Cluster I long-tail research — closure candidates, not implementation candidates.

--- a/aidocs/implementation-plan.md
+++ b/aidocs/implementation-plan.md
@@ -1,0 +1,289 @@
+# Implementation Plan — shepard
+
+Snapshot date: 2026-05-04. Phased plan derived from Wave 1-3 outputs and Wave 4 synthesis.
+
+## Plan at a glance
+
+| Phase | Focus | Effort total | Risk | Cluster refs |
+|---|---|---|---|---|
+| 0 | Housekeeping (mirror sync, file-as-issue, hygiene) | S-M | low | reconciliation, code-quality |
+| 1 | Security fixes (critical → high → medium) | M-L | high reward | C1-C5, H1-H8, M1-M12 |
+| 2 | First issues (XS / S, fresh) | S-M | low | A, F (small items), J (cleanup) |
+| 3 | Core improvements (medium effort, high value) | L | medium | A epic, F epic, Subscription epic, FE foundation |
+| 4 | Larger work (L / XL) | XL | high | E (Neo4j refactor), Search hardening |
+| 5 | Dependency & code-quality cleanup | M | low | J Renovate, code-quality TODOs |
+| 6 | Backlog / Won't-fix | XS (mostly closure) | low | I long-tail, G UX, K bit-rotted MR |
+
+---
+
+## Phase 0 — Housekeeping
+
+**Goal**: get the GitHub mirror state honest, file untracked findings, fix small documentation/config drift.
+
+### 0.1 — Mirror reconciliation
+- Re-import GitLab issue **#557** (only open GitLab issue not on GitHub mirror).
+- Re-enable MR mirroring (broken since 2024-09-16; ~23 open + 80-100 closed/merged MRs missing).
+- Add confirmation comments to GH PRs #995, #994, #963, #946 pointing to authoritative GitLab MRs.
+- Document gh#683 as a mirror artifact (orphan since GL #684 was deleted upstream).
+
+### 0.2 — File untracked critical findings as GitHub issues
+- C1 — SQL injection in `NativeQueryStringBuilder.java`
+- C2 — CORS wildcard with state-changing methods
+- C3 — Permissions fallback grants full access
+- C4 — SSRF + ReDoS in subscription webhook filter
+- C5 — Cypher injection in `Neo4jQueryBuilder.java`
+- H1 through H8 (8 high findings)
+
+(Per repository policy these go to **GitHub** copies, not GitLab.)
+
+### 0.3 — File untracked code-quality items
+- TODOs at `PermissionsIO.java:43`, `StructuredDataSearchService.java:87`, `SubscriptionFilter.java:62`, `DataObjectService.java:358`, `LabJournalEntryRest.java:41`, `ExportService.java:92`, `FileContainerServiceTest.java:309` ("doesn't test anything"), `StructuredDataContainerServiceTest.java:258`, `PermissionsServiceSecondTest.java:36`, `PKIHelperTest.java:22`.
+
+### 0.4 — Trivial config / doc fixes
+- Fix `renovate.json:21` typo `natchUpdateTypes` → `matchUpdateTypes`.
+- Add ADR 019 + ADR 020 entries to `architecture/src/09_architecture_decisions/index.adoc`.
+- Fix typo in active GitLab label `staus::longterm` → `status::longterm` (decision: re-label or accept).
+
+**Effort total**: S-M. **Risk**: low. **Order**: do 0.1-0.4 in any order; can be one combined PR for 0.3-0.4.
+
+---
+
+## Phase 1 — Security fixes
+
+**Goal**: close critical and high security findings; activate SAST so the next PR is checked automatically.
+
+### Phase 1A — CRITICAL (do first)
+
+| # | Finding | Files | Acceptance | Effort | Tests needed |
+|---|---|---|---|---|---|
+| C3 | Permissions fallback inversion | `PermissionsService.java:258-262` | `getRoles` for missing Permissions returns `Roles(false,false,false,false)`; startup audit fails deploy if any `BasicEntity` lacks `has_permissions` edge | S | per-entity-type integration test verifying Permissions node creation; negative-path tests for entities without Permissions |
+| C5 | Cypher injection — parameterise search | `common/search/query/Neo4jQueryBuilder.java:200-202,239-241,280,376,386` | All user-controlled values bound as Cypher parameters; property names whitelisted to enum or `[A-Za-z_][A-Za-z0-9_]*` | L | search regression suite; adversarial property-name fixtures |
+| C1 | SQL injection — parameterise spatial JSON queries | `data/spatialdata/repositories/NativeQueryStringBuilder.java:40,65,116-123`; `SpatialDataPointRepository.java:47-55,86-94` | Replace `'%s'` interpolation with named parameters and `CAST(:metadata AS JSONB)`; dynamic JSON paths via `jsonb_path_exists(:json, :path::jsonpath)` | M | adversarial JSON/SQL injection fixtures; spatial integration test (currently 0.26 ratio — invest before fixing) |
+| C4 | Subscription SSRF + ReDoS | `common/filters/SubscriptionFilter.java:63-78` | Regex compile uses timeout-bounded matcher; `callbackURL` enforces HTTPS + denylist of loopback/link-local/RFC1918/cloud-metadata; redirects disabled; `EventIO` carries IDs only | M | URL fixtures; ReDoS benchmark; mock outbound webhook |
+| C2 | CORS allowlist | `application.properties:18-21` | `quarkus.http.cors.origins=${SHEPARD_ALLOWED_ORIGINS}`; `access-control-allow-credentials=false`; per-deployment value | XS | configuration test |
+
+**Effort total**: M-L. **Risk**: high reward, medium implementation risk on C5 (large search surface).
+
+### Phase 1B — HIGH
+
+| # | Finding | Files | Effort | Notes |
+|---|---|---|---|---|
+| H7 + H1 | jjwt 0.11 → 0.12.x **plus** add `setExpiration` to API-key JWTs | `pom.xml`; `auth/apikey/services/ApiKeyService.java:138-150`; `common/filters/JWTFilter.java` | S | Bundle in one MR; remove Renovate `<0.12` pin |
+| H2 | `UserLastSeenCache` TTL: 30 min → 5 min (or update docs) | `auth/security/UserLastSeenCache.java:8` | XS | Decide: change code or update `auth.adoc` |
+| H3 | OPTIONS bypass — subsumed by C2 | `JWTFilter.java:98-101` | XS | No standalone change once C2 is fixed |
+| H4 | `ShepardExceptionMapper` sanitisation | `common/exceptions/ShepardExceptionMapper.java:21-24` | S | Generic 500 message; `WebApplicationException` subclasses keep their messages |
+| H5 | `PublicEndpointRegistry` exact-match | `common/filters/PublicEndpointRegistry.java:8-15` | XS | Anchored match + URI normalisation + tests |
+| H6 | Replace `dotenv` with `python-dotenv` | `scripts/pyproject.toml:18`; `scripts/poetry.lock` | XS | Smoke-test CLI |
+| H8 | Default credentials | `application.properties:133-145`; `infrastructure/.env.example` | XS | Replace with `CHANGE_ME_<random>`; add startup check |
+
+### Phase 1C — MEDIUM (M1-M12)
+
+Fold into Phase 5 cleanup unless adjacent to a Phase 1 fix. Notable inline fixes during Phase 1:
+- M2 — set `0600` on private key (`PKIHelper.java:107-110`).
+- M4 — `header.substring(7)` instead of `replace("Bearer ", "")` (`JWTFilter.java:159`).
+- M5 — redact tokens in failure logs (`JWTFilter.java:113-117`).
+- M12 — **Activate SpotBugs / findsecbugs in CI** (`backend/pom.xml:476-490`). Move plugins from `<reporting>` to `<build>`; fail on Medium-severity security categories. **Highest leverage in Phase 1.**
+
+### Phase 1D — CI security plumbing (Epic 7)
+- Activate SpotBugs+findsecbugs in `<build>` (M12).
+- Add Trivy container scan.
+- Add `eslint-plugin-security` for frontend.
+- Add `bandit` or `semgrep` for `scripts/`.
+- Run full `mvn verify` (not just `check`) on main and release pipelines.
+- Extend secret scanning to fail on default values like `shepard_secret`, `shepardshepard`.
+
+**Phase 1 effort total**: M-L. **Phase 1 risks**: C5 has wide blast radius; must be a parameterisation patch only — do NOT conflate with Cluster E refactor.
+
+---
+
+## Phase 2 — First issues
+
+**Goal**: ship small, fresh wins; confirm closures; set up frontend test foundation alongside the first frontend feature.
+
+| # | Goal | Files | Acceptance | Effort | Tests | Deps |
+|---|---|---|---|---|---|---|
+| #710 | Verify-and-close | `TimeseriesReferenceRest.java:267-275` | issue closed, regression test exists | XS | one regression test if missing | none |
+| #711 | Verify-and-close | `CsvFormat.java`, `CsvColumnLineProvider.java` | closed | XS | regression test for column mode | none |
+| #721 | Fix race in default file container | `data/file/services/FileContainerService.java` | concurrent creation cannot produce duplicate `default` relations | S | concurrent integration test | none |
+| #717 | Permission gate on timeseries metadata | `data/timeseries/services/TimeseriesService.java:80` | unprivileged users cannot read metadata; container-level permission no longer required for metadata-only path | S | negative-path tests | aligns with Phase 1 C3 |
+| #667 | Recent permission bug | (per issue) | bug fix + regression test | S | per issue | aligns with Phase 1 C3 |
+| !800 | Documentation update | `architecture/...`, `README.md` | merged | S | n/a | none |
+| #722, #688, #683 | Fresh search/UX bugs | `common/search/...` | bug fixes | S each | regression tests in HIGH-risk module | none |
+| (enabler) | Frontend Vitest scaffolding | `frontend/` | Vitest configured; `npm test` in CI; one component test passes | M | n/a | precedes #720 |
+| #720 | Frontend column export | `frontend/components/container/timeseries/...` | UI exposes the column-CSV export the backend provides; component test for the page | M | new component test | needs Vitest scaffolding above |
+
+**Phase 2 effort total**: S-M. **Phase 2 risks**: low — these are fresh, owner-tracked items.
+
+---
+
+## Phase 3 — Core improvements
+
+**Goal**: ship medium-effort high-value workstreams sequenced via cluster map. Respect architecture boundaries.
+
+### 3.1 — Permissions Hardening (Epic 2)
+- C3 already shipped in Phase 1; ensure regression coverage.
+- Triage and act on #41, #62, #424, #483 — close superseded; fix live ones.
+- Tech-debt #1 (entity-creation invariant) — addressed by C3's startup audit.
+- Tech-debt #2 (cryptic OIDC subject usernames) — design proposal for stable mapping.
+
+**Effort**: M-L. **Risks**: needs explicit owner; F has been long-standing.
+
+### 3.2 — Subscription Hardening (Epic 4)
+- C4 already shipped in Phase 1; expand subscription test coverage; add per-user subscription cap (related to L4 informational finding).
+
+**Effort**: S-M. **Risks**: low — module-isolated.
+
+### 3.3 — Active timeseries cluster closure (Epic 1)
+- Land !808 / !809 (#712 sub-tasks). Continue !763 (search annotatedTimeseries).
+- Cut shepard 5.4.2 once Sprint 23 cluster is green.
+
+**Effort**: L. **Risks**: collides with Renovate Quarkus !723 — freeze !723 until 5.4.2 ships.
+
+### 3.4 — MEDIUM security findings (M1-M12 minus those already done in Phase 1)
+
+| # | Notes |
+|---|---|
+| M1 | `quarkus.http.limits.max-body-size` |
+| M3 | RSA-2048 → RSA-3072 / EdDSA |
+| M6 | logging-filter scope |
+| M7 | exception-mapper rate-limit |
+| M8 | per-Service permission-check tests |
+| M9 | bind `createdBy` / `updatedBy` as Cypher parameters |
+| M10 | `Vary: Origin` on CORS responses |
+| M11 | document required `FRONTEND_AUTH_SECRET` entropy |
+
+**Effort**: M total. **Risks**: low.
+
+---
+
+## Phase 4 — Larger work
+
+**Goal**: structural refactors that unblock entire clusters. Plan is approach + PR breakdown.
+
+### 4.1 — Cluster E: Neo4j refactor (#274, #577, #660)
+
+- **Approach**: ADR for the new entity model; shadow tables / dual-write migration; `neo4j-migrations` scripts; cutover; cleanup.
+- **PR breakdown** (suggested):
+  1. ADR-021 documenting the new model.
+  2. New entity classes alongside old ones.
+  3. Read path: prefer new model, fall back to old.
+  4. Migration scripts + dual-write in writer services.
+  5. Cutover and removal of legacy paths.
+  6. Cleanup of deprecated MongoDB queries (`StructuredDataSearchService.java:87` TODO).
+- **Open questions**:
+  - Owner — currently no active assignee; without one, Phase 4 cannot start.
+  - Backwards-compat for older Python clients (#664 closed but legacy concern).
+  - Performance budget vs. current Neo4j query patterns.
+- **Dependency risks**: blocks D (semantics) fully; partially blocks A long-term; affects every search query (cluster H).
+
+### 4.2 — Cluster D: Semantic annotations (#43, #553, #656, #660)
+- Sequenced **after** 4.1 lands (or at least after 4.1 stage 3 enables read-side parity).
+- #43 already PARTIAL (`data/semantic/`); finish coverage across all entity types.
+
+### 4.3 — Cluster B: Versioning frontend (#46, #127, #150, #155, #271)
+- Gated on Epic 6 (Phase 2 enabler) being live.
+- Owner-confirm scope; scope-reduce per `ready-to-close.md` recommendation.
+
+### 4.4 — Cluster C: Spatial-data product decision (#441-#447, #530, #557)
+- Product decision: graduate (remove feature flag) OR deprecate.
+- C1 (SQL injection) is fixed in Phase 1 regardless.
+- If graduate: implement #441-#447 / #530 / #557 with spatial test suite.
+- If deprecate: bulk-close per `ready-to-close.md`.
+
+**Phase 4 effort**: XL. **Phase 4 risks**: ownership in handover phase; do not start without an explicit assignee.
+
+---
+
+## Phase 5 — Dependency & code-quality cleanup
+
+**Goal**: drain Renovate backlog without colliding with Phase 2-4 work; close the remaining code-quality TODOs.
+
+### 5.1 — Renovate batch drain (Cluster J)
+
+| Batch | MRs | When |
+|---|---|---|
+| Build tooling / non-frontend non-runtime | `!647`, `!695`, `!804`, `!805`, `!806`, `!810`, `!766`, `!734`, `!740` | At any time, after each green CI |
+| Frontend (non-#720-colliding) | `!779`, `!780` | Before #720 work, or after |
+| Frontend (Nuxt majors, #720-colliding) | `!722`, `!758` | After #720 lands |
+| Backend Quarkus (A-cluster-colliding) | `!723` | After !808/!809 land and 5.4.2 ships |
+| `develop` aggregator | `!636`, `!803` | After their constituent updates |
+
+### 5.2 — Renovate config cleanup
+- Done in Phase 0: typo fix.
+- Prune stale Vue 2-era pins (`vue<3`, `vuex<4`, `vue-router<4`, `portal-vue<3`, `typescript<5`, `@vue/tsconfig<0.2`, `bootstrap<5`).
+- Relax `jjwt<0.12` (after H7 lands).
+- Relax `junit-jupiter<5.11`.
+- Relax `neo4j-ogm<4`.
+
+### 5.3 — Other dependency upgrades not yet covered by an MR
+- Nuxt 3.20 → Nuxt 4 (medium effort; plan).
+- ESLint 8 → 9 + Vue ecosystem (medium effort; plan).
+- Vite 6 → 7 (small).
+- Python `^3.11` → `^3.12` in `scripts/pyproject.toml`.
+- `@dlr-shepard/shepard-client` 5.1.2 → 5.2.0 in `clients/tests/typescript`.
+- `typescript` 5.5.3 → 5.6+ in `clients/tests/typescript`.
+
+### 5.4 — Code-quality TODO closure
+- Merge `PermissionsServiceSecondTest` into `PermissionsServiceTest`.
+- Refactor `LabJournalEntryRest.java:41` endpoint logic into the service layer.
+- Optimise `DataObjectService.java:358` `referencedIds` loop.
+- Fix the two "doesn't test anything" tests at `FileContainerServiceTest.java:309` and `StructuredDataContainerServiceTest.java:258` (likely paired with Phase 2 #721).
+- Improve `ExportService.java:92` strategy pattern.
+
+**Phase 5 effort**: M. **Phase 5 risks**: low; sequencing with Phase 2-4 is the only concern.
+
+---
+
+## Phase 6 — Backlog / Won't fix
+
+**Goal**: get the remaining 100+ open issues to a state where the next planning round can read them.
+
+### 6.1 — UX cluster (#642-#645)
+Bulk-close per `ready-to-close.md`. **Effort**: S (closure pass).
+
+### 6.2 — Bit-rotted MR !498
+Close (or reassign for rebase if anyone volunteers). **Effort**: XS.
+
+### 6.3 — Long-tail research / refactoring (~70 items)
+Bulk close-with-comment per `ready-to-close.md` template, excluding owner-assigned items. **Effort**: S (closure pass).
+
+### 6.4 — Spatial cluster (if Phase 4 product decision = deprecate)
+Bulk-close #441-#447 / #530 / #557. **Effort**: XS.
+
+### 6.5 — Versioning low-value items
+Close #150 / #155 / #271 unless Cluster B is greenlit in Phase 4. **Effort**: XS.
+
+**Phase 6 effort**: S total. **Phase 6 risks**: requires maintainer pass; do not bulk-close without owner sign-off.
+
+---
+
+## Suggested order
+
+```
+Phase 0 (housekeeping)              — week 0
+  ↓
+Phase 1A (CRITICAL security)        — weeks 1-3
+Phase 1B (HIGH security)            — weeks 1-3 (parallel)
+Phase 1D (CI plumbing)              — week 1
+  ↓
+Phase 2 (first issues + Vitest)     — weeks 3-5
+  ↓
+Phase 3 (core improvements)         — weeks 5-9
+  ↓
+Phase 4 (larger work — needs owner) — months 3-6
+  ↓
+Phase 5 (dep + code-quality drain)  — continuous from week 4
+  ↓
+Phase 6 (backlog closure)           — weeks 1-2 maintainer pass
+```
+
+Phases 5 and 6 run continuously alongside the others; Phase 6 in particular should happen early to recover backlog signal.
+
+## Key risks across phases
+
+1. **Handover phase**: ownership for Phase 4 (Cluster E) and Phase 3.1 (Permissions epic) is not currently assigned. Without explicit assignment these slip.
+2. **Renovate vs feature collisions**: !723 Quarkus must not land before !808/!809; !722/!758 nuxt should not land mid-#720.
+3. **C5 patch must not be conflated with Cluster E** — patch first, refactor later.
+4. **Frontend zero tests**: every Phase 2-4 frontend MR is regression-prone until Vitest scaffolding is live.
+5. **`UserLastSeenCache` 30-min vs 5-min** — small fix but signals lack of Auth.Users tests; treat as a coverage signal during Phase 1B.
+6. **Bulk closure (Phase 6)** — requires maintainer sign-off; cannot be done by an agent unilaterally.

--- a/aidocs/issues-status.md
+++ b/aidocs/issues-status.md
@@ -1,0 +1,191 @@
+# Issues Status — shepard (GitLab open items)
+
+Snapshot date: 2026-05-04. Source: GitLab (authoritative). 166 open issues, 23 open MRs.
+
+## Method
+
+Each open item gauged on six axes from Wave 1-3 evidence:
+
+- **Effort**: XS (<0.5d), S (<2d), M (<1w), L (<2w), XL (>2w)
+- **Complexity**: low / medium / high
+- **Value**: low / medium / high (user impact + security + unblocking)
+- **Confidence**: high / medium / low (in the gauge itself)
+- **Test risk**: from coverage map — modules timeseries 0.37, spatialdata 0.26, neo4j 0.29, search 0.38, labJournal 0.20, frontend 0.0 are HIGH
+- **Staleness**: fresh (<6mo) / stale (6-12mo) / very stale (12+mo)
+- **Implementation status**: DONE / PARTIAL / NOT_IMPLEMENTED / SUPERSEDED / BLOCKED / UNCLEAR
+
+GitLab labels (`issue::*`, `journey::*`, `status::*`, `td-priority::*`) inform but don't override the gauge.
+
+## Status distribution (open items)
+
+| Implementation status | Count |
+|---|---|
+| DONE (verify-and-close) | ~12 |
+| PARTIAL | ~22 |
+| NOT_IMPLEMENTED | ~95 |
+| SUPERSEDED candidates | ~8 |
+| BLOCKED | ~6 |
+| UNCLEAR | ~23 |
+
+Staleness: 35 fresh, 86 stale (6-12 months), 45 very stale (12+ months).
+
+Open MR breakdown: 1 bit-rotted (`!498`, 402 days idle); 19 Renovate dependency MRs; 5 active draft feature MRs (`!80`, `!763`, `!788`, `!800`, `!808`, `!809`).
+
+## Cluster: Active timeseries / 5.4.2 / Sprint 23
+
+| iid | Type | Title | Status | Effort | Cmplx | Value | Conf | Test | Stale | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| #710 | feature | Support additional parameters for timeseries reference | DONE | XS | low | med | high | HIGH | fresh | `TimeseriesReferenceRest.java:267-275` |
+| #711 | feature | Provide column-based export of timeseries | DONE | XS | low | med | high | MED | fresh | `CsvFormat.java`, `CsvColumnLineProvider.java` |
+| #712 | refactor | Refactor referenced/annotated timeseries | PARTIAL | L | high | high | high | HIGH | fresh | MR !809 in flight |
+| #713-#716 | refactor | Sub-tasks of #712 refactor | PARTIAL | M each | high | med | med | HIGH | fresh | Sprint 23 cluster |
+| #717 | bug | Timeseries metadata access without permissions | NOT_IMPLEMENTED | S | med | high | high | HIGH | fresh | `TimeseriesService.getTimeseriesById:80` still gates via container; security-relevant |
+| #718 | chore | Dependency Updates | PARTIAL | XS | low | med | high | n/a | fresh | Standing meta-bucket |
+| #720 | feature | Make column export available in frontend | NOT_IMPLEMENTED | M | med | med | med | HIGH (FE=0) | fresh | Backend ready (#711); UI absent |
+| #721 | bug | Race condition default file container | NOT_IMPLEMENTED | S | med | high | high | HIGH | fresh | `FileContainerService` lacks synchronization; data-corruption risk |
+| #696-#707 | bug | Audit trail, TS plot fixes, search bugs | varies | S each | low-med | med | med | mixed | fresh | ~10 small items; some likely DONE (verify) |
+
+## Cluster: Versioning frontend (backend done)
+
+| iid | Effort | Cmplx | Value | Conf | Test | Stale | Notes |
+|---|---|---|---|---|---|---|---|
+| #46 | L | med | med | med | HIGH (FE=0) | very stale | Frontend version UI; assigned RolandGlueck; backend ready |
+| #127 | M | med | med | med | HIGH (FE=0) | very stale | Version-aware navigation |
+| #150 | M | med | low | med | HIGH (FE=0) | very stale | Diff view — nice-to-have |
+| #155 | S | low | low | med | HIGH (FE=0) | very stale | Cosmetic version label |
+| #271 | M | med | low | low | HIGH (FE=0) | very stale | Likely SUPERSEDED — needs triage |
+
+All blocked on frontend capacity in handover. `frontend/components/context/` has no `version` directory.
+
+## Cluster: Spatial data (feature-flagged)
+
+| iid | Effort | Cmplx | Value | Conf | Test | Stale | Notes |
+|---|---|---|---|---|---|---|---|
+| #441-#447 | M-L each | med-high | low | low | HIGH | very stale | Behind `SHEPARD_SPATIAL_DATA_ENABLED`; not adopted |
+| #530 | M | med | low | low | HIGH | very stale | Same |
+| #557 | S | low | low | low | HIGH | very stale | Heap-memory issue; mirror gap on GitHub side |
+
+**Cross-cut**: security finding C1 (SQL injection in `NativeQueryStringBuilder.java`) supersedes feature work in this cluster.
+
+## Cluster: Semantic annotations
+
+| iid | Effort | Cmplx | Value | Conf | Test | Stale | Notes |
+|---|---|---|---|---|---|---|---|
+| #43 | L | high | med | med | HIGH | very stale | PARTIAL impl in `data/semantic/`; partly blocked on Neo4j refactor |
+| #553 | M | high | med | low | HIGH | stale | BLOCKED on Neo4j refactor |
+| #656 | M | high | med | low | HIGH | stale | BLOCKED on Neo4j refactor |
+| #660 | L | high | med | low | HIGH | stale | Overlaps Neo4j refactor itself |
+
+## Cluster: Neo4j refactor
+
+| iid | Effort | Cmplx | Value | Conf | Test | Stale | Notes |
+|---|---|---|---|---|---|---|---|
+| #274 | XL | high | high | low | HIGH | very stale | Foundational; unblocks #43/#553/#656/#660 |
+| #577 | L | high | med | low | HIGH | stale | Sub-area of #274 |
+| #660 | L | high | med | low | HIGH | stale | Listed in semantic cluster too |
+
+## Cluster: Permissions / admin (overlaps security C3, H1, H2)
+
+| iid | Effort | Cmplx | Value | Conf | Test | Stale | Notes |
+|---|---|---|---|---|---|---|---|
+| #41 | M | high | high | med | MED | very stale | Permission model — overlaps security C3 |
+| #62 | M | high | high | med | MED | very stale | Admin role gaps; C3 |
+| #424 | M | med | high | med | MED | stale | xit-* assigned; permission UX |
+| #483 | M | med | high | med | MED | stale | xit-* assigned; permission UX |
+| #667 | S | med | high | high | MED | fresh | Recent permission bug; tied to C3 |
+
+Treat as a single security workstream alongside C3/H1/H2/H7 (Permissions Hardening epic — see `cluster-map.md`).
+
+## Cluster: UX cluster (2025-06-06 batch)
+
+| iid | Effort | Cmplx | Value | Conf | Test | Stale | Notes |
+|---|---|---|---|---|---|---|---|
+| #642-#645 | S each | low | low | med | HIGH (FE=0) | stale | Created same day; no follow-through; close-as-wontfix candidates |
+
+## Cluster: Search & fresh bugs (recent)
+
+| iid | Effort | Cmplx | Value | Conf | Test | Stale | Notes |
+|---|---|---|---|---|---|---|---|
+| #683 | S | med | med | med | HIGH | fresh | Search bug (mvistein); also corresponds to GH gh#683 reconciliation note |
+| #688 | S | med | med | med | HIGH | fresh | lettfe |
+| #722 | S | low | med | med | MED | fresh | kauf_pt |
+| #758 | M | med | med | med | MED | fresh | kauf_pt |
+| #763 | M | med | med | med | HIGH | fresh | TS payload search (Willmeroth); cf MR !763 |
+| #779 | XS | low | low | high | n/a | fresh | Dep update |
+| #780 | XS | low | low | high | n/a | fresh | Dep update |
+
+## Cluster: Long-tail research / refactoring backlog (~90 items)
+
+Group gauge: **Effort L+, Complexity high, Value low, Confidence low, Staleness very stale.** Includes Aras / Nexus / Object Storage / Workflow Mgmt evaluations; mostly `issue::research` / `issue::meta` labels.
+
+High-confidence outliers worth retaining (have an active owner):
+
+- #23 (Willmeroth, noheton)
+- #32 (thaase)
+- #284, #507, #513, #655, #657, #659 (RolandGlueck cluster)
+- #296, #602, #650, #673 (lettfe)
+- #306 (mvistein), #326 (ZeroOne42)
+- #390, #394, #524, #633 (xit-* contractor handover items)
+
+Everything else in this cluster: bulk close-with-comment unless owner objects.
+
+## Cluster: Renovate / dependency MRs (group)
+
+| Group gauge | Effort XS each | Complexity low | Value medium (security hygiene) | Confidence high | Staleness fresh |
+
+Open: `!636`, `!647`, `!695`, `!722`, `!723`, `!734`, `!740`, `!758`, `!766`, `!779`, `!780`, `!803`, `!804`, `!805`, `!806`, `!810` (≈19). Action: batch-merge after CI green; sequence to avoid conflicts with `!808/!809` (Quarkus) and #720 (nuxt).
+
+## Cluster: Active draft MRs
+
+| MR | Title | Effort | Cmplx | Value | Conf | Test | Stale | Notes |
+|---|---|---|---|---|---|---|---|---|
+| !498 | RetrieveCollectionWithVersionOfIncomingReferences | M (rebase) | high | low | med | HIGH | very stale (BIT-ROT 402d) | Close or rebase |
+| !80 | Draft: Timeseries payload search concept | L | high | med | low | HIGH | very stale | May be superseded by #763 |
+| !763 | Draft: search annotatedTimeseries in container | M | med | med | med | HIGH | fresh | Active |
+| !779 | Draft: update @vuetify | XS | low | low | high | n/a | fresh | |
+| !780 | Draft: update @vue-tsc | XS | low | low | high | n/a | fresh | |
+| !788 | Draft: takeSuccessorIntoAccount | M | med | med | med | MED | fresh | |
+| !800 | Draft: update documentation and Readme | S | low | med | high | n/a | fresh | |
+| !808 | Draft: Refactor timeseries graph DB | L | high | high | high | HIGH | fresh | #712 |
+| !809 | #712 refactor referenced timeseries | L | high | high | high | HIGH | fresh | |
+
+## Top 20 highest value-per-effort
+
+Ranked by (value / effort) with security tiebreakers. Note: untracked critical security findings (C1, C2, C4, C5) outrank everything below — see `security-issues.md`.
+
+1. **#710** — XS, already DONE; verify-and-close
+2. **#711** — XS, already DONE; verify-and-close
+3. **#717** — S, security-adjacent (timeseries metadata auth gap)
+4. **#721** — S, race condition / data corruption in `FileContainerService`
+5. **#667** — S, fresh permission bug (C3 overlap)
+6. **!800** — S, doc update, ready
+7. **#722** — S, fresh, owner assigned
+8. **#688** — S, fresh search bug
+9. **#683** — S, fresh search bug
+10. **!779 / !780** — XS dep updates
+11. **#779 / #780** — XS dep updates
+12. **#718** — XS standing dep bumps
+13. **!808** — L but unblocks Sprint 23 closure
+14. **!809** — L, same
+15. **#712** — L, unblocks #713-#716
+16. **#763** — M, fresh and owner-driven
+17. **!763** — M, ties to #763
+18. **!788** — M, fresh draft
+19. **#41 / #62 / #424 / #483** — M each, but high permissions value (C3) — bundle as one workstream
+20. **#697-#707** — S each, fresh bugs; many can be batched
+
+## Low-confidence items (need triage / clarification)
+
+- **#271** versioning frontend — possibly superseded
+- **#553, #656, #660, #43** semantic annotations — blocked on #274; status unclear
+- **#274, #577** Neo4j refactor — scope vs handover capacity
+- **Spatial cluster #441-#447, #530, #557** — feature flag still warranted? Or close?
+- **#642-#645** UX batch — intent unclear given no follow-through
+- **!498** bit-rotted MR — rebase or close?
+- **!80** — superseded by #763 / !763?
+- **xit-* items #390, #394, #524, #633** — contractor handover status unknown
+- **Long-tail research issues** (~80 of cluster minus called-out owners) — bulk-triage candidates
+
+## Recommended for closure (staleness / superseded / done)
+
+Detailed list and closing comment drafts in `ready-to-close.md`.

--- a/aidocs/ready-to-close.md
+++ b/aidocs/ready-to-close.md
@@ -1,0 +1,104 @@
+# Ready to Close on GitHub — shepard
+
+Snapshot date: 2026-05-04. GitLab is authoritative. The GitHub issue mirror is in sync at the issue level (zero state mismatches), so most "closure" candidates here are about closing the underlying GitLab item, which the mirror will reflect; or about historical / mirror-artifact GH issues that can be safely left closed.
+
+Confidence levels: **certain** (objective evidence) / **likely** (strong inference) / **uncertain** (needs maintainer review).
+
+## A. GitLab issues already implemented — verify-and-close
+
+These appear DONE based on code evidence; closing on GitLab will sync to GitHub.
+
+| GL iid | Title (abbr) | Evidence | Confidence | Closing comment draft |
+|---|---|---|---|---|
+| #710 | Support additional parameters for timeseries reference | `TimeseriesReferenceRest.java:267-275` exposes `function`, `groupBy`, `fillOption`, device/location/symbolic/measurement/field tag, `csvFormat` | certain | "Closing — endpoint already accepts the requested parameter set per `TimeseriesReferenceRest.java:267-275`. Reopen if a specific parameter is still missing." |
+| #711 | Provide column-based export of timeseries | `CsvFormat.java` (ROW + COLUMN), `CsvColumnLineProvider.java`; commit `c4980a6` | certain | "Closing — column-mode CSV export is implemented (`CsvFormat.COLUMN`, `CsvColumnLineProvider`). Frontend exposure tracked under #720." |
+
+## B. GitHub-only artifacts — leave closed, document
+
+| GH id | Why | Action |
+|---|---|---|
+| gh#683 "Bug explore" | CLOSED on GitHub; body references `…/-/work_items/684` but GitLab iid 684 was deleted on GitLab. Orphan mirror artifact. | Leave closed. Optional: add comment "Mirror artifact — GitLab counterpart was deleted upstream." |
+| 27 `[PLACEHOLDER]` rows on GitHub (label `gitlab merge request`) | By-design numbering pads from the mirror; no underlying GitLab counterpart. | Leave as-is. They are part of the mirror's numbering strategy. |
+
+## C. Stale open MRs to close on GitLab (will reflect on GitHub)
+
+| GL MR | State | Reason | Confidence | Closing comment draft |
+|---|---|---|---|---|
+| !498 RetrieveCollectionWithVersionOfIncomingReferences | open, 402 days idle | Bit-rotted; `develop` has diverged substantially. Versioning frontend has no owner in handover phase. | likely | "Closing as stale — branch is 402 days idle and develop has moved past the surface. Reopen against current develop if the work is still desired." |
+| !80 Draft: Timeseries payload search concept | open, very stale | Likely superseded by #763 / !763 (search annotatedTimeseries) | uncertain | Owner-confirm first; if confirmed: "Superseded by #763 / !763 — closing the original concept draft." |
+
+## D. Stale open issues — closure candidates
+
+### D1. Spatial-data backlog (#441-#447, #530, #557)
+
+All very stale; feature is gated behind `SHEPARD_SPATIAL_DATA_ENABLED` and not adopted. Security finding C1 (SQL injection in `NativeQueryStringBuilder.java`) supersedes feature work in this cluster.
+
+| iid | Confidence | Closing comment draft |
+|---|---|---|
+| #441-#447, #530, #557 | uncertain | "Closing pending product decision on spatial-data graduation. The feature flag has been disabled and there is no active investment. Filing a separate ticket to track the SQL-injection finding (C1) in `NativeQueryStringBuilder.java` regardless of graduation outcome. Reopen if graduation is decided." |
+
+### D2. UX triage cluster (#642-#645)
+
+Created same day 2025-06-06; no follow-through commits.
+
+| iid | Confidence | Closing comment draft |
+|---|---|---|
+| #642-#645 | likely | "Closing — created in a single batch on 2025-06-06 with no subsequent activity, no owner assigned, and no commits referencing the items. Reopen with concrete repro/scope if any of these are still observable regressions." |
+
+### D3. Versioning frontend (low-value items)
+
+| iid | Confidence | Closing comment draft |
+|---|---|---|
+| #150 Diff view | likely | "Closing as low-value nice-to-have; no FE owner in handover phase, very stale. Reopen if user demand surfaces." |
+| #155 Cosmetic version label | likely | "Closing as low-value cosmetic; very stale. Reopen alongside any broader versioning frontend epic." |
+| #271 (versioning behaviour) | uncertain | "Closing as likely superseded — backend versioning is in place; specific behaviour gap is no longer clear. Reopen with a concrete repro." |
+
+### D4. Long-tail research / refactoring backlog (~70 items, very stale)
+
+`issue::research`, `issue::meta`, and very-stale `issue::refactoring` items in clusters such as Aras / Nexus / Object Storage / Workflow Mgmt evaluations. Suggest **bulk close-with-comment** unless an owner objects.
+
+Generic closing comment:
+
+> "Closing as part of backlog hygiene. This research / refactoring item has been idle for 12+ months and the project is in a handover/wind-down phase (see `Handover period` and `Interim` milestones). The architectural decisions captured in `architecture/src/09_architecture_decisions/*.adoc` have rendered several evaluation items obsolete. Reopen if active work resumes."
+
+Exclusions (do NOT bulk-close — assigned to active or named owner):
+- #23 (Willmeroth, noheton)
+- #32 (thaase)
+- #284, #507, #513, #655, #657, #659 (RolandGlueck)
+- #296, #602, #650, #673 (lettfe)
+- #306 (mvistein)
+- #326 (ZeroOne42)
+- #390, #394, #524, #633 (xit-* contractor handover)
+
+These need individual owner-confirmation rather than bulk closure.
+
+## E. PRs on GitHub corresponding to still-open GitLab MRs
+
+The following GH PRs were closed on GitHub while their GitLab MR counterpart is still `opened`. Treat GitLab as canonical — leave closed-on-GitHub is acceptable but worth a confirmation comment.
+
+| GH PR | GL MR | Action | Comment draft |
+|---|---|---|---|
+| 995 | !758 | leave closed | "GitLab is authoritative; tracking continues at gitlab.com/dlr-shepard/shepard/-/merge_requests/758." |
+| 994 | !803 | leave closed | Same template (link to !803). |
+| 963 | !636 | leave closed | Same template (link to !636). |
+| 946 | !803 | leave closed (duplicate of 994) | Same template. |
+| 799 | !80 | **leave open** | This PR correctly mirrors an open GitLab draft. |
+
+## F. Top-level mirror operations (not closure, but related)
+
+1. Re-import GitLab issue **#557** (only open GitLab issue not on GitHub).
+2. Re-enable MR mirroring (last MR-as-issue body dated 2024-09-16; ~23 open and 80–100 closed/merged MRs since are not represented).
+
+## Closure plan summary
+
+| Action | Item count | Confidence |
+|---|---|---|
+| Verify-and-close on GitLab (will sync to GH) | 2 (#710, #711) | certain |
+| Leave closed on GitHub (mirror artifacts) | 1 + 27 placeholders | certain |
+| Close stale open MRs on GitLab | 2 (!498, !80*) | likely / uncertain |
+| Close spatial-data cluster (gated, very stale) | 9 (#441-#447, #530, #557) | uncertain — needs product decision |
+| Close UX triage cluster | 4 (#642-#645) | likely |
+| Close versioning low-value items | 3 (#150, #155, #271*) | likely / uncertain |
+| Bulk-close research/refactoring backlog | ~70 | likely (assuming maintainer agrees with bulk pass) |
+| Add confirmation comments to GH PRs | 4 | certain |
+| Re-import / mirror fixes | 2 mirror operations | n/a |

--- a/aidocs/reconciliation.md
+++ b/aidocs/reconciliation.md
@@ -1,0 +1,114 @@
+# Reconciliation — GitHub mirror vs GitLab authoritative
+
+Snapshot date: 2026-05-04. GitLab is authoritative.
+
+## Summary
+
+| Metric | GitHub (noheton/shepard) | GitLab (dlr-shepard/shepard) |
+|---|---|---|
+| Issues — total | 973 | 693 |
+| Issues — open | 166 | 166 |
+| Issues — closed | 807 | 527 |
+| Pull/Merge requests — total | 22 | 801 |
+| PRs/MRs — open | 1 | 23 |
+| PRs/MRs — merged | — | 699 |
+| PRs/MRs — closed | 21 | 79 |
+
+**Match rate (GitHub items → GitLab counterpart)**: 972 / 973 = **99.9%**.
+
+State mismatches: **0**. Every GitHub item that is open has an open GitLab counterpart; every closed GitHub item has a closed/merged GitLab counterpart. The mirror is in sync at the issue level.
+
+## Mirror model
+
+- The mirror imports both GitLab issues and GitLab MRs into the GitHub *issues* number space (PRs are not used for the mirror itself).
+- Two label values: `gitlab issue` and `gitlab merge request`.
+- Where a GitLab MR has the same iid as an existing GitHub issue, the mirror creates a `[PLACEHOLDER] - for issue #N` row to keep numbering aligned. 27 placeholders found; all are by design.
+- Issue titles are mirrored verbatim; MR titles get a `- [merged]/[closed]` suffix on GH.
+- Body of every mirrored row contains a `Migrated from GitLab: …/-/work_items/N` (issue) or `…/-/merge_requests/N` (MR) URL — used as the iid mapping.
+
+| Match type | Count |
+|---|---|
+| `url` (GitLab issue URL embedded in body) | 692 |
+| `url→MR` (GitLab MR URL embedded in body) | 252 |
+| `placeholder` (numbering pad) | 27 |
+| `title→MR` (title-only MR match) | 1 |
+| `no-match` | 1 |
+
+## GitHub items with no GitLab match (1)
+
+- **gh#683 "Bug explore"** (CLOSED, label `gitlab issue`). Body says "migrated from `…/-/work_items/684`", but GitLab iid 684 does not exist — deleted on GitLab. Recommendation: leave closed; document as historical mirror artifact.
+
+## State mismatches needing close-on-GitHub
+
+**None.** No action required.
+
+## Mirror gaps — open on GitLab, missing from GitHub
+
+### Issues (1)
+
+| GL iid | Title | Action |
+|---|---|---|
+| 557 | spatial data: Out of (heap) memory while getting larger datasets | Re-import via the mirror tool, or open a corresponding GitHub issue manually |
+
+### MRs (23)
+
+The latest GitHub-mirrored MR-as-issue body in the dataset is dated **2024-09-16**, suggesting MR mirroring stopped while issue mirroring continued. All open GitLab MRs are missing from the GitHub issue stream:
+
+| GL MR iid | Title |
+|---|---|
+| 810 | Update dependency `eu.michael-simons.neo4j:neo4j-migrations` to v4 |
+| 809 | #712 refactor referenced timeseries |
+| 808 | Draft: Refactor timeseries structure in graph database |
+| 806 | Update dependency `webpack-cli` to v7 |
+| 805 | Update load tests |
+| 804 | Update scripts dependencies |
+| 803 | Update backend dependencies |
+| 800 | Draft: update documentation and Readme Datein |
+| 788 | Draft: takeSuccessorIntoAccount |
+| 780 | Draft: update `@vue-tsc` dependencies |
+| 779 | Draft: update `@vuetify` dependencies |
+| 766 | Update infrastructure dependencies |
+| 763 | Draft: search annotatedTimeseries in container |
+| 758 | Update `nuxtend` dependencies |
+| 740 | Update `timescale/timescaledb` Docker tag to v2.26.3 |
+| 734 | Update `python` Docker tag to v3.14.3 |
+| 723 | Update backend Quarkus update |
+| 722 | Update `nuxtend` dependencies (major) |
+| 695 | Update scripts dependencies (major) |
+| 647 | Update `openapitools/openapi-generator-cli` Docker tag to v7.21.0 |
+| 636 | Update develop dependencies |
+| 498 | RetrieveCollectionWithVersionOfIncomingReferences |
+| 80  | Draft: Timeseries payload search concept |
+
+Recommendation: re-enable the MR mirror, or accept GitLab as canonical and document the gap.
+
+## GitHub PRs corresponding to GitLab MRs
+
+All 22 PRs in `noheton/shepard` correspond to GitLab MRs by exact title match.
+
+### PRs needing review (4 closed on GitHub while GL MR is open)
+
+| GH PR | GH state | GL MR | GL state | Action |
+|---|---|---|---|---|
+| 995 | closed | !758 | opened | Likely safe to leave closed (GitLab is authoritative); confirm with maintainer |
+| 994 | closed | !803 | opened | Same |
+| 963 | closed | !636 | opened | Same |
+| 946 | closed | !803 | opened | Duplicate of 994 — same |
+
+### PR open on GitHub (1)
+
+| GH PR | GH state | GL MR | GL state | Action |
+|---|---|---|---|---|
+| 799 | open | !80 | opened | Leave open — correctly mirrors active draft |
+
+### Other PRs (17)
+
+All closed; all correspond to closed/merged/abandoned GitLab MRs. No action.
+
+## Recommended sync actions (top-level)
+
+1. **Fix MR mirroring** — last MR-as-issue body dated 2024-09-16; reconfigure or replace the mirror tool to resume MR ingestion. ~23 open and 80–100 closed/merged MRs since 2024-09 are not represented on GitHub.
+2. **Re-import GitLab issue iid 557** — only open GitLab issue not on GitHub.
+3. **Document gh#683** — orphan since GL iid 684 was deleted; leave closed.
+4. **Review PRs #995/#994/#963/#946** — closed on GH while GitLab MR open. Treat GitLab as canonical; close-and-leave is acceptable.
+5. **No close-on-GitHub state-mismatch actions** are needed today.

--- a/aidocs/repo-overview.md
+++ b/aidocs/repo-overview.md
@@ -1,0 +1,165 @@
+# Repo Overview — shepard
+
+GitHub: https://github.com/noheton/shepard (mirror)
+GitLab (authoritative): https://gitlab.com/dlr-shepard/shepard
+Snapshot date: 2026-05-04
+Branch reviewed: `claude/cleanup-github-mirror-f2bsP` (from `develop` HEAD `d55b8de`).
+
+## Project goals & scope
+
+Shepard ("Storage for HEterogeneous Product And Research Data") is a multi-database research-data platform developed by DLR's Center for Lightweight Production Technology (Augsburg). It exposes a single REST API that stores timeseries, files, structured documents, spatial data, and semantic annotations alongside metadata, in support of FAIR research-data management.
+
+Quality goals (`architecture/src/01_introduction_and_goals/index.adoc`), prioritized: Usability, Reliability, Maintainability, Performance, Operability.
+
+Constraints (`architecture/src/02_architecture_constraints/index.adoc`):
+- On-premises only (no cloud, no internet); operable in DLR environments.
+- Open-source-licensed dependencies only.
+- FAIR principles; backwards-compatible data migrations.
+- Browser support: Firefox ESR + latest Edge; desktop/tablet only.
+
+## Top-level layout
+
+```
+backend/              Quarkus 3.27.2 / Java 21 REST API
+backend-client/       TypeScript client (auto-generated from OpenAPI)
+clients/{java,python,typescript,tests}  Multi-language client generation + tests
+frontend/             Nuxt 3.20.2 + Vue 3 + Vuetify 3 web UI
+infrastructure/       Docker Compose production deployment (Caddy, Prometheus, Grafana)
+infrastructure-local/ Local dev environment (Keycloak + DBs)
+load-tests/           k6 (TypeScript) performance suite — not in CI
+scripts/              Python CLI utilities (Poetry)
+architecture/         AsciiDoc Arc42 architectural documentation
+.gitlab/              Modular CI/CD definitions (~800 lines)
+renovate.json         Dependency-update automation config
+```
+
+Key files:
+- `.gitlab-ci.yml` — main CI orchestrator
+- `backend/pom.xml`, `frontend/package.json`, `scripts/pyproject.toml`
+- `CONTRIBUTING.md`, `README.md`, `CITATION.cff`, `codemeta.json`
+- No `CHANGELOG` (history tracked via Git tags).
+
+## Technology stack
+
+| Area | Tech |
+|---|---|
+| Backend | Quarkus 3.27.2, Java 21, Maven; JJWT 0.11.5; Hibernate Spatial 7.2.6; Lombok 1.18.44 |
+| Frontend | Nuxt 3.20.2, Vue 3.5.13, Vuetify 3.12.1, TipTap, Vite 6 |
+| Persistence | Neo4j 5.24 (metadata graph), MongoDB 8.0 (files & structured data), PostgreSQL+TimescaleDB (timeseries), PostgreSQL+PostGIS (spatial, behind feature flag) |
+| Auth | External OIDC (Keycloak typical); JWT bearer tokens; secondary `X-API-KEY` header for long-lived API keys |
+| Test stack (backend) | JUnit 5, Mockito 5, WireMock, JaCoCo, `@QuarkusTest`/`@QuarkusIntegrationTest` |
+| Test stack (frontend) | **None — zero tests** |
+| Migrations | Flyway (Postgres), neo4j-migrations (Neo4j) |
+| Tooling | OpenAPI Generator, Renovate bot, k6, Prettier, Ruff, docToolchain |
+
+Build & entry points:
+- Backend main: `backend/src/main/java/de/dlr/shepard/ShepardMain.java` → `mvn package -P prod -Drevision=${VERSION_NUMBER}`
+- Frontend: `npm run dev | build | preview` (Nuxt)
+- Clients: OpenAPI Generator
+- Documentation: docToolchain → HTML
+
+## Architecture
+
+Backend modules (`architecture/src/05_building_block_view/index.adoc`):
+
+- **Data**: Timeseries, Structured Data, Files, Semantic Repository, Spatial Data
+- **Context**: Collections & DataObjects, Lab Journal, Export, References, Version
+- **Auth**: API Keys, Permissions, Users, Security
+- **Common**: Configuration, Exceptions, Filters, MongoDB, Neo4j, Search, Subscription, Healthz, Versionz, Util
+
+Data model (per the wiki `Data-Model.md`): Collections → DataObjects (parent/child, predecessor/successor) → References (Structured-Data, File, Timeseries, Collection, DataObject, URI) → Containers (Timeseries, Structured Data, File).
+
+Integration points:
+- REST: `https://[host]/shepard/api/...`; OpenAPI at `/shepard/doc/openapi.json`; Swagger UI at `/shepard/doc/swagger-ui`.
+- OIDC identity provider via JWT bearer tokens; static OIDC public-key pinning.
+- Outbound webhook subscriptions (regex-matched URLs/methods) — see security finding C4.
+- Outbound SPARQL queries to semantic repositories (e.g., Ontobee).
+- RO-Crate ZIP export with `ro-crate-metadata.json`.
+- Prometheus metrics at `/shepard/doc/metrics/prometheus`.
+
+Architecture Decision Records (ADRs) of note (`architecture/src/09_architecture_decisions/`):
+
+- ADR-002: Quarkus chosen over Spring Boot/Javalin/Micronaut.
+- ADR-005: Nuxt + Vuetify frontend.
+- ADR-008: Neo4j + MongoDB + Postgres (TimescaleDB/PostGIS) — MinIO/Postgres-only rejected (32 TB limit, migration cost).
+- ADR-010/011: Postgres+TimescaleDB replaced InfluxDB for timeseries.
+- ADR-014/017: PostGIS for spatial data (380 ms vs 59 s vs pgvector for bounding-box).
+- ADR-019: Member injection preferred over constructor injection (flipped from ADR-004).
+- ADR-020: Single relation for default container.
+
+ADR index file `09_architecture_decisions/index.adoc` is **out of date** — it lists through 018 but ADRs 019 and 020 exist on disk.
+
+## CI/CD baseline
+
+Five pipeline shapes wired from `.gitlab-ci.yml`:
+
+1. **Feature branch**: secret-detection, dependency-scanning, prettier, scripts check.
+2. **Merge request**: check + build (backend, frontend, clients) + test (unit + integration + migrations + coverage) + diff jobs.
+3. **Develop**: same as MR + upload Docker images & client packages tagged `:dev`.
+4. **Main**: only check stage (no build/test).
+5. **Release tag** (`*-release` regex): full pipeline with Docker registry & Maven/PyPI/npm registry uploads.
+
+In-CI database services for tests: Neo4j 5.24, MongoDB 8.0, Postgres 16+TimescaleDB 2.18, PostGIS 3.5.
+
+### CI/CD gaps
+
+| Gap | Impact |
+|---|---|
+| **No active SAST** — SpotBugs + findsecbugs are configured under `<reporting>` but never run during `mvn verify` or CI | Security findings missed at PR time |
+| **No container image scanning** (Trivy etc.) | Base-image CVEs missed |
+| **No Java linting** (CheckStyle/PMD/SpotBugs) in pipeline | Code-style drift |
+| **No frontend tests at all** | Every frontend change is a regression risk |
+| **No E2E tests** (frontend ↔ backend) | Integration drift |
+| **No load tests in pipeline** (k6 suite present but unused) | Performance regressions invisible |
+| **Main branch pipeline minimal** (no build/test) | Release tags only validated via tag pipeline |
+| **Coverage report MR-only** | Main coverage not tracked |
+| **Prettier check-only** | No auto-formatting |
+
+## Documentation inventory
+
+| Document | Location | Format | Status |
+|---|---|---|---|
+| README | `README.md` | Markdown | Quick setup + links |
+| Contributing | `CONTRIBUTING.md` | Markdown | Branching, dev setup, review checklist |
+| Architecture (Arc42) | `architecture/src/{01..12}_*/index.adoc` | AsciiDoc | Comprehensive but several stub chapters |
+| ADRs | `architecture/src/09_architecture_decisions/{000..020}-*.adoc` | AsciiDoc | Index out of date (019, 020 missing from index) |
+| Codemeta | `codemeta.json` | JSON-LD | Software metadata (ORCID authors, Zenodo) |
+| Citation | `CITATION.cff` | CITATION format | Citation metadata |
+| API docs | dynamic | OpenAPI 3.0 | Served by backend |
+| Infrastructure | `infrastructure/README.md` | Markdown | Docker Compose deployment |
+
+Stub / "TBD" chapters in architecture: `06_runtime_view`, `07_deployment_view`, `10_quality_requirements`, the Risks table.
+
+## Wiki vs `/architecture` — gaps & contradictions
+
+**Only in the wiki** (https://gitlab.com/dlr-shepard/shepard/-/wikis/home):
+- Practical Python-client examples (`Examples/01-08`).
+- DLR institutional context.
+- Wiki-side data-model overview.
+
+**Only in `/architecture`**:
+- All ADRs + tech-choice rationale.
+- Module-level building-block decomposition.
+- Migration plan InfluxDB → TimescaleDB.
+- Lab Journal feature.
+- Spatial Data feature.
+- Versioning / HEAD/UUID semantics.
+- Validation, exception hierarchy, OpenAPI quirks.
+- Testing strategy, k6 load tests, Renovate workflow, release/hotfix scripts.
+- Quality goals, technical debt log, glossary.
+- LastSeenCache, JWTFilter, UserFilter, PublicEndpointRegistry implementation details.
+
+**Contradictions / inconsistencies**:
+- Wiki `home.md` references a `[Backend]` page that does not exist (dead link).
+- Wiki `Examples/05-Permissions.md` describes the permission model without the `PublicReadable` value (only listed in wiki `REST-API.md`); architecture (`auth.adoc`) authoritatively defines `Public`, `PublicReadable`, `Private`.
+- Architecture says "5-minute grace period" for revoked API keys / permissions; the actual `UserLastSeenCache` TTL is **30 minutes** (`UserLastSeenCache.java:8`). See security finding H2.
+- ADR-003 keeps frontend/backend as separate Docker images; wiki `home.md` mentions "two main parts" but admins must read `infrastructure/README.md` separately.
+
+## Project state observations
+
+- **Handover / wind-down phase** signals: active milestones include `Handover period` and `Interim`; multiple `xit-*` external-contractor assignees; many `staus::longterm` (sic) and `stale` labels.
+- 166 open issues vs 35 fresh (21%) — large stale backlog.
+- 23 open MRs are mostly Renovate dependency updates; only `!498` is bit-rotted (402 days idle).
+- Active feature work concentrated in `shepard 5.4.2` milestone (timeseries refactor) and `Sprint 23` (issues #712-#716).
+- Renovate is heavily used (205 MRs ever labeled `dependencies` ≈ 26% of all MRs).
+- Typo in active label `staus::longterm` (vs intended `status::longterm`).

--- a/aidocs/security-issues.md
+++ b/aidocs/security-issues.md
@@ -1,0 +1,169 @@
+# Security Issues — shepard
+
+Audit date: 2026-05-04. Scope: backend Java, scripts Python, frontend, infrastructure config.
+
+## Executive summary
+
+Five **CRITICAL** findings: (1) SQL injection in the spatial-data native query builder; (2) wildcard CORS configuration combined with state-changing methods; (3) permissions fallback that grants full read/write/manage to every user when an entity has no Permissions node; (4) SSRF + ReDoS in the subscription webhook filter; (5) Cypher injection in the Neo4j search query builder via user-controlled property names.
+
+**Eight HIGH** findings around JWT lifetimes, cache TTL contradictions, exception leakage, default credentials, EOL crypto library (jjwt 0.11), and a supply-chain risk (`dotenv` package).
+
+A configured-but-unused `spotbugs+findsecbugs` plugin (`backend/pom.xml:476-490`) provides no runtime signal — it lives in `<reporting>` and is never invoked by `mvn verify` or CI.
+
+None of the critical findings are tracked as open GitLab issues. Two HIGH findings overlap with permission-cluster issues (#41, #62, #424, #483, #667, #717).
+
+---
+
+## CRITICAL findings
+
+### C1 — SQL injection in spatial-data native query builder
+- **Location**: `backend/src/main/java/de/dlr/shepard/data/spatialdata/repositories/NativeQueryStringBuilder.java:40,65,116-123`; callers `SpatialDataPointRepository.java:47-55,86-94`
+- **Description**: `addJsonContainsCondition` interpolates a JSON-serialized user filter into a Postgres single-quoted literal: `" AND %s @> '%s'".formatted(parameterName, filterAsString)`. JSON serialization escapes `"` but **not `'`**; any `'` in a string value or key closes the literal and pivots into SQL. `addJsonFilterConditions` (lines 116-123) inlines `filterCondition.getKey()` and `filterCondition.getValue()` directly. The insert path inlines `JsonConverter.convertToString(metadata)` and `measurements` into `'...'` JSONB casts. Authenticated user with write on a spatial container can pivot to arbitrary SQL on the spatial datasource (PostGIS).
+- **Recommendation**: Replace with named parameters via `query.setParameter("metadata", jsonString)` and `CAST(:metadata AS JSONB)`. Switch JSONB filtering to JDBC bind parameters; for dynamic JSON paths use `jsonb_path_exists(:json, :path::jsonpath)` with bound paths.
+- **Fix effort**: M
+- **Tracked**: No
+
+### C2 — CORS misconfiguration: wildcard origin + state-changing methods
+- **Location**: `backend/src/main/resources/application.properties:18-21`
+- **Description**: `quarkus.http.cors.origins=*` together with `methods=GET,POST,HEAD,OPTIONS,DELETE,PUT,PATCH` and `Authorization,X-API-KEY` in allowed headers. Browsers block credentialed wildcard usage, but this still permits any web origin to issue cross-site reads (which return 401 but expose error bodies/timing) and, more importantly, makes Authorization-bearing requests possible cross-origin if a token leaks via a forwarding proxy or attacker-controlled subdomain. Combined with the X-API-KEY long-lived header, an XSS on any origin a user visits can spend tokens cross-origin.
+- **Recommendation**: Replace with an environment-driven allowlist (`quarkus.http.cors.origins=${SHEPARD_ALLOWED_ORIGINS}`), set `quarkus.http.cors.access-control-allow-credentials=false`, and pin per deployment.
+- **Fix effort**: XS
+- **Tracked**: No
+
+### C3 — Permissions fallback grants full access to entities with no Permissions node
+- **Location**: `backend/src/main/java/de/dlr/shepard/auth/permission/services/PermissionsService.java:258-262`
+- **Description**: `getRoles` returns `new Roles(false, true, true, true)` — i.e. manager + writer + reader = true — for any "legacy entity without permissions". `isAccessTypeAllowedForUser` (line 115) consults `getRoles` for every authorization decision; a single missed `createPermissions(...)` call (in a new entity type or due to a race condition during creation) silently exposes data with full write/manage rights to **every authenticated user**. Architecture documents this as known tech-debt #1, but the severity from a security standpoint is critical.
+- **Recommendation**: Invert the default — empty Optional should return `new Roles(false,false,false,false)`. Add a Neo4j constraint or startup audit job that fails the deploy if any `BasicEntity` is missing its `has_permissions` edge. Add an integration test that creates each entity type and verifies a Permissions node exists.
+- **Fix effort**: S
+- **Tracked**: Partial overlap with #41/#62/#424/#483/#667 (permissions cluster) and tech-debt #1.
+
+### C4 — SSRF + ReDoS in subscription webhook filter
+- **Location**: `backend/src/main/java/de/dlr/shepard/common/filters/SubscriptionFilter.java:63-78`
+- **Description**: `Pattern.compile(sub.getSubscribedURL())` compiles a user-supplied regex on every successful API response and runs `pattern.matcher(event.getUrl()).matches()` with **no timeout** — a catastrophic-backtracking regex DoSes every request. `client.target(sub.getCallbackURL())` POSTs to **any URL** the user supplied: no scheme allowlist, no IP filter for `169.254.169.254` (cloud metadata) / `127.0.0.1` / RFC1918, no DNS-rebinding mitigation. Outbound notifications include the `EventIO` payload (entity body), so this can also exfiltrate other tenants' data.
+- **Recommendation**: (a) Validate `subscribedURL` regexes with a complexity checker / timeout-bounded matcher; (b) enforce HTTPS and an allowlist (or denylist of `localhost`/loopback/link-local/private CIDRs after DNS resolution) on `callbackURL`; (c) disable redirects on the JAX-RS client; (d) drop entity body from EventIO and only send IDs + URL.
+- **Fix effort**: M
+- **Tracked**: No
+
+### C5 — Cypher injection via user-controlled property names and IRI types
+- **Location**: `backend/src/main/java/de/dlr/shepard/common/search/query/Neo4jQueryBuilder.java:376` (`atPart`: `variable + "." + property`), `:386` (`iRIPart`: `"sem." + iriType`), `:280` (lowercased JSON value concatenated), `:200-202,239-241` (annotation IRI/Name interpolated inside `"…"`)
+- **Description**: `node.get(OP_PROPERTY).textValue()` — the JSON search-request body's property name — is user-controlled and concatenated as a Cypher identifier path (`variable.property`), allowing breaking the expression with `}) RETURN n // ` payloads. Annotation pair values are split on `::` and inserted between literal `"` quotes; a value containing `"` terminates the literal. `valuePart` (line 149) inserts `node.get(OP_VALUE).toString()` raw — JSON encoding gives some safety for strings, but for non-string `JsonNode`s (arbitrary nested objects passed where a number is expected) attacker text still emerges. Impact: read access to entities bypassing `readableByPart` filtering, Neo4j RCE-equivalent via cluster procedures, cross-tenant data exfiltration.
+- **Recommendation**: Use Neo4j parameter binding (`session.query(query, Map.of("prop", value))`) for all values; whitelist `OP_PROPERTY` against a known enum before concatenation; reject any property name not matching `[A-Za-z_][A-Za-z0-9_]*`.
+- **Fix effort**: L (search path is large)
+- **Tracked**: Partial overlap with #717 area.
+
+---
+
+## HIGH findings
+
+### H1 — JWT API-key tokens are minted without `setExpiration`
+- **Location**: `backend/src/main/java/de/dlr/shepard/auth/apikey/services/ApiKeyService.java:138-150`; validation in `JWTFilter.java:210-247`
+- **Description**: API-key JWTs carry `setIssuedAt` / `setNotBefore` only — no `setExpiration`. Once issued, an API-key JWT is valid forever. Revocation requires a DB delete plus a 5-minute cache flush (line 232). If the private key in `~/.shepard/keys/private.key` ever leaks (file permissions are OS default, no `chmod 600` in `PKIHelper.java:107-110`), an attacker can mint API tokens for any username.
+- **Recommendation**: Set `setExpiration` on JWT mint (e.g. 90 days) and rotate. Restrict key files to `0600` via `Files.setPosixFilePermissions`. Move to JWKS so keys can be cycled.
+- **Fix effort**: S
+- **Tracked**: No
+
+### H2 — `UserLastSeenCache` is 30 minutes, contradicting documented "5 minute" grace period
+- **Location**: `backend/src/main/java/de/dlr/shepard/auth/security/UserLastSeenCache.java:8`
+- **Description**: Architecture docs say "5-minute grace period" for revoked sessions. `UserLastSeenCache` is `30 * 60 * 1000`. While JWT roles are still checked per-request, `UserFilter`'s userinfo→DB sync (which validates token-vs-userinfo username match, line 59) is bypassed for up to 30 minutes. This widens token-theft impact and disables Keycloak-side disablement for 30 min vs the advertised 5.
+- **Recommendation**: Reduce TTL to 5 min (match `ApiKey`/`Permission` caches) or update the docs and architecture to match.
+- **Fix effort**: XS
+- **Tracked**: No
+
+### H3 — CORS allows `OPTIONS` preflight bypass of authentication by design
+- **Location**: `backend/src/main/java/de/dlr/shepard/common/filters/JWTFilter.java:98-101`
+- **Description**: All `OPTIONS` requests are allowed without a token. Combined with C2 (wildcard origin), this gives browser-side attackers free reconnaissance of the API surface and lets them read CORS error envelopes.
+- **Recommendation**: Subsumed by C2; once CORS origin is restricted, OPTIONS bypass becomes scoped.
+- **Fix effort**: XS (no separate change once C2 is fixed)
+
+### H4 — `ShepardExceptionMapper` leaks internal exception messages to clients
+- **Location**: `backend/src/main/java/de/dlr/shepard/common/exceptions/ShepardExceptionMapper.java:21-24`
+- **Description**: Catches all exceptions and returns `exception.getClass().getSimpleName()` and `exception.getMessage()` to the client. Hibernate / Neo4j / MongoDB exceptions frequently embed query fragments, parameter values, schema details, and constraint names. Full stack traces are logged at `error` on every 4xx (line 21), so logs fill with PII and noisy stacks.
+- **Recommendation**: Return generic message for `INTERNAL_SERVER_ERROR`; only expose message for explicit `WebApplicationException` subclasses; log full stack only at `debug` or with sanitization.
+- **Fix effort**: S
+- **Tracked**: No
+
+### H5 — `PublicEndpointRegistry` uses `startsWith` — path-traversal risk
+- **Location**: `backend/src/main/java/de/dlr/shepard/common/filters/PublicEndpointRegistry.java:8-15`
+- **Description**: `requestContext.getUriInfo().getPath().startsWith("/versionz")`. Any future entry like `/users` would match `/usersearch`, `/users/admin`, etc. URI normalization isn't performed — `/versionz/../containers/1` could match. Currently only `/versionz` is registered with no realistic prefix collision, but the implementation is unsafe by construction.
+- **Recommendation**: Use exact-match or anchored regex; normalize the path; add unit tests.
+- **Fix effort**: XS
+- **Tracked**: No
+
+### H6 — `dotenv` 0.9.9 in `scripts/poetry.lock` — supply-chain risk
+- **Location**: `scripts/pyproject.toml:18`, `scripts/poetry.lock:158-169`
+- **Description**: `dotenv` (PyPI) is a low-quality orphan package that re-exports `python-dotenv`. Owned by a single PyPI account; if the account is compromised, every CLI invocation runs attacker code. (Note: `jinja2` is locked to 3.1.6 — patched against the 2024-2025 CVEs.)
+- **Recommendation**: Replace `dotenv = "^0.9.9"` with `python-dotenv = "^1.0"` and purge `dotenv` from `poetry.lock`.
+- **Fix effort**: XS
+- **Tracked**: No
+
+### H7 — jjwt 0.11.5 (EOL) still in use across all auth code
+- **Location**: imports in `JWTFilter.java:12-16`, `ApiKeyService.java:12`
+- **Description**: jjwt 0.11.x branch is no longer maintained. Concrete impact today is limited (algorithm-confusion attacks not directly exploitable here because `setSigningKey(PublicKey)` pins to RSA and refuses HMAC), but lack of patches is a HIGH dependency-hygiene issue.
+- **Recommendation**: Upgrade to `io.jsonwebtoken:jjwt-api:0.12.x`; switch to `parser().verifyWith(key).build()` API. Bundle with H1 (add `setExpiration` while migrating).
+- **Fix effort**: S
+- **Tracked**: No (Renovate `<0.12` pin currently blocks)
+
+### H8 — Default credentials checked into the repo
+- **Location**: `backend/src/main/resources/application.properties:133-145` (mongodb password `"password"`, neo4j `"shepardshepard"`, postgres `"shepard_secret"`); `infrastructure/.env.example:2,10,14,18,24,27,30` (Neo4j/Mongo/Postgres/Influx/Grafana all `"secret"`)
+- **Description**: While `%dev` profile credentials are not used in prod and `.env.example` is a template, README guidance does not force users to change them and `infrastructure-local` containers default to these. Operators frequently copy `.env.example` to `.env` unchanged.
+- **Recommendation**: Replace example values with placeholders that fail at startup if not changed (e.g. `CHANGE_ME_<random>`); document hardening; add a startup check.
+- **Fix effort**: XS
+- **Tracked**: No
+
+---
+
+## MEDIUM findings (compact)
+
+| # | Location | Issue | Recommendation | Effort |
+|---|---|---|---|---|
+| M1 | `application.properties:85` | `quarkus.http.limits.max-body-size=` (unlimited) → trivial DoS via large uploads | Set explicit limit (e.g. 1 GiB) and per-endpoint constraints | XS |
+| M2 | `PKIHelper.java:107-110` | Generated RSA keys written without explicit `0600` perms | `Files.setPosixFilePermissions` on private key | XS |
+| M3 | `PKIHelper.java:104` | RSA 2048; modern guidance is RSA-3072 / Ed25519 | Increase or migrate to EdDSA | S |
+| M4 | `JWTFilter.java:159` | `header.replace("Bearer ", "")` strips `"Bearer "` anywhere — token containing literal "Bearer " is mangled | Use `header.substring(7)` after prefix check | XS |
+| M5 | `JWTFilter.java:113-117` | Logs the entire failed Authorization and X-API-KEY header values at warn level — possible token leak to log file | Redact tokens in log lines | XS |
+| M6 | `application.properties:38-41,45` | Logging filtered to suppress Neo4j deprecations and `BoltRequest` at INFO — masks security-relevant query failures | Keep WARN+ for these categories or route to a separate logger | XS |
+| M7 | `ShepardExceptionMapper.java:21` | All exceptions logged with full stack at error — log-volume DoS plus PII | Sanitize and rate-limit | S |
+| M8 | `PermissionsService.isAllowed:198-243` | Hard-coded path-segment whitelist; comments say "permissions are already checked inside …Service" — that's a doc invariant, not code-enforced | Add unit tests asserting each Service performs its own check; consider annotation-based authorization | M |
+| M9 | `Neo4jQueryBuilder.java:280` | `node.get(OP_VALUE).toString().toLowerCase()` for `createdBy`/`updatedBy` — fragile JSON-encode-then-lowercase; bind as Cypher parameter | Bind as Cypher parameter | S |
+| M10 | `application.properties:18-22` | CORS responses do not configure `Vary: Origin` — browser-cache poisoning risk if origins is later restricted | Set `quarkus.http.cors.origins-vary=true` if Quarkus supports | XS |
+| M11 | `infrastructure/.env.example:35` | `FRONTEND_AUTH_SECRET="Frontend auth secret"` is not high-entropy | Document required entropy; validate at startup | XS |
+| M12 | `backend/pom.xml:476-490` | SpotBugs/findsecbugs in `<reporting>` only; never runs during `mvn verify`; CI does not call `mvn site` | Move to `<build><plugins>` with `verify` execution; fail on High findings | S |
+
+---
+
+## LOW / informational
+
+| # | Location | Note |
+|---|---|---|
+| L1 | `JWTFilter.java:202-203` | OIDC subject split on `:` → cryptic usernames (tech-debt #2). Consider stable `sub`-based UUID mapping. |
+| L2 | `application.properties:117-118` | Prometheus metrics endpoint at `/shepard/api/metrics/prometheus` — confirm auth is required (only `/versionz` is in the public registry). |
+| L3 | `HtmlSanitizer.java:34` | `addAttributes(":all", "style", …)` — inline `style` is a CSS-XSS sink; jsoup strips most but `style` remains broad. |
+| L4 | `SubscriptionRest.java` | No per-user cap on subscriptions — DoS via 10k subscriptions slows every successful response (line 60-73 iterates all matching). |
+| L5 | `ApiKeyRest.java:115-123` | `createApiKey` returns the JWT once via `ApiKeyWithJWTIO` — good. No rate limiting on creation. |
+| L7 | `application.properties:48` | MongoDB connection string defaults to `mongodb://mongo@mongodb:27017` — relies on env for password in prod profile. |
+| L8 | `JWTFilter.java:58` | Package-private no-arg constructor exists for CDI proxying; bypasses key initialization on direct instantiation. Acceptable due to CDI semantics. |
+
+---
+
+## Doc-vs-implementation gaps
+
+- **"Static OIDC public-key configuration"** — confirmed (`JWTFilter.java:75-83`; `oidc.public` decoded from base64 and pinned at startup). No JWKS rotation; key change requires redeploy.
+- **"5-minute grace period for revoked keys/permissions"** — partially false. `ApiKeyLastSeenCache` and `PermissionLastSeenCache` are 5 min; `UserLastSeenCache` is **30 min**. See H2.
+- **"Container deletion only by owner"** — not directly verified; recommend coverage in permission tests.
+- **"Public Readable" semantics** — implementation is correct (`PermissionsService.isReader:281-286` returns true for `Public` and `PublicReadable`; `isWriter:289-293` only for `Public`).
+- **"Pre-permission entities have NO permissions → fallback grants access"** — confirmed; rated CRITICAL (C3). Architecture lists this as known tech-debt; severity from a security standpoint deserves elevation.
+- **`@EndpointDisabled` / `@IfBuildProperty` toggles do not work in native builds** — confirmed by code presence (`SpatialDataPointRest.java:47`, `CollectionVersioningRest.java:39`); native-build behavior not testable here.
+- **`/healthz` is not in `PublicEndpointRegistry`** — `/versionz` is the only public path. Operators expecting unauthenticated `/healthz` will hit 401.
+
+---
+
+## CI/CD security recommendations
+
+1. **Activate SAST**: move SpotBugs + findsecbugs from `<reporting>` to `<build>` and run in the `check` stage (`mvn -Pci verify spotbugs:check`). Fail build on `Threshold=Medium` security categories.
+2. **Add Trivy** (`aquasecurity/trivy-action` or GitLab template) to scan the produced container image and Maven dependencies; fail on high CVE severity.
+3. **Add ESLint security plugin** (`eslint-plugin-security`) to the frontend lint step.
+4. **Add `bandit` or `semgrep` for `scripts/`**: catches the `dotenv` issue and Jinja2 SSTI patterns.
+5. **Run full `verify` (not just `check`) on main and release pipelines** so integration tests + SAST run before tag.
+6. **Add a startup integration test** that creates each entity type and asserts it acquires a Permissions node — addresses the C3 invariant.
+7. **Extend secret scanning** to fail on default values like `shepard_secret` / `shepardshepard`.
+8. **Add OWASP Dependency-Check or Renovate-driven CVE policy** for jjwt, jinja2, and Quarkus BOM updates.


### PR DESCRIPTION
Adds 11 cleanup documents synthesised from a four-wave audit (codebase, architecture, dependencies, GitLab issues/MRs, GitHub reconciliation, security, implementation status, test coverage, issue gauging, cluster mapping):

- aidocs/repo-overview.md
- aidocs/issues-status.md
- aidocs/reconciliation.md
- aidocs/security-issues.md
- aidocs/dependency-report.md
- aidocs/code-quality.md
- aidocs/cluster-map.md
- aidocs/ready-to-close.md
- aidocs/first-issues.md
- aidocs/implementation-plan.md
- aidocs/cleanup-plan.md

Highlights: 5 critical security findings (untracked), 8 high; 79% of open issues stale; frontend has zero tests; SpotBugs/findsecbugs configured but not run in CI; mirror MR-import broken since 2024-09-16. See cleanup-plan.md for the executive summary.