### PR TITLE
T1-tags: GET /v2/templates/tags (distinct tag autocomplete)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/template/daos/ShepardTemplateDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/template/daos/ShepardTemplateDAO.java
@@ -135,6 +135,30 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
   }
 
   /**
+   * Distinct list of tags across all non-retired templates, sorted
+   * ascending. Used by the picker UI's tag-autocomplete dropdown.
+   * Optionally narrows to one {@code templateKind}.
+   */
+  public List<String> listDistinctTags(String templateKind) {
+    StringBuilder cypher = new StringBuilder(
+      "MATCH (t:ShepardTemplate) WHERE (t.retired IS NULL OR t.retired = false)"
+    );
+    Map<String, Object> params = new HashMap<>();
+    if (templateKind != null) {
+      cypher.append(" AND t.templateKind = $kind");
+      params.put("kind", templateKind);
+    }
+    cypher.append(" UNWIND coalesce(t.tags, []) AS tag RETURN DISTINCT tag ORDER BY tag");
+    var result = session.query(cypher.toString(), params);
+    List<String> out = new ArrayList<>();
+    for (Map<String, Object> row : result.queryResults()) {
+      Object tag = row.get("tag");
+      if (tag != null) out.add(tag.toString());
+    }
+    return out;
+  }
+
+  /**
    * Record that a Collection was instantiated from a given template —
    * idempotent {@code :USES_TEMPLATE} edge.
    */

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
@@ -188,4 +188,24 @@ public class ShepardTemplateRest {
     dao.createOrUpdate(t);
     return Response.noContent().build();
   }
+
+  @GET
+  @Path("/tags")
+  @Operation(
+    summary = "Distinct list of tags across all non-retired templates.",
+    description = "Used by the picker UI's tag-autocomplete. Optionally narrow to one templateKind."
+  )
+  @APIResponse(
+    responseCode = "200",
+    description = "Distinct tag list, sorted ascending.",
+    content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = String.class))
+  )
+  @APIResponse(responseCode = "401", description = "Authentication required.")
+  public Response tags(
+    @Parameter(description = "Filter to a single templateKind.") @QueryParam("kind") String kind,
+    @Context SecurityContext securityContext
+  ) {
+    if (securityContext.getUserPrincipal() == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    return Response.ok(dao.listDistinctTags(kind)).build();
+  }
 }

--- a/backend/src/test/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRestTest.java
@@ -195,4 +195,31 @@ class ShepardTemplateRestTest {
     assertEquals(404, r.getStatus());
     verify(dao, never()).createOrUpdate(any());
   }
+
+  @Test
+  void tagsReturns401WhenUnauthenticated() {
+    when(securityContext.getUserPrincipal()).thenReturn(null);
+    Response r = resource.tags(null, securityContext);
+    assertEquals(401, r.getStatus());
+    verify(dao, never()).listDistinctTags(any());
+  }
+
+  @Test
+  void tagsReturnsDistinctList() {
+    when(dao.listDistinctTags(null)).thenReturn(List.of("calibration", "hot-fire", "lumen"));
+    Response r = resource.tags(null, securityContext);
+    assertEquals(200, r.getStatus());
+    @SuppressWarnings("unchecked")
+    List<String> tags = (List<String>) r.getEntity();
+    assertEquals(3, tags.size());
+    assertEquals("calibration", tags.get(0));
+  }
+
+  @Test
+  void tagsHonoursKindFilter() {
+    when(dao.listDistinctTags("EXPERIMENT_RECIPE")).thenReturn(List.of("hot-fire"));
+    Response r = resource.tags("EXPERIMENT_RECIPE", securityContext);
+    assertEquals(200, r.getStatus());
+    verify(dao).listDistinctTags("EXPERIMENT_RECIPE");
+  }
 }


### PR DESCRIPTION
## Summary

Tiny picker-UX endpoint. `ShepardTemplateDAO.listDistinctTags(kind)` returns the sorted distinct tag list across non-retired templates, optionally narrowed by `templateKind`. `ShepardTemplateRest` exposes it at `GET /v2/templates/tags`.

3 new tests; 1360 → 1363 / 0 failures / coverage gate met.

https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_