### PR TITLE
U1-profile-ui: ORCID + displayName edit dialog in ProfilePane

### DIFF
--- a/aidocs/42-vision.md
+++ b/aidocs/42-vision.md
@@ -83,7 +83,8 @@ Plus payload kinds (the things References point at):
 - **HDF5 / HSDS reference** *(coming with A5; design done in
   `aidocs/35`)* → HDF5 datasets accessible via `h5pyd`-compatible
   REST.
-- **Git reference** *(coming with G1; design done in `aidocs/38`)* →
+- **Git reference** *(mode-a shipped: loose link to repo URL + ref + path;
+  UI in-flight; tracked + pinned-snapshot modes coming with G1b/G1c)* →
   pinned git commit + path, for analysis code provenance.
 
 ## The cross-cutting features
@@ -168,8 +169,10 @@ The four things on the near horizon, in priority order:
 3. **Templates + processes** (`aidocs/39` + `aidocs/40 §2`, T1 +
    PR1 series). Standardise how DataObjects get created; bring
    process design + runtime into shepard core.
-4. **User profile + ORCID** (`aidocs/36`, U1 series). Closes #29
-   and makes RO-Crate exports cite authors properly.
+4. **User profile + ORCID** (`aidocs/36`, U1 series). ~~Closes #29~~
+   **U1a shipped** — ORCID field live with ISO 7064 checksum; ProfilePane
+   edit dialog in-flight. RO-Crate exports now cite authors when the
+   field is set. `displayName` override (U1b) in review.
 
 Mid-horizon:
 

--- a/aidocs/44-fork-vs-upstream-feature-matrix.md
+++ b/aidocs/44-fork-vs-upstream-feature-matrix.md
@@ -143,7 +143,7 @@ backlog and `aidocs/00-index.md`. A row that's stale is the bug.
 | Capability | Upstream | This fork | Status | Refs |
 |---|---|---|---|---|
 | HDF5 / HSDS as a payload kind (`HdfContainer` / `HdfReference`); `h5pyd` parity | none | TBD; HSDS sidecar + shared-Keycloak token relay | 📐 (queued, A5) | `aidocs/35` |
-| Git integration (`GitReference`); 3 modes (loose / tracked / pinned-snapshot); commit-SHA in RO-Crate | none | TBD | 📐 (queued, G1) | `aidocs/38` |
+| Git integration (`GitReference`); mode-a (loose link: repoUrl + ref + path); modes b/c scaffolded; CRUD via `/v2/data-objects/{appId}/git-references`; UI renders as clickable link | none | Backend ✓; UI 🚧 | **✓ ↑ (backend, G1a #1063)** / **🚧 UI** | `aidocs/38` |
 | Templates feature (Templates Collection of DataObject blueprints; per-Collection allow-list) | none | TBD; replaces / supersedes upstream-aspirational L3 | 📐 (queued, T1) | `aidocs/39` |
 | Process design + runtime in shepard core (`ProcessDefinition` + browser-hosted stepper) | SPW desktop only | TBD | 📐 (queued, PR1) | `aidocs/40 §2` |
 | Snapshots (point-in-time, immutable, reproducible reads) | `Version` is a marker only | TBD; logical snapshots backed by entity revisions | 📐 (queued, V2) | `aidocs/41` |
@@ -152,8 +152,8 @@ backlog and `aidocs/00-index.md`. A row that's stale is the bug.
 
 | Capability | Upstream | This fork | Status | Refs |
 |---|---|---|---|---|
-| ORCID iD on user profile (#29) | none | TBD; mod 11-2 checksum, no network | 📐 (queued, U1a) | `aidocs/36` |
-| `displayName` override + audit-trail render switch (#694) | username only | TBD | 📐 (queued, U1b) | `aidocs/36` |
+| ORCID iD on user profile (#29) | none | `PATCH /v2/users/me` (orcid); ISO 7064 mod 11-2 checked; UI edit dialog in ProfilePane | **✓ ↑** | U1a (#1062) + U1-profile-ui |
+| `displayName` override + `effectiveDisplayName` derivation + audit-trail render switch (#694) | username only | `displayName` field + `DisplayNameResolver` fallback chain; backend 🚧 PR open | **🚧 (U1b #1064)** | `aidocs/36` |
 | `/me` route (split from Configuration) | mixed Configuration page | TBD | 📐 (queued, U1c) | `aidocs/36 §5` |
 | Preferences (`theme`, `language`, `timeZone`, `dateFormat`, `defaultPageSize`, `defaultLandingPage`) via `SettingDescriptor` enum + typed map | none | TBD | 📐 (queued, U1d) | `aidocs/36 §3.2 / §7` |
 | Avatar (shepard-uploaded → IdP `picture` → Gravatar tier) | none | TBD | 📐 (queued, U1e) | `aidocs/36 §3.1` |

--- a/backend-client/src/apis/MeApi.ts
+++ b/backend-client/src/apis/MeApi.ts
@@ -1,0 +1,68 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * PATCH /v2/users/me — RFC 7396 JSON Merge Patch for the caller's User record.
+ * Manually maintained: not generated from OpenAPI spec (v2 endpoints not yet in
+ * the upstream openapi.json; will be replaced by generated code on next full
+ * client-codegen run).
+ */
+
+import * as runtime from '../runtime';
+import type { User } from '../models/index';
+import { UserFromJSON } from '../models/index';
+
+export interface PatchMeRequest {
+  /** RFC 7396 merge-patch object. Absent fields are preserved. */
+  body: {
+    orcid?: string | null;
+    displayName?: string | null;
+  };
+}
+
+export class MeApi extends runtime.BaseAPI {
+  /**
+   * Partial-update the caller's User record.
+   * v1 (U1a/U1b) patches `orcid` and `displayName`.
+   * Empty-string clears the field; null clears; absent preserves.
+   */
+  async patchMeRaw(
+    requestParameters: PatchMeRequest,
+    initOverrides?: RequestInit | runtime.InitOverrideFunction,
+  ): Promise<runtime.ApiResponse<User>> {
+    const headerParameters: runtime.HTTPHeaders = {
+      'Content-Type': 'application/merge-patch+json',
+    };
+
+    if (this.configuration?.apiKey) {
+      headerParameters['X-API-KEY'] = await this.configuration.apiKey('X-API-KEY');
+    }
+
+    if (this.configuration?.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request(
+      {
+        path: `/v2/users/me`,
+        method: 'PATCH',
+        headers: headerParameters,
+        body: JSON.stringify(requestParameters.body),
+      },
+      initOverrides,
+    );
+
+    return new runtime.JSONApiResponse(response, jsonValue => UserFromJSON(jsonValue));
+  }
+
+  async patchMe(
+    requestParameters: PatchMeRequest,
+    initOverrides?: RequestInit | runtime.InitOverrideFunction,
+  ): Promise<User> {
+    const response = await this.patchMeRaw(requestParameters, initOverrides);
+    return await response.value();
+  }
+}

--- a/backend-client/src/apis/index.ts
+++ b/backend-client/src/apis/index.ts
@@ -22,6 +22,7 @@ export * from './TimeseriesContainerApi';
 export * from './TimeseriesMigrationApi';
 export * from './TimeseriesReferenceApi';
 export * from './UriReferenceApi';
+export * from './MeApi';
 export * from './UserApi';
 export * from './UserGroupApi';
 export * from './VersionzApi';

--- a/backend-client/src/models/User.ts
+++ b/backend-client/src/models/User.ts
@@ -50,11 +50,29 @@ export interface User {
      */
     readonly subscriptionIds: Array<number>;
     /**
-     * 
+     *
      * @type {Array<string>}
      * @memberof User
      */
     readonly apiKeyIds: Array<string>;
+    /**
+     * ORCID identifier (16-digit ISO 7064 checked). Null until set via PATCH /v2/users/me.
+     * @type {string}
+     * @memberof User
+     */
+    orcid?: string | null;
+    /**
+     * Optional display-name override set via PATCH /v2/users/me.
+     * @type {string}
+     * @memberof User
+     */
+    displayName?: string | null;
+    /**
+     * Computed display name: displayName override → firstName+lastName → redacted username.
+     * @type {string}
+     * @memberof User
+     */
+    readonly effectiveDisplayName?: string;
 }
 
 /**
@@ -83,6 +101,9 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'email': json['email'] == null ? undefined : json['email'],
         'subscriptionIds': json['subscriptionIds'],
         'apiKeyIds': json['apiKeyIds'],
+        'orcid': json['orcid'] == null ? undefined : json['orcid'],
+        'displayName': json['displayName'] == null ? undefined : json['displayName'],
+        'effectiveDisplayName': json['effectiveDisplayName'] == null ? undefined : json['effectiveDisplayName'],
     };
 }
 

--- a/frontend/components/context/user/ProfilePane.vue
+++ b/frontend/components/context/user/ProfilePane.vue
@@ -1,12 +1,49 @@
 <script setup lang="ts">
 import { useFetchUserProfile } from "~/composables/context/useFetchUserProfile";
+import { usePatchMe } from "~/composables/context/usePatchMe";
 
 const { user, isLoading } = useFetchUserProfile();
+const { patchMe, isSaving } = usePatchMe();
+
+const editDialog = ref(false);
+const editOrcid = ref<string>("");
+const editDisplayName = ref<string>("");
+
+function openEdit() {
+  editOrcid.value = user.value?.orcid ?? "";
+  editDisplayName.value = user.value?.displayName ?? "";
+  editDialog.value = true;
+}
+
+async function saveEdit() {
+  const updated = await patchMe({
+    orcid: editOrcid.value.trim() === "" ? null : editOrcid.value.trim(),
+    displayName:
+      editDisplayName.value.trim() === ""
+        ? null
+        : editDisplayName.value.trim(),
+  });
+  if (updated) {
+    user.value = updated;
+    editDialog.value = false;
+  }
+}
 </script>
 
 <template>
   <div class="d-flex flex-column ga-4">
-    <h4 class="text-h4">Profile</h4>
+    <div class="d-flex align-center justify-space-between">
+      <h4 class="text-h4">Profile</h4>
+      <v-btn
+        v-if="user && !isLoading"
+        variant="tonal"
+        size="small"
+        prepend-icon="mdi-pencil"
+        @click="openEdit"
+      >
+        Edit
+      </v-btn>
+    </div>
 
     <centered-loading-spinner v-if="isLoading" />
     <v-table v-if="user && !isLoading" class="table">
@@ -14,6 +51,10 @@ const { user, isLoading } = useFetchUserProfile();
         <tr>
           <th>Username</th>
           <td>{{ user.username }}</td>
+        </tr>
+        <tr v-if="user.effectiveDisplayName">
+          <th>Display Name</th>
+          <td>{{ user.effectiveDisplayName }}</td>
         </tr>
         <tr>
           <th>First Name</th>
@@ -27,8 +68,59 @@ const { user, isLoading } = useFetchUserProfile();
           <th>E-Mail</th>
           <td>{{ user.email }}</td>
         </tr>
+        <tr>
+          <th>ORCID</th>
+          <td>
+            <a
+              v-if="user.orcid"
+              :href="`https://orcid.org/${user.orcid}`"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ user.orcid }}
+            </a>
+            <span v-else class="text-disabled">Not set</span>
+          </td>
+        </tr>
       </tbody>
     </v-table>
+
+    <!-- Edit dialog -->
+    <v-dialog v-model="editDialog" max-width="480">
+      <v-card>
+        <v-card-title>Edit Profile</v-card-title>
+        <v-card-text>
+          <v-text-field
+            v-model="editDisplayName"
+            label="Display Name"
+            hint="Overrides first/last name in the UI. Leave blank to use your name."
+            persistent-hint
+            class="mb-4"
+          />
+          <v-text-field
+            v-model="editOrcid"
+            label="ORCID"
+            placeholder="0000-0002-1825-0097"
+            hint="16-digit identifier from orcid.org. Leave blank to clear."
+            persistent-hint
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" :disabled="isSaving" @click="editDialog = false">
+            Cancel
+          </v-btn>
+          <v-btn
+            variant="tonal"
+            color="primary"
+            :loading="isSaving"
+            @click="saveEdit"
+          >
+            Save
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 

--- a/frontend/composables/common/api/useV2ShepardApi.ts
+++ b/frontend/composables/common/api/useV2ShepardApi.ts
@@ -1,0 +1,37 @@
+import type { BaseAPI } from "@dlr-shepard/backend-client";
+import { Configuration } from "@dlr-shepard/backend-client";
+import { ref, watch } from "vue";
+
+/**
+ * Like useShepardApi but routes to `/v2/...` endpoints which live at the
+ * server root, not under `/shepard/api`.
+ *
+ * Derives the v2 base URL by stripping the `/shepard/api` path suffix from
+ * `backendApiUrl`. e.g. `http://host/shepard/api` → `http://host`.
+ */
+export function useV2ShepardApi<A extends BaseAPI>(
+  apiClass: new (config: Configuration) => A,
+) {
+  const { data } = useAuth();
+
+  const configuration = computed(() => {
+    const legacyBase = useRuntimeConfig().public.backendApiUrl as string;
+    const v2Base = legacyBase.replace(/\/shepard\/api\/?$/, "");
+    return new Configuration({
+      basePath: v2Base,
+      accessToken: data.value?.accessToken,
+    });
+  });
+
+  const apiInstance = ref<A>(new apiClass(configuration.value));
+
+  watch(
+    configuration,
+    newConfig => {
+      apiInstance.value = new apiClass(newConfig);
+    },
+    { deep: true },
+  );
+
+  return apiInstance;
+}

--- a/frontend/composables/common/api/useV2ShepardApi.ts
+++ b/frontend/composables/common/api/useV2ShepardApi.ts
@@ -15,8 +15,12 @@ export function useV2ShepardApi<A extends BaseAPI>(
   const { data } = useAuth();
 
   const configuration = computed(() => {
-    const legacyBase = useRuntimeConfig().public.backendApiUrl as string;
-    const v2Base = legacyBase.replace(/\/shepard\/api\/?$/, "");
+    const config = useRuntimeConfig().public;
+    const explicit = config.backendV2ApiUrl as string | undefined;
+    const v2Base =
+      explicit && explicit.length > 0
+        ? explicit
+        : (config.backendApiUrl as string).replace(/\/shepard\/api\/?$/, "");
     return new Configuration({
       basePath: v2Base,
       accessToken: data.value?.accessToken,

--- a/frontend/composables/context/usePatchMe.ts
+++ b/frontend/composables/context/usePatchMe.ts
@@ -1,0 +1,29 @@
+import { MeApi, type User } from "@dlr-shepard/backend-client";
+import { useV2ShepardApi } from "../common/api/useV2ShepardApi";
+
+export interface PatchMePayload {
+  orcid?: string | null;
+  displayName?: string | null;
+}
+
+export function usePatchMe() {
+  const isSaving = ref<boolean>(false);
+  const saveError = ref<string | null>(null);
+
+  async function patchMe(payload: PatchMePayload): Promise<User | null> {
+    isSaving.value = true;
+    saveError.value = null;
+    try {
+      const result = await useV2ShepardApi(MeApi).value.patchMe({ body: payload });
+      return result;
+    } catch (error) {
+      handleError(error, "updating profile");
+      saveError.value = "Failed to save profile";
+      return null;
+    } finally {
+      isSaving.value = false;
+    }
+  }
+
+  return { patchMe, isSaving, saveError };
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -102,6 +102,10 @@ export default defineNuxtConfig({
     sessionRefreshInterval: getSessionRefreshInterval(),
     public: {
       backendApiUrl: "",
+      // Base URL for /v2/ endpoints (server root, no /shepard/api suffix).
+      // Example: "http://localhost:8080". If unset, derived from backendApiUrl
+      // by stripping the /shepard/api suffix.
+      backendV2ApiUrl: "",
     },
   },
 });


### PR DESCRIPTION
## Summary

- **ProfilePane.vue**: shows ORCID (linked to orcid.org), `effectiveDisplayName`, and an Edit button that opens a dialog to set/clear `orcid` and `displayName`.
- **backend-client/MeApi.ts**: hand-written `PATCH /v2/users/me` TypeScript client (RFC 7396 merge-patch; manually maintained until next full `client-codegen` run against a running backend).
- **backend-client/User.ts**: add `orcid`, `displayName`, `effectiveDisplayName` fields to the generated User model.
- **useV2ShepardApi**: new composable that derives the `/v2/` base URL by stripping the `/shepard/api` suffix from `backendApiUrl` — the existing `useShepardApi` can't be reused here since v2 endpoints live at the server root, not under `/shepard/api`.
- **usePatchMe**: composable wrapping `MeApi.patchMe` with `isSaving` / `saveError` state.

## Addresses

- User directive: "make sure all functionalities planned in shepard are accessible by API as well as UI" — this PR closes the UI gap for U1a (ORCID, already on main) and pre-wires `displayName` for when U1b (#1064) merges.

## Open question for reviewer

The v2 base URL is currently derived by stripping `/shepard/api` from `backendApiUrl`. If you'd prefer an explicit `BACKEND_V2_API_URL` env var instead, say so and I'll add it to `nuxt.config.ts`.

## Test plan

- [ ] Confirm ProfilePane shows ORCID row ("Not set" placeholder when unset)
- [ ] Edit dialog: set a valid ORCID → saved, link appears
- [ ] Edit dialog: empty ORCID field → clears stored value
- [ ] Edit dialog: invalid ORCID (e.g. wrong checksum) → backend returns 400 → error notification shown
- [ ] Edit dialog: set displayName → effectiveDisplayName row updates

https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_