### PR TITLE
docs: free test deploy guide for Oracle Cloud Always-Free Ampere

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A GitHub Pages site is published from `docs/` on this mirror:
 
 **<https://noheton.github.io/shepard/>**
 
-Tour: overview & use cases (`/`) · architecture (`/architecture`) · Python quickstart (`/getting-started`) · user guide (`/user-guide`) · admin guide (`/admin`) · system requirements (`/system-requirements`).
+Tour: overview & use cases (`/`) · architecture (`/architecture`) · Python quickstart (`/getting-started`) · user guide (`/user-guide`) · admin guide (`/admin`) · system requirements (`/system-requirements`) · [free test deploy on Oracle Cloud](https://noheton.github.io/shepard/deploy-oracle-free) (`/deploy-oracle-free`).
 
-Source under `docs/`; built and deployed by `.github/workflows/pages.yml` on push to `main` (preview also runs on the dispatcher branch while PRs are open). The canonical authoritative documentation is the GitLab wiki linked further down in this README; the GitHub Pages site is a structured overview for the GitHub mirror.
+Source under `docs/`; built and deployed by `.github/workflows/pages.yml` on push to `main`. The canonical authoritative documentation is the GitLab wiki linked further down in this README; the GitHub Pages site is a structured overview for the GitHub mirror.
 
 ## Quick test / evaluation setup
 

--- a/aidocs/25-neo4j-id-migration-design.md
+++ b/aidocs/25-neo4j-id-migration-design.md
@@ -2,9 +2,9 @@
 
 **Scope.** Forward-looking design note for backlog item **L2** (`aidocs/16-dispatcher-backlog.md`, originating from `aidocs/input/input_raw.md:90` and `:715-717`): retire Neo4j's deprecated `id()` function from every Cypher query and every cross-store / API surface, in favour of an **application-generated stable identifier** (`appId`). This is the load-bearing prerequisite for Templates (**L3**) and removes the largest residual blocker on the search (`aidocs/13`) and semantic-annotation (`aidocs/14`) work.
 
-**Status.** Proposal. No code or migration scripts touched.
+**Status.** Phase 1 (L2a) **landed** `fec7979` (cherry-pick onto `claude/implement-input-raw-changes-2WiOF`, merged via PR #1003 at `79f3ffd`). Phase 2 (L2b) **queued** — see §3.1 / §4.Phase-2 for the prescribed migration shape. Phases 3–5 stay queued; L2c gated on C5, L2d gated on P4 + H4.
 
-**Snapshot date.** 2026-05-05.
+**Snapshot date.** 2026-05-07.
 
 **Companion docs.** Reads as a fourth member of the C-section (`12`/`13`/`14`); extends `aidocs/12-timescaledb-performance-analysis.md` §11 (identifier discipline) — does not duplicate it.
 
@@ -56,7 +56,7 @@ Snowflake is rejected: even one shared worker-id register is one more piece of i
 
 Each entity node gains a property `appId: STRING` (UUID v7 canonical). A unique constraint and a lookup index. The existing `id` property (the OGM-mirrored Long, see `backend/src/main/java/de/dlr/shepard/common/neo4j/entities/AbstractEntity.java:30-32`) stays in place during the deprecation window — it is the OGM's primary key and yanking it requires the full OGM-removal pass on `aidocs/03-issues-status.md` #274 to land first.
 
-Cypher migration sketch (do not run; `V11__Add_appId_to_entities.cypher` in the next migration slot — current head is `V10__Refactor_Semantic_Annotations.cypher`):
+Cypher migration **as shipped** in L2a is `V11__Add_appId_unique_constraints.cypher` (constraints only — 28 per-label `REQUIRE n.appId IS UNIQUE`, idempotent via `IF NOT EXISTS`). The backfill below is the **L2b** payload, slated for `V12__Backfill_appId.cypher`:
 
 ```cypher
 // Phase 2 backfill — run idempotent.
@@ -145,10 +145,12 @@ Five phases. Each ships independently. Preconditions cite the backlog ID at `aid
 
 **Change set.**
 
-1. Cypher migration `V11__Add_appId_constraints.xml` introduces the unique constraint + lookup index per label.
-2. A new mixin `HasAppId` (interface + getter/setter) added to `AbstractEntity`, defaulting `appId = UuidCreator.getTimeOrderedEpoch()` (UUID v7) at construction. Same as the Lombok `@Data` pattern already used.
-3. `GenericDAO.createOrUpdate` (`backend/src/main/java/de/dlr/shepard/common/neo4j/daos/GenericDAO.java:90-93`) gains a one-line guard: if `entity.getAppId() == null`, set it before save.
+1. Cypher migration `V11__Add_appId_unique_constraints.cypher` — 28 per-label `REQUIRE n.appId IS UNIQUE` (idempotent via `IF NOT EXISTS`). **Landed.**
+2. New mixin `HasAppId` (interface, `getAppId() / setAppId(String)`) implemented by 28 `@NodeEntity` classes — 18 via `AbstractEntity`, 2 via `AbstractMongoObject`, 8 standalones (`User`, `ApiKey`, `Permissions`, `Subscription`, `AnnotatableTimeseries`, `SemanticAnnotation`, `Version`, `ReferencedTimeseriesNodeEntity`). **Landed.** Note: implementation does **not** mint at construction (would have required adding `appId` to existing hand-written `equals/hashCode` — out of additive scope); the seam mints at the DAO write boundary instead, see (3).
+3. `GenericDAO.createOrUpdate` (`backend/src/main/java/de/dlr/shepard/common/neo4j/daos/GenericDAO.java`) gains a one-line guard: `if (entity instanceof HasAppId hai && hai.getAppId() == null) hai.setAppId(AppIdGenerator.next());` before `session.save`. Single seam, no per-DAO instrumentation. **Landed.**
 4. `Neo4jQueryBuilder` and `PermissionsDAO` Cypher unchanged — still `WHERE ID(e) = %d`.
+
+**Deviation from spec list.** `Roles` (`backend/.../auth/permission/model/Roles.java`) is a plain DTO, not `@NodeEntity` — no `appId`, no constraint. Spec mentioned it as a node label; it isn't one in this codebase.
 
 **Observability.** Add an integration test that creates 1000 collections and asserts `MATCH (c:Collection) WHERE c.appId IS NULL RETURN count(*) = 0` and that no two collections share an `appId`.
 
@@ -162,7 +164,11 @@ Five phases. Each ships independently. Preconditions cite the backlog ID at `aid
 
 **Goal.** Every existing entity (pre-Phase-1) gets an `appId`.
 
-**Change set.** Cypher migration `V12__Backfill_appId.cypher` per the sketch in §3.1, **idempotent** (the `WHERE n.appId IS NULL` filter). The `MigrationsRunner` (`backend/src/main/java/de/dlr/shepard/common/neo4j/MigrationsRunner.java:66-74`) picks it up on next startup. Migration runs in `PER_STATEMENT` transaction mode (`:39`); on a graph with > 1 M nodes this is a lightly chunked cypher (`CALL { ... } IN TRANSACTIONS OF 10000 ROWS`).
+**Preconditions.**
+- **L2a landed** (`fec7979`) — every new write since L2a already has a v7 `appId`. The backfill only touches rows older than L2a's deploy.
+- **MigrationsRunner fail-fast (risk #4 below).** The runner currently logs `MigrationsException` and starts the app anyway. A botched backfill — e.g. a rare uniqueness collision on Neo4j's `randomUUID()` (v4) — must abort startup, not leave the cluster accepting writes on a half-migrated graph. **Fix before L2b ships in any environment that holds real data.**
+
+**Change set.** Cypher migration `V12__Backfill_appId.cypher` per the sketch in §3.1, **idempotent** (the `WHERE n.appId IS NULL` filter). The `MigrationsRunner` (`backend/src/main/java/de/dlr/shepard/common/neo4j/MigrationsRunner.java:66-74`) picks it up on next startup. Migration runs in `PER_STATEMENT` transaction mode (`:39`); on a graph with > 1 M nodes this is a lightly chunked cypher (`CALL { ... } IN TRANSACTIONS OF 10000 ROWS`). The unique constraint from V11 already guards against collisions — a violation aborts the chunk.
 
 **Observability.** Log progress per chunk; mirror the `migration_progress` table pattern from P3 (TimescaleDB-side) with a Neo4j-side `MigrationProgress` node, or — simpler — emit Prometheus counters.
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -8,6 +8,14 @@ This page describes how to run shepard. It cites only what is actually in the
 repository today; the dedicated admin CLI is **in design** and not yet
 shipped — see "Admin CLI" below.
 
+## Free test deploy
+
+Want to spin up a personal test instance without paying for hosting?
+See [Deploy on Oracle Cloud Free Tier](deploy-oracle-free) — a one-page
+operator guide covering OCI signup quirks, the ARM-image caveat for
+shepard's backend/frontend, TLS via Caddy + Let's Encrypt, and nightly
+Object Storage backups within the always-free 10 GB allowance.
+
 ## Stack — docker-compose
 
 Production deployment uses `infrastructure/docker-compose.yml`. The

--- a/docs/deploy-oracle-free.md
+++ b/docs/deploy-oracle-free.md
@@ -1,0 +1,205 @@
+---
+layout: default
+title: Deploy on Oracle Cloud Free Tier
+description: One-page operator guide for hosting a free shepard test instance on Oracle Cloud Infrastructure (Ampere ARM, always-free).
+---
+
+# Deploy on Oracle Cloud Free Tier
+
+A one-page guide for putting a **test instance** of shepard on
+Oracle Cloud Infrastructure's Always-Free Ampere ARM allocation. This
+is the cheapest practical home for shepard's full stack
+(Quarkus + Neo4j + Mongo + TimescaleDB + PostGIS + Nuxt) outside a
+managed-services split.
+
+> **Not for production data.** Oracle's "Always Free" guarantee has an
+> idle-reclaim clause: a VM with no traffic for 7 consecutive days can
+> be flagged for reclamation. Use this for demos, CI environments, and
+> reviewer trials — back up anything you care about (see §6).
+
+## 1. What you get
+
+| Resource | Always-Free allowance |
+|---|---|
+| Compute | **4 OCPU + 24 GB RAM** of `VM.Standard.A1.Flex` (Ampere ARM), splittable across up to 2 VMs |
+| Block storage | 200 GB total |
+| Object storage | 10 GB (good for backups) |
+| Egress | 10 TB / month |
+| Public IPv4 | 2 reserved |
+
+For shepard, allocate **the full 4 OCPU + 24 GB** to a single VM. The
+default JVM heap (`-Xmx2G` per `infrastructure/docker-compose.yml:5`),
+Neo4j 5.24, Mongo 8, TimescaleDB, and PostGIS together fit comfortably
+inside 24 GB with headroom for swap.
+
+## 2. Sign up — the friction
+
+Oracle requires a credit card at signup even for the free tier (no
+charge unless you upgrade). ARM-shape capacity has historically been
+patchy in some regions; if your home region's Ampere pool is full, the
+console returns "Out of host capacity" — pick a different home region
+on signup (Frankfurt and Phoenix are usually available). The home
+region is permanent; choose carefully.
+
+## 3. Provision the VM
+
+In the OCI console: **Compute → Instances → Create instance**.
+
+- **Image:** Canonical Ubuntu 22.04 LTS (`Ubuntu-22.04-aarch64-...`)
+- **Shape:** `VM.Standard.A1.Flex`, **4 OCPU**, **24 GB**
+- **Networking:** assign a public IPv4. Add an **ingress** rule on the
+  default VCN's security list for TCP **22**, **80**, **443**.
+  Optionally **8080** while you smoke-test before TLS.
+- **Boot volume:** 200 GB (max free).
+- **SSH keys:** paste your public key. Password auth stays disabled.
+
+Capacity hint: if creation fails with a capacity error, retry every
+30 minutes — Ampere capacity churns. Don't pre-provision a smaller
+shape and resize later; create at the target shape.
+
+## 4. System prep on the VM
+
+```bash
+ssh ubuntu@<public-ip>
+
+# OCI's default firewalld rules drop everything; either flush or just
+# use ufw. The ingress allowlist on the VCN is what matters.
+sudo systemctl disable --now firewalld
+
+# Docker (official repo, arm64).
+curl -fsSL https://get.docker.com | sudo sh
+sudo usermod -aG docker ubuntu
+newgrp docker
+
+# 8 GB swap. Helps when migrations spike Neo4j heap.
+sudo fallocate -l 8G /swapfile && sudo chmod 600 /swapfile
+sudo mkswap /swapfile && sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+
+# UFW for ssh + http(s).
+sudo ufw allow OpenSSH && sudo ufw allow 80 && sudo ufw allow 443
+sudo ufw --force enable
+```
+
+## 5. Run shepard
+
+### 5a. The ARM image caveat
+
+shepard's published images
+(`registry.gitlab.com/dlr-shepard/shepard/{backend,frontend}:5.2.0`)
+are **amd64-only** at the time of writing. The data tier
+(`neo4j:5.24`, `mongo:8.0`, `postgis/postgis:16-3.5`,
+`timescale/timescaledb:2.24.0-pg16`, `caddy:2`) ships multi-arch and
+runs natively on ARM.
+
+Two paths:
+
+- **(recommended) Rebuild backend + frontend for `linux/arm64`** on the VM, push to a free registry (Docker Hub free tier or **GitHub Container Registry**, which is free for public images), and pin the compose file to your registry tag. Wall-clock: ≈ 10 min Maven build, ≈ 2 min Nuxt build. Native ARM throughput.
+
+- **(fast) Run the upstream amd64 images under QEMU emulation** — add `platform: linux/amd64` to the `backend` and `frontend` services in `docker-compose.yml`, install `qemu-user-static` (`sudo apt install qemu-user-static binfmt-support`). Functional but ≈ 2-3× slower; fine for a demo.
+
+### 5b. Clone, configure, start
+
+```bash
+sudo mkdir -p /opt/shepard && sudo chown -R ubuntu:ubuntu /opt/shepard
+cd /opt && git clone https://github.com/noheton/shepard.git
+cd shepard/infrastructure
+cp .env.example .env
+
+# REQUIRED: rotate the example passwords. The shipped values
+# (POSTGRES_*, NEO4J_PW, MONGO_PASSWORD, etc.) are placeholders and
+# already-public — see aidocs/07 H8.
+$EDITOR .env
+
+docker compose up -d
+docker compose ps
+```
+
+Backend logs land in `/opt/shepard/backend/logs` per the compose
+volume mount.
+
+### 5c. TLS + domain
+
+The repo ships `infrastructure/proxy/Caddyfile` with a
+`hostname_placeholder_do_not_change` token. For a free domain:
+
+```bash
+# Pick one — DuckDNS free subdomain is the simplest.
+# Sign up at https://www.duckdns.org/, get <name>.duckdns.org pointed
+# at your OCI public IP.
+
+cd /opt/shepard/infrastructure/proxy
+sed -i 's/hostname_placeholder_do_not_change/<name>.duckdns.org/g' Caddyfile
+
+# Switch Caddy from the bundled self-signed cert to Let's Encrypt:
+# remove the `auto_https disable_certs` line and the explicit
+# `tls /etc/caddy/ssl/...` lines so Caddy auto-issues.
+$EDITOR Caddyfile
+docker compose restart caddy
+```
+
+Caddy obtains and renews Let's Encrypt certs automatically; no
+certbot needed.
+
+## 6. Backup to the free Object Storage
+
+```bash
+# 10 GB Always-Free object storage. Tarball the volumes nightly.
+sudo apt install -y oci-cli
+oci setup config   # walks you through API key + region
+
+cat > /usr/local/bin/shepard-backup.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+cd /opt/shepard
+docker compose stop neo4j mongodb timescaledb postgis
+tar czf /tmp/shepard-$(date -u +%FT%H%MZ).tgz \
+    /var/lib/docker/volumes/{shepard_neo4j_data,shepard_mongodb_data,shepard_timescaledb_data,shepard_postgis_data}
+docker compose start neo4j mongodb timescaledb postgis
+oci os object put -bn shepard-backups --file /tmp/shepard-*.tgz --force
+rm -f /tmp/shepard-*.tgz
+EOF
+chmod +x /usr/local/bin/shepard-backup.sh
+
+# Nightly at 02:30.
+echo '30 2 * * * root /usr/local/bin/shepard-backup.sh' | sudo tee /etc/cron.d/shepard-backup
+```
+
+Object Storage lifecycle policies can age out backups beyond 7 days
+to stay inside the 10 GB allowance.
+
+## 7. Hardening checklist
+
+Beyond the defaults the steps above set:
+
+- [ ] **Rotate every password** in `.env` — `aidocs/07` H8 explicitly
+      flags the shipped defaults as a known issue.
+- [ ] **fail2ban** for sshd (`sudo apt install fail2ban`).
+- [ ] **Restrict port 22 ingress** to your IP via the VCN security list
+      once you have a stable home address.
+- [ ] **Disable mongo-express and prometheus exposure** on a public
+      instance — they listen on the docker network only by default,
+      but double-check `docker compose ps` doesn't bind them to
+      `0.0.0.0`.
+- [ ] **Set `OIDC_AUTHORITY`** to a real Keycloak (Identity Cloud
+      Service free tier, or a self-hosted Keycloak in the same compose).
+
+## 8. What this isn't
+
+- **Not a production deployment.** No HA, no off-site backups by
+  default, no log aggregation, no monitoring alerting.
+- **Not a privacy-grade host.** Oracle's free tier ToS reserves the
+  right to inspect VMs flagged as abusive.
+- **Not a benchmark target.** Ampere ARM throughput is solid but the
+  free tier shares physical hosts; latency is variable.
+
+For a production deploy, see `docs/admin.md` and consider
+self-hosting on bare metal or a paid VPS (Hetzner CCX13 is the usual
+shepard-team reference at €4–€8 / month).
+
+## 9. Teardown
+
+`Compute → Instances → Terminate` releases the VM and the boot volume.
+The reserved public IP and Object Storage bucket survive separately —
+delete those from their respective consoles to fully reclaim the
+allowance.


### PR DESCRIPTION
A one-page operator guide at `docs/deploy-oracle-free.md` for spinning up a free test instance of shepard on Oracle Cloud Infrastructure's Always-Free Ampere ARM allocation (4 OCPU + 24 GB RAM).

## What it covers

- **Signup quirks** — credit card required, ARM capacity churn, home-region permanence.
- **VM provisioning** — `VM.Standard.A1.Flex`, full 4 OCPU + 24 GB on a single host, ingress allowlist.
- **System prep** — Docker install, 8 GB swap, UFW + firewalld interaction.
- **The ARM-image caveat** — shepard's published `backend:5.2.0` and `frontend:5.2.0` are amd64-only. Two paths: rebuild for `linux/arm64` via `docker buildx` and host on GHCR (recommended), or run upstream amd64 tags under QEMU emulation (slower but zero-build).
- **TLS** — reuse of `infrastructure/proxy/Caddyfile` with a free DuckDNS subdomain and auto Let's Encrypt.
- **Backups** — nightly tarball of the data-volume mounts to OCI Object Storage Free Tier (10 GB).
- **Hardening checklist** — explicitly cites `aidocs/07` H8 (rotate the shipped `.env` defaults).
- **Honest fine print** — Always-Free idle-reclaim clause, "not for production data."

## Surface changes

- New: `docs/deploy-oracle-free.md` (Jekyll front matter, builds to `deploy-oracle-free.html`).
- `docs/admin.md`: short "Free test deploy" subsection at the top of the stack guide pointing at the new page.
- `README.md`: inline link in the Pages-site tour line.

## Test plan

- [ ] Pages workflow rebuilds; new page lands at https://noheton.github.io/shepard/deploy-oracle-free with site chrome.
- [ ] Linked from `/admin` and the README — both routes lead users to the new guide.
- [ ] (out-of-band) Spot-check the actual OCI instructions on a test signup if anyone gets to it before the next dispatch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_