### PR TITLE
ci: auto-enable Pages source + showcase.md front matter

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,17 +7,13 @@ name: GitHub Pages
 # the actions/deploy-pages step below to take effect.
 #
 # Trigger posture:
-#  - push to `main` — the production deploy after PR-#1001 merges.
-#  - push to `claude/implement-input-raw-changes-2WiOF` — preview of
-#    the dispatcher branch while PR-#1001 is still open. Drop this
-#    branch from the list once the PR merges.
+#  - push to `main` — production deploy.
 #  - workflow_dispatch — manual run from the Actions tab.
 
 on:
   push:
     branches:
       - main
-      - claude/implement-input-raw-changes-2WiOF
     paths:
       - "docs/**"
       - ".github/workflows/pages.yml"
@@ -41,6 +37,11 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          # Programmatically flips repo Pages source to "GitHub Actions"
+          # if it is still set to "Deploy from a branch" (or unset). Avoids
+          # the manual Settings -> Pages toggle on first deploy.
+          enablement: true
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Showcase
+description: Ten-stop tour of shepard's feature surface against a synthetic LUMEN-inspired hot-fire campaign.
+---
+
 # Showcase tour — LUMEN-inspired hot-fire campaign
 
 > **Disclaimer.** Everything below is **synthetic**. The Collection is loosely


### PR DESCRIPTION
Follow-up to #1001 after the production Pages deploy failed.

## Root cause hypothesis

The most likely failure mode is that **Settings → Pages → Source** is
still set to "Deploy from a branch" (or unset). The previous unstyled
"https://noheton.github.io/shepard/" page that the user could see was
GitHub's default Jekyll serving from a branch path — bypassing our
SCSS pipeline. Once `main` triggered our workflow, `actions/deploy-pages@v4`
had nowhere to deploy to under that source setting and failed.

## Fix

1. `actions/configure-pages@v5` now runs with `enablement: true` so
   the workflow programmatically flips the Source to "GitHub Actions"
   on first run — no manual maintainer toggle needed.
2. Drop the `claude/implement-input-raw-changes-2WiOF` branch from
   the trigger list now that #1001 is merged; production deploys
   come from `main`.
3. `docs/showcase.md` was missing front matter and rendered as a raw
   `.md` in the build output. Added the standard `layout: default`
   block so it lands as `showcase.html` with site chrome.

## Test plan

- [ ] Workflow run on `main` after merge completes both `build` and `deploy` jobs.
- [ ] Site at https://noheton.github.io/shepard/ renders with the DLR design system (white header, blue accents, splash hero).
- [ ] `https://noheton.github.io/shepard/showcase` returns the LUMEN-inspired tour with chrome (not raw `.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_