### PR TITLE
docs: deploy index + self-hosted-Zoraxy guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A GitHub Pages site is published from `docs/` on this mirror:
 
 **<https://noheton.github.io/shepard/>**
 
-Tour: overview & use cases (`/`) · architecture (`/architecture`) · Python quickstart (`/getting-started`) · user guide (`/user-guide`) · admin guide (`/admin`) · system requirements (`/system-requirements`) · [free test deploy on Oracle Cloud](https://noheton.github.io/shepard/deploy-oracle-free) (`/deploy-oracle-free`).
+Tour: overview & use cases (`/`) · architecture (`/architecture`) · Python quickstart (`/getting-started`) · user guide (`/user-guide`) · admin guide (`/admin`) · system requirements (`/system-requirements`) · [deploy options](https://noheton.github.io/shepard/deploy) (Oracle Free, self-hosted behind Zoraxy, paid VPS, managed-services split).
 
 Source under `docs/`; built and deployed by `.github/workflows/pages.yml` on push to `main`. The canonical authoritative documentation is the GitLab wiki linked further down in this README; the GitHub Pages site is a structured overview for the GitHub mirror.
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -8,13 +8,18 @@ This page describes how to run shepard. It cites only what is actually in the
 repository today; the dedicated admin CLI is **in design** and not yet
 shipped — see "Admin CLI" below.
 
-## Free test deploy
+## Deploy paths beyond docker-compose
 
-Want to spin up a personal test instance without paying for hosting?
-See [Deploy on Oracle Cloud Free Tier](deploy-oracle-free) — a one-page
-operator guide covering OCI signup quirks, the ARM-image caveat for
-shepard's backend/frontend, TLS via Caddy + Let's Encrypt, and nightly
-Object Storage backups within the always-free 10 GB allowance.
+For paths that go beyond running the bundled compose locally — free
+cloud, self-hosted on a Docker host fronted by a reverse proxy, paid
+VPS, managed-services split — see **[Deploy options](deploy/)**. The
+two deep guides are:
+
+- **[Oracle Cloud Free Tier (Ampere ARM)](deploy-oracle-free)** —
+  always-free 4 OCPU / 24 GB cloud VM, public IPv4 included.
+- **[Self-hosted Docker host behind Zoraxy](deploy-self-hosted-zoraxy)** —
+  your own hardware (mini PC, NUC, lab box) with Zoraxy as the reverse
+  proxy, optionally paired with Cloudflare Tunnel for CG-NAT.
 
 ## Stack — docker-compose
 

--- a/docs/deploy-self-hosted-zoraxy.md
+++ b/docs/deploy-self-hosted-zoraxy.md
@@ -1,0 +1,315 @@
+---
+layout: default
+title: Self-hosted shepard behind Zoraxy
+description: Operator guide for running shepard's Docker stack on a self-hosted machine, fronted by Zoraxy as the reverse proxy with automatic Let's Encrypt and optional Cloudflare Tunnel.
+---
+
+# Self-hosted shepard behind Zoraxy
+
+This guide covers running shepard's full stack on **a Docker host you
+own** — a mini PC, NUC, lab server, or any always-on machine with
+≥ 8 GB RAM — and fronting it with [**Zoraxy**](https://github.com/tobychui/zoraxy)
+instead of the bundled Caddy. Zoraxy gives you a web UI for managing
+proxy rules, automatic Let's Encrypt, geo-IP filtering, TOTP-protected
+admin access, and a statistics dashboard — all from a single Go
+binary or one Docker container.
+
+> Companion to [Deploy options](deploy/) — see that page for the
+> comparison matrix and other hosting paths.
+
+## 1. What you need
+
+- **A Docker host.** Linux, ≥ 8 GB RAM, ≥ 30 GB free disk. Tested on
+  Ubuntu 22.04 / 24.04 LTS. Mini-PC class hardware (Beelink, Minisforum,
+  Topton) works fine; older laptops with the lid-close-suspend disabled
+  are surprisingly viable.
+- **A domain name.** Any registrar. You'll point a wildcard (or two
+  A records) at the Docker host's reachable IP.
+- **Reachability for ports 80 and 443**, *or* a Cloudflare account
+  for Tunnel (covered in §6).
+- **Docker + Docker Compose plugin.** `curl -fsSL https://get.docker.com | sh`.
+
+## 2. Architecture
+
+```
+                           ┌─────────────────────────────┐
+   Internet ──── 80/443 ───▶│ Zoraxy (zoraxydocker:latest)│
+                            │  - HTTP/HTTPS listener      │
+                            │  - ACME / Let's Encrypt     │
+                            │  - Web UI on :8000 (LAN)    │
+                            └────────────┬────────────────┘
+                                         │ docker network: edge
+                                         ▼
+                  ┌──────────────────────────────────────────┐
+                  │ shepard compose stack                    │
+                  │  frontend (nuxt)  ─┐                     │
+                  │  backend (quarkus) ┤                     │
+                  │  neo4j ─┐          ├─ docker network:    │
+                  │  mongo  ┤           shepard (internal)   │
+                  │  timescaledb ┤                           │
+                  │  postgis (opt) ┘                         │
+                  └──────────────────────────────────────────┘
+```
+
+Zoraxy and the shepard stack run on the **same host** (typical) or on
+**separate hosts** (Zoraxy on edge, shepard on a backend host). Same
+host is simpler; the two-host split lets you put the data tier on
+beefier hardware.
+
+## 3. Drop the bundled Caddy
+
+shepard's `infrastructure/docker-compose.yml` ships a Caddy proxy on
+ports 80/443. Zoraxy will take those ports, so disable Caddy.
+
+```bash
+git clone https://github.com/noheton/shepard.git /opt/shepard
+cd /opt/shepard/infrastructure
+cp .env.example .env
+# Rotate every credential in .env — see aidocs/07 H8.
+$EDITOR .env
+```
+
+Create `docker-compose.override.yml` next to the upstream compose file
+so you don't have to edit it directly:
+
+```yaml
+# /opt/shepard/infrastructure/docker-compose.override.yml
+services:
+  caddy:
+    profiles:
+      - disabled
+
+  backend:
+    networks:
+      - shepard
+      - edge      # joinable from Zoraxy
+
+  frontend:
+    networks:
+      - frontend
+      - edge
+
+networks:
+  edge:
+    external: true
+    name: edge
+```
+
+The `profiles: [disabled]` trick excludes Caddy from the default
+`docker compose up` (compose only starts services with no profile, or
+with a profile passed via `--profile`).
+
+## 4. Bring up the `edge` network and shepard
+
+```bash
+docker network create edge
+
+cd /opt/shepard/infrastructure
+docker compose up -d
+
+docker compose ps
+# backend, frontend, neo4j, mongodb, timescaledb listed Up.
+# caddy NOT in the list (excluded by profile).
+```
+
+The shepard frontend is reachable at `frontend:80` from any container
+on the `edge` network; the backend at `backend:8080`.
+
+## 5. Run Zoraxy
+
+`/opt/zoraxy/docker-compose.yml`:
+
+```yaml
+services:
+  zoraxy:
+    image: zoraxydocker/zoraxy:latest
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8000:8000"           # management UI; firewall this off WAN
+    volumes:
+      - ./config:/opt/zoraxy/config
+      - ./plugin:/opt/zoraxy/plugin
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      TZ: Europe/Berlin
+      FASTGEOIP: "true"
+    networks:
+      - edge
+
+networks:
+  edge:
+    external: true
+```
+
+```bash
+sudo mkdir -p /opt/zoraxy/{config,plugin}
+cd /opt/zoraxy
+docker compose up -d
+```
+
+First-run setup of the Zoraxy admin account happens via the UI at
+`http://<host>:8000`. Do this from the LAN, set a strong password, and
+**enable TOTP** before exposing the host to the internet. Then either
+stop publishing port 8000 (`docker compose down && remove the line`) or
+restrict it with the host firewall (`ufw allow from <your-lan-cidr> to
+any port 8000`).
+
+## 6. Public reachability
+
+Two paths depending on whether your host has a public IP:
+
+### 6a. Direct (you have a public IPv4 / IPv6 + DNS control)
+
+Open ports **80** and **443** on your router / firewall and forward
+both to the Docker host. Add A records:
+
+```
+shepard.example.com.       A  <your-public-ip>
+api.shepard.example.com.   A  <your-public-ip>
+```
+
+Skip to §7.
+
+### 6b. Cloudflare Tunnel (CG-NAT, no static IP, or you don't want
+to open ports)
+
+Add a `cloudflared` sidecar to the Zoraxy compose file:
+
+```yaml
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN}
+    networks:
+      - edge
+```
+
+Provision the tunnel and grab `CF_TUNNEL_TOKEN` from the Cloudflare
+Zero Trust dashboard (Networks → Tunnels → Create). Configure the
+tunnel's Public Hostname routes to point at **`http://zoraxy:80`** for
+each subdomain you need; Cloudflare handles the public TLS, Zoraxy
+handles the routing inside.
+
+This is the recommended path for residential / lab installations —
+no port forwards, no DDNS, and Cloudflare's edge takes the brunt of
+unsolicited traffic.
+
+## 7. Configure Zoraxy proxy rules
+
+In the Zoraxy UI:
+
+1. **HTTP Proxy → New Proxy Rule**
+   - Matching keyword: `shepard.example.com`
+   - Backend: `frontend:80` (Zoraxy is on the same docker network, so
+     container DNS resolves)
+   - Enable HTTPS, "Use TLS for backend": off
+   - Save.
+
+2. Repeat for `api.shepard.example.com` → `backend:8080`.
+
+3. **TLS / SSL → ACME** (left sidebar)
+   - Provider: Let's Encrypt
+   - Email: yours
+   - Challenge: HTTP-01 (works for direct deploys; Cloudflare Tunnel
+     deployments should use **DNS-01** with Cloudflare API token
+     instead)
+   - Generate certificates for both hostnames.
+   - Renewal is automatic; the `AUTORENEW` env var defaults to
+     86400 s (daily check) and `EARLYRENEW` to 30 days.
+
+4. **Apply** — Zoraxy reloads listeners. Hit
+   `https://shepard.example.com` from any browser; the Nuxt frontend
+   loads with a green-padlock cert.
+
+## 8. Update the backend's published URL
+
+The frontend container reads the backend URL from the env it was
+started with (`VUE_APP_BACKEND` for the legacy frontend, the
+new-frontend equivalent in `application.properties`). Update `.env`:
+
+```
+BACKEND_URL=https://api.shepard.example.com/
+```
+
+then `docker compose up -d backend frontend` to recreate with the new
+env. CORS in the backend (`quarkus.http.cors.origins=*`) is permissive
+out of the box; **tighten it** to the frontend hostname before going
+public — this is `aidocs/07` C2.
+
+## 9. Backups
+
+Same recipe as the Oracle guide, minus the OCI Object Storage step:
+
+```bash
+cat > /usr/local/bin/shepard-backup.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+cd /opt/shepard/infrastructure
+docker compose stop neo4j mongodb timescaledb postgis
+tar czf /backup/shepard-$(date -u +%FT%H%MZ).tgz \
+    /var/lib/docker/volumes/shepard_*_data \
+    /opt/shepard/backend/{logs,config}
+docker compose start neo4j mongodb timescaledb postgis
+# Optional: rsync to a Hetzner Storage Box, BorgBase, or rclone target.
+find /backup -name 'shepard-*.tgz' -mtime +14 -delete
+EOF
+chmod +x /usr/local/bin/shepard-backup.sh
+echo '30 2 * * * root /usr/local/bin/shepard-backup.sh' | sudo tee /etc/cron.d/shepard-backup
+```
+
+If your edge box has limited disk, point `/backup` at a USB drive or
+NAS mount. **Test restore at least once** — an untested backup is a
+hope, not a backup.
+
+## 10. Hardening checklist (Zoraxy specifics)
+
+- [ ] **TOTP on the Zoraxy admin account.** UI: System Settings →
+      Auth → enable 2FA.
+- [ ] **Firewall :8000** to LAN only (or unpublish entirely; access
+      the UI via `ssh -L 8000:localhost:8000 host` instead).
+- [ ] **Geo-IP block lists** for the proxy rules — Zoraxy's GeoIP
+      filter blocks at the proxy layer, ahead of the application.
+- [ ] **Access lists** for sensitive paths (e.g.
+      `/shepard/api/admin/*` if/when admin endpoints exist —
+      `aidocs/22-admin-cli-draft.md` for the planned shape).
+- [ ] **Statistics retention** — Zoraxy logs every request by default;
+      tune retention so the volume doesn't blow up disk.
+- [ ] **shepard `.env`** rotated, not the shipped placeholders
+      (aidocs/07 H8). Worth saying twice.
+- [ ] **Docker socket exposure.** The compose snippet mounts
+      `/var/run/docker.sock:ro` so Zoraxy can resolve container names.
+      `:ro` is mandatory; without it a Zoraxy compromise becomes a
+      host compromise.
+
+## 11. Troubleshooting
+
+- **"Bad Gateway" from Zoraxy** — the backend / frontend containers
+  aren't on the `edge` network. `docker network inspect edge` should
+  list them. Recreate with `docker compose up -d --force-recreate`
+  after fixing the override file.
+- **Let's Encrypt rate limit** — five failed attempts in an hour
+  trips the rate limit for that hostname. Use Let's Encrypt's
+  **staging** ACME directory while you debug:
+  `https://acme-staging-v02.api.letsencrypt.org/directory`.
+- **Port 80 on host is taken** — `sudo ss -ltnp | grep ':80 '` will
+  show the offender. Common culprits: another reverse proxy (nginx,
+  Caddy outside compose), or the host's mDNS responder.
+- **HTTP-01 challenge fails behind Cloudflare Tunnel** — switch to
+  DNS-01 with a Cloudflare API token; HTTP-01 won't work because
+  Cloudflare terminates TLS on its edge.
+
+## 12. What this isn't
+
+- **Not a multi-tenant deployment.** Zoraxy can host multiple sites
+  on one box but isn't built for ten-thousand-tenant scale; for that
+  use Traefik or HAProxy.
+- **Not a substitute for an HA setup.** Single-host, single-Zoraxy
+  means a host outage takes everything down.
+- **Not a fit for compliance-heavy data.** A self-hosted lab box
+  rarely satisfies the auditing, access-logging, and physical-security
+  controls real research data demands. shepard is a research-data
+  platform; treat your test instance accordingly.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,120 @@
+---
+layout: default
+title: Deploy options
+description: Hosting paths for shepard — free / low-cost / self-hosted — with a comparison matrix and pointers to the deep guides.
+---
+
+# Deploy options
+
+shepard's full stack (Quarkus + Neo4j 5 + Mongo 8 + TimescaleDB +
+optional PostGIS + Nuxt 3) needs roughly **8 GB RAM and 20 GB disk**
+to run comfortably. That requirement narrows the hosting field; this
+page surveys what's realistic, with deep guides for the two paths most
+shepard users actually take.
+
+## Comparison matrix
+
+| Path | Hardware budget | RAM | Cost | TLS | NAT-friendly | Best for |
+|---|---|---|---|---|---|---|
+| **[Oracle Cloud Free Tier (Ampere ARM)](deploy-oracle-free)** | Cloud, public IPv4 | 24 GB | €0 | Caddy + Let's Encrypt (HTTP-01) | n/a (public IP) | Demos, reviewer access, CI test instances |
+| **[Self-hosted Docker host behind Zoraxy](deploy-self-hosted-zoraxy)** | Mini PC, NUC, lab server | 8–32 GB | €0 + power | Zoraxy + Let's Encrypt (HTTP-01 / DNS-01) | yes — Cloudflare Tunnel pairs cleanly | Lab teams, on-prem demos, anyone with hardware to spare |
+| Hetzner Cloud CX22 / CCX13 | Cloud VPS | 4–16 GB | €4–€15 / month | Caddy / Zoraxy / Traefik | n/a | Production-shape on a budget |
+| Managed-services split | n/a | per-service | €0 (free tiers) | per-service | n/a | Backend-only proof-of-concept |
+| Fly.io free allowance | Cloud edge | 256 MB × 3 | €0 | Fly TLS | n/a | Toy stack only — won't fit shepard's data tier |
+| GitHub Codespaces / Gitpod | Ephemeral cloud dev | 8–16 GB | 60 hr/month free | Codespace HTTPS | n/a | Throwaway evaluations, code review on a live stack |
+
+The two **deep guides** below cover the paths that fit shepard's
+multi-DB stack without surgery.
+
+## Path 1 — Oracle Cloud Free Tier
+
+Best when you want **a public, always-on test instance** and don't have
+hardware. The Ampere Free Tier gives 4 OCPU + 24 GB RAM at €0; the
+caveat is that shepard's published `backend` and `frontend` images are
+amd64-only at the time of writing and either need rebuilding for
+`linux/arm64` or running under QEMU emulation.
+
+→ **[deploy-oracle-free](deploy-oracle-free)**
+
+## Path 2 — Self-hosted Docker host behind Zoraxy
+
+Best when you have **a mini PC, NUC, or always-on lab box** and want
+control over the data without paying for cloud. Pairs nicely with
+Cloudflare Tunnel if you don't have a public IP. Uses
+[Zoraxy](https://github.com/tobychui/zoraxy) — a Go-based reverse
+proxy with a web UI, automatic Let's Encrypt, geo-IP / TOTP / access
+lists, and statistics — instead of the bundled Caddy.
+
+→ **[deploy-self-hosted-zoraxy](deploy-self-hosted-zoraxy)**
+
+## Other paths in brief
+
+### Hetzner Cloud (cheapest paid)
+
+A Hetzner **CX22** (2 vCPU, 4 GB, ~€4/month) is too small for shepard
+in default shape; a **CX32** (4 vCPU, 8 GB, ~€7/month) is the workable
+floor; **CCX13** (4 dedicated vCPU, 16 GB, ~€15/month) is the
+production-shape reference the upstream team uses for staging. Same
+docker-compose as everywhere else; reuse the bundled Caddy or swap in
+Zoraxy per the self-hosted guide. No surprises.
+
+### Managed-services split
+
+For a **backend-only** proof-of-concept where you skip the frontend
+and exercise shepard's REST API:
+
+- **Neo4j AuraDB Free** — 50K nodes / 175K relationships limit. Plenty
+  for the Showcase Seed.
+- **MongoDB Atlas M0** — 512 MB, free forever. Good for files and
+  structured-data payloads at small scale.
+- **Render Free Postgres** — 1 GB, but **TimescaleDB extension is not
+  available** on Render's managed Postgres; you'd have to drop
+  timeseries from the demo or run TimescaleDB elsewhere.
+
+The connection strings drop into the backend container's env
+directly — `NEO4J_HOST`, `QUARKUS_MONGODB_CONNECTION_STRING`,
+`QUARKUS_DATASOURCE_JDBC_URL`. The backend itself can run on Fly.io's
+free shared-CPU VM (256 MB is too tight for the JVM; bump to a paid
+shared-cpu-1x at ~$2/month).
+
+This path's main draw is **no infra to manage**; its cost is
+**provider sprawl** (three accounts, three dashboards, three billing
+relationships). Not recommended unless you have a specific reason to
+avoid running databases yourself.
+
+### GitHub Codespaces / Gitpod
+
+For **interactive evaluation only**. A 4-core Codespace with the
+docker-in-docker feature can run shepard's compose end-to-end via
+`docker compose up`; access is via Codespaces' auto-issued public
+HTTPS URL on the forwarded port. The instance shuts down on idle and
+data does not survive the codespace's lifecycle — fine for a
+30-minute demo, not for anything you'd revisit.
+
+### Fly.io
+
+The free allowance (3 × 256 MB shared-cpu-1x) is too small for any
+single service in shepard's stack — Neo4j alone wants ≥ 1.5 GB, Mongo
+wants ≥ 512 MB, the Quarkus JVM with `-Xmx2G`. Skipping unless you
+upgrade to a paid plan, at which point Hetzner is cheaper and simpler.
+
+## Pre-deploy checklist (all paths)
+
+Independent of where you host:
+
+- [ ] **Rotate `.env` defaults.** `aidocs/07` H8 explicitly flags the
+      shipped `POSTGRES_*`, `NEO4J_PW`, `MONGO_PASSWORD`, etc. as
+      already-public placeholders.
+- [ ] **Restrict CORS.** `quarkus.http.cors.origins=*` in the bundled
+      `application.properties` is permissive; tighten before any
+      internet-exposed deployment (`aidocs/07` C2).
+- [ ] **Decide on auth.** All paths assume an OIDC provider. The
+      simplest path is to add a Keycloak service to the same compose;
+      a managed OIDC is less ops but shifts trust to a third party.
+- [ ] **Decide on backups.** Each guide gives a recipe; pick one
+      *before* you load real data, not after.
+
+For the production-shape deploy on bare metal or a paid VPS, the
+authoritative guide remains the GitLab wiki at
+`gitlab.com/dlr-shepard/shepard`. The pages here are scoped to the
+free/low-cost paths the GitHub mirror users typically take.


### PR DESCRIPTION
Follows up on PR #1004 (Oracle Free guide) — turns deploy docs into a small index + a second deep-guide for the self-hosted path the user asked about.

## Summary

- **`docs/deploy.md`** (new) — comparison matrix across Oracle Free, self-hosted-behind-Zoraxy, Hetzner Cloud, managed-services split, GitHub Codespaces / Gitpod, and Fly.io. Two deep guides linked; everything else gets a paragraph with the tradeoff that makes it less suitable.
- **`docs/deploy-self-hosted-zoraxy.md`** (new) — operator guide for running shepard's compose stack on a self-owned Docker host (mini PC / NUC / lab box), with [Zoraxy](https://github.com/tobychui/zoraxy) replacing the bundled Caddy. Covers:
  - Architecture diagram + edge/shepard network split
  - Disabling the bundled Caddy via `docker-compose.override.yml` (no upstream-file edit)
  - Zoraxy compose snippet pinned to `zoraxydocker/zoraxy:latest` with `:ro` docker.sock, `/opt/zoraxy/config` volume, ports 80/443/8000
  - Cloudflare Tunnel sidecar for CG-NAT / no-static-IP installs (HTTP-01 → DNS-01 swap noted)
  - Let's Encrypt via Zoraxy UI; rate-limit + staging-directory tip
  - Backup recipe (data-volume tarballs, optional rsync to Storage Box / BorgBase / rclone)
  - Hardening checklist: TOTP on Zoraxy admin, GeoIP filter, statistics retention, the `aidocs/07` H8 `.env`-rotation reminder
  - Troubleshooting (Bad Gateway, port 80 contention, ACME under Tunnel)
- **`docs/admin.md`** — single Oracle-only link replaced with a "Deploy paths beyond docker-compose" subsection pointing at the index + both guides.
- **`README.md`** — tour line in the Documentation site section now links to `/deploy` instead of the Oracle page directly.

## Test plan

- [ ] Pages workflow rebuilds; `/deploy`, `/deploy-self-hosted-zoraxy`, `/deploy-oracle-free` all render with site chrome.
- [ ] Internal links between admin → deploy index → deep guides resolve.
- [ ] (out of band) Spot-check the Zoraxy compose snippet on a real host.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_