### PR TITLE
G1-cred-ui: git credentials management page (/me)

### DIFF
--- a/backend-client/src/apis/GitCredentialsApi.ts
+++ b/backend-client/src/apis/GitCredentialsApi.ts
@@ -1,0 +1,130 @@
+import * as runtime from '../runtime';
+
+export interface GitCredentialIO {
+  appId: string;
+  host: string;
+  displayName: string | null;
+  username: string;
+}
+
+export interface CreateGitCredentialIO {
+  host: string;
+  displayName?: string | null;
+  username: string;
+  pat: string;
+}
+
+export interface PatchGitCredentialIO {
+  displayName?: string | null;
+  username?: string;
+  pat?: string | null;
+}
+
+export class GitCredentialsApi extends runtime.BaseAPI {
+  async listCredentials(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<GitCredentialIO[]> {
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request({
+      path: `/v2/me/git-credentials`,
+      method: 'GET',
+      headers: headerParameters,
+      query: {},
+    }, initOverrides);
+
+    return response.json() as Promise<GitCredentialIO[]>;
+  }
+
+  async createCredential(body: CreateGitCredentialIO, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<GitCredentialIO> {
+    const headerParameters: runtime.HTTPHeaders = {};
+    headerParameters['Content-Type'] = 'application/json';
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request({
+      path: `/v2/me/git-credentials`,
+      method: 'POST',
+      headers: headerParameters,
+      query: {},
+      body,
+    }, initOverrides);
+
+    return response.json() as Promise<GitCredentialIO>;
+  }
+
+  async getCredential(appId: string, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<GitCredentialIO> {
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request({
+      path: `/v2/me/git-credentials/${encodeURIComponent(appId)}`,
+      method: 'GET',
+      headers: headerParameters,
+      query: {},
+    }, initOverrides);
+
+    return response.json() as Promise<GitCredentialIO>;
+  }
+
+  async patchCredential(appId: string, body: PatchGitCredentialIO, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<GitCredentialIO> {
+    const headerParameters: runtime.HTTPHeaders = {};
+    headerParameters['Content-Type'] = 'application/json';
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request({
+      path: `/v2/me/git-credentials/${encodeURIComponent(appId)}`,
+      method: 'PATCH',
+      headers: headerParameters,
+      query: {},
+      body,
+    }, initOverrides);
+
+    return response.json() as Promise<GitCredentialIO>;
+  }
+
+  async deleteCredential(appId: string, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    await this.request({
+      path: `/v2/me/git-credentials/${encodeURIComponent(appId)}`,
+      method: 'DELETE',
+      headers: headerParameters,
+      query: {},
+    }, initOverrides);
+  }
+}

--- a/backend-client/src/apis/index.ts
+++ b/backend-client/src/apis/index.ts
@@ -2,6 +2,7 @@
 /* eslint-disable */
 export * from './AdminFeaturesApi';
 export * from './ApikeyApi';
+export * from './GitCredentialsApi';
 export * from './CollectionApi';
 export * from './CollectionReferenceApi';
 export * from './DataObjectApi';

--- a/frontend/components/context/user/GitCredentialsPane.vue
+++ b/frontend/components/context/user/GitCredentialsPane.vue
@@ -1,0 +1,360 @@
+<script setup lang="ts">
+import type {
+  CreateGitCredentialIO,
+  GitCredentialIO,
+  PatchGitCredentialIO,
+} from "@dlr-shepard/backend-client";
+import { useFetchGitCredentials } from "~/composables/context/useFetchGitCredentials";
+import { useManageGitCredentials } from "~/composables/context/useManageGitCredentials";
+
+const { credentials, isLoading, refresh } = useFetchGitCredentials();
+const { create, patch, remove, isSaving, saveError } = useManageGitCredentials();
+
+const showAddDialog = ref(false);
+const showEditDialog = ref(false);
+const showDeleteDialog = ref(false);
+const editingCredential = ref<GitCredentialIO | null>(null);
+const deletingAppId = ref<string | null>(null);
+
+const showAddPat = ref(false);
+const showEditPat = ref(false);
+
+const addForm = ref<CreateGitCredentialIO>({
+  host: "",
+  displayName: "",
+  username: "",
+  pat: "",
+});
+
+const editForm = ref<PatchGitCredentialIO>({
+  displayName: "",
+  username: "",
+  pat: "",
+});
+
+function openAddDialog() {
+  addForm.value = { host: "", displayName: "", username: "", pat: "" };
+  showAddPat.value = false;
+  showAddDialog.value = true;
+}
+
+function openEditDialog(credential: GitCredentialIO) {
+  editingCredential.value = credential;
+  editForm.value = {
+    displayName: credential.displayName ?? "",
+    username: credential.username,
+    pat: "",
+  };
+  showEditPat.value = false;
+  showEditDialog.value = true;
+}
+
+function openDeleteDialog(appId: string) {
+  deletingAppId.value = appId;
+  showDeleteDialog.value = true;
+}
+
+const addFormValid = computed(
+  () =>
+    addForm.value.host.trim().length > 0 &&
+    addForm.value.username.trim().length > 0 &&
+    addForm.value.pat.trim().length > 0,
+);
+
+async function submitAdd() {
+  const result = await create({
+    host: addForm.value.host.trim(),
+    displayName: addForm.value.displayName?.trim() || null,
+    username: addForm.value.username.trim(),
+    pat: addForm.value.pat,
+  });
+  if (result) {
+    showAddDialog.value = false;
+    await refresh();
+  }
+}
+
+async function submitEdit() {
+  if (!editingCredential.value) return;
+  const body: PatchGitCredentialIO = {
+    displayName: editForm.value.displayName?.trim() || null,
+    username: editForm.value.username?.trim() || undefined,
+  };
+  if (editForm.value.pat && editForm.value.pat.trim().length > 0) {
+    body.pat = editForm.value.pat.trim();
+  }
+  const result = await patch(editingCredential.value.appId, body);
+  if (result) {
+    showEditDialog.value = false;
+    await refresh();
+  }
+}
+
+async function confirmDelete() {
+  if (!deletingAppId.value) return;
+  const ok = await remove(deletingAppId.value);
+  if (ok) {
+    await refresh();
+  }
+}
+
+function truncateAppId(appId: string): string {
+  return appId.length > 12 ? appId.slice(0, 12) + "…" : appId;
+}
+</script>
+
+<template>
+  <div>
+    <div class="top-row">
+      <h4 class="text-h4">Git Credentials</h4>
+      <ExpansionPanelTitleButton
+        icon="mdi-plus-circle"
+        text="ADD"
+        @click="openAddDialog"
+      />
+    </div>
+
+    <CenteredLoadingSpinner v-if="isLoading" />
+    <div v-else>
+      <v-alert
+        v-if="saveError"
+        type="error"
+        class="mb-4"
+        closable
+        @click:close="saveError = null"
+      >
+        {{ saveError }}
+      </v-alert>
+      <div v-if="credentials.length === 0">No git credentials linked yet.</div>
+      <v-table v-else hover>
+        <thead>
+          <tr>
+            <th>Host</th>
+            <th>Display Name</th>
+            <th>Username</th>
+            <th>App ID</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="cred in credentials" :key="cred.appId">
+            <td>{{ cred.host }}</td>
+            <td>{{ cred.displayName ?? "—" }}</td>
+            <td>{{ cred.username }}</td>
+            <td class="app-id-column" :title="cred.appId">
+              {{ truncateAppId(cred.appId) }}
+            </td>
+            <td class="action-column">
+              <ActionButton
+                icon="mdi-pencil-outline"
+                @click="openEditDialog(cred)"
+              />
+              <ActionButton
+                icon="mdi-delete-outline"
+                color="error"
+                @click="openDeleteDialog(cred.appId)"
+              />
+            </td>
+          </tr>
+        </tbody>
+      </v-table>
+    </div>
+
+    <v-dialog
+      v-model="showAddDialog"
+      max-width="560"
+      persistent
+      @keydown.esc="showAddDialog = false"
+    >
+      <v-card color="canvas">
+        <template #title>
+          <div class="d-flex justify-space-between align-baseline">
+            <div class="text-h4">Add Git Credential</div>
+            <v-btn
+              variant="plain"
+              icon="mdi-close"
+              @click="showAddDialog = false"
+            />
+          </div>
+        </template>
+        <template #text>
+          <v-alert v-if="saveError" type="error" class="mb-4">
+            {{ saveError }}
+          </v-alert>
+          <v-text-field
+            v-model="addForm.host"
+            label="Host"
+            placeholder="gitlab.com"
+            :disabled="isSaving"
+            required
+            class="mb-2"
+          />
+          <v-text-field
+            v-model="addForm.displayName"
+            label="Display Name"
+            placeholder="Work account"
+            :disabled="isSaving"
+            class="mb-2"
+          />
+          <v-text-field
+            v-model="addForm.username"
+            label="Username"
+            :disabled="isSaving"
+            required
+            class="mb-2"
+          />
+          <v-text-field
+            v-model="addForm.pat"
+            label="Personal Access Token"
+            :type="showAddPat ? 'text' : 'password'"
+            :append-inner-icon="showAddPat ? 'mdi-eye-off' : 'mdi-eye'"
+            :disabled="isSaving"
+            required
+            class="mb-2"
+            @click:append-inner="showAddPat = !showAddPat"
+          />
+        </template>
+        <template #actions>
+          <v-spacer />
+          <v-btn
+            variant="flat"
+            color="treeview"
+            :disabled="isSaving"
+            @click="showAddDialog = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            variant="flat"
+            color="primary"
+            :disabled="!addFormValid || isSaving"
+            :loading="isSaving"
+            @click="submitAdd"
+          >
+            Add
+          </v-btn>
+        </template>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog
+      v-model="showEditDialog"
+      max-width="560"
+      persistent
+      @keydown.esc="showEditDialog = false"
+    >
+      <v-card color="canvas">
+        <template #title>
+          <div class="d-flex justify-space-between align-baseline">
+            <div class="text-h4">Edit Git Credential</div>
+            <v-btn
+              variant="plain"
+              icon="mdi-close"
+              @click="showEditDialog = false"
+            />
+          </div>
+        </template>
+        <template #text>
+          <v-alert v-if="saveError" type="error" class="mb-4">
+            {{ saveError }}
+          </v-alert>
+          <v-text-field
+            v-model="editForm.displayName"
+            label="Display Name"
+            placeholder="Work account"
+            :disabled="isSaving"
+            class="mb-2"
+          />
+          <v-text-field
+            v-model="editForm.username"
+            label="Username"
+            :disabled="isSaving"
+            class="mb-2"
+          />
+          <v-text-field
+            v-model="editForm.pat"
+            label="Personal Access Token"
+            :type="showEditPat ? 'text' : 'password'"
+            :append-inner-icon="showEditPat ? 'mdi-eye-off' : 'mdi-eye'"
+            placeholder="Leave blank to keep current PAT"
+            :disabled="isSaving"
+            class="mb-2"
+            @click:append-inner="showEditPat = !showEditPat"
+          />
+        </template>
+        <template #actions>
+          <v-spacer />
+          <v-btn
+            variant="flat"
+            color="treeview"
+            :disabled="isSaving"
+            @click="showEditDialog = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            variant="flat"
+            color="primary"
+            :disabled="isSaving"
+            :loading="isSaving"
+            @click="submitEdit"
+          >
+            Save
+          </v-btn>
+        </template>
+      </v-card>
+    </v-dialog>
+
+    <ConfirmDeleteDialog
+      v-if="showDeleteDialog"
+      v-model:show-dialog="showDeleteDialog"
+      prompt-text="Delete this git credential? This cannot be undone."
+      @confirmed="confirmDelete"
+    />
+  </div>
+</template>
+
+<style scoped lang="scss">
+td {
+  white-space: nowrap;
+}
+.app-id-column {
+  width: 100%;
+  font-family: monospace;
+  font-size: 0.85em;
+}
+.action-column {
+  text-align: center;
+  white-space: nowrap;
+}
+.top-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.v-table {
+  background-color: unset;
+
+  :deep(thead) > tr > th {
+    background-color: rgb(var(--v-theme-divider2));
+  }
+
+  :deep(td) {
+    padding: 8px 24px !important;
+  }
+
+  :deep(tr):hover {
+    background-color: rgb(var(--v-theme-focus1));
+  }
+
+  :deep(th) {
+    font-size: 16px;
+    padding: 8px 24px !important;
+  }
+
+  :deep(.mdi) {
+    margin-left: 0.2em;
+  }
+}
+</style>

--- a/frontend/components/context/user/userMenuItems.ts
+++ b/frontend/components/context/user/userMenuItems.ts
@@ -4,6 +4,7 @@ export enum UserFragments {
   PROFILE = "profile",
   API_KEYS = "api-keys",
   SUBSCRIPTIONS = "subscriptions",
+  GIT_CREDENTIALS = "git-credentials",
 }
 
 export const UserMenuEntries: MenuEntry[] = [
@@ -21,5 +22,10 @@ export const UserMenuEntries: MenuEntry[] = [
     name: "Subscriptions",
     fragment: UserFragments.SUBSCRIPTIONS,
     icon: "mdi-bell-outline",
+  },
+  {
+    name: "Git Credentials",
+    fragment: UserFragments.GIT_CREDENTIALS,
+    icon: "mdi-source-repository",
   },
 ];

--- a/frontend/composables/context/useFetchGitCredentials.ts
+++ b/frontend/composables/context/useFetchGitCredentials.ts
@@ -1,0 +1,27 @@
+import {
+  GitCredentialsApi,
+  type GitCredentialIO,
+} from "@dlr-shepard/backend-client";
+import { useV2ShepardApi } from "../common/api/useV2ShepardApi";
+
+export function useFetchGitCredentials() {
+  const credentials = ref<GitCredentialIO[]>([]);
+  const isLoading = ref<boolean>(true);
+
+  const api = useV2ShepardApi(GitCredentialsApi);
+
+  async function refresh() {
+    isLoading.value = true;
+    try {
+      credentials.value = await api.value.listCredentials();
+    } catch (error) {
+      handleError(error, "fetching git credentials");
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  refresh();
+
+  return { credentials, isLoading, refresh };
+}

--- a/frontend/composables/context/useManageGitCredentials.ts
+++ b/frontend/composables/context/useManageGitCredentials.ts
@@ -1,0 +1,59 @@
+import {
+  GitCredentialsApi,
+  type CreateGitCredentialIO,
+  type GitCredentialIO,
+  type PatchGitCredentialIO,
+} from "@dlr-shepard/backend-client";
+import { useV2ShepardApi } from "../common/api/useV2ShepardApi";
+
+export function useManageGitCredentials() {
+  const isSaving = ref<boolean>(false);
+  const saveError = ref<string | null>(null);
+
+  const api = useV2ShepardApi(GitCredentialsApi);
+
+  async function create(body: CreateGitCredentialIO): Promise<GitCredentialIO | null> {
+    isSaving.value = true;
+    saveError.value = null;
+    try {
+      return await api.value.createCredential(body);
+    } catch (error) {
+      saveError.value = "Failed to create git credential.";
+      handleError(error, "creating git credential");
+      return null;
+    } finally {
+      isSaving.value = false;
+    }
+  }
+
+  async function patch(appId: string, body: PatchGitCredentialIO): Promise<GitCredentialIO | null> {
+    isSaving.value = true;
+    saveError.value = null;
+    try {
+      return await api.value.patchCredential(appId, body);
+    } catch (error) {
+      saveError.value = "Failed to update git credential.";
+      handleError(error, "updating git credential");
+      return null;
+    } finally {
+      isSaving.value = false;
+    }
+  }
+
+  async function remove(appId: string): Promise<boolean> {
+    isSaving.value = true;
+    saveError.value = null;
+    try {
+      await api.value.deleteCredential(appId);
+      return true;
+    } catch (error) {
+      saveError.value = "Failed to delete git credential.";
+      handleError(error, "deleting git credential");
+      return false;
+    } finally {
+      isSaving.value = false;
+    }
+  }
+
+  return { create, patch, remove, isSaving, saveError };
+}

--- a/frontend/pages/user/index.vue
+++ b/frontend/pages/user/index.vue
@@ -4,6 +4,7 @@ import {
   UserMenuEntries,
 } from "~/components/context/user/userMenuItems";
 import SubscriptionsPane from "~/components/context/user/SubscriptionsPane.vue";
+import GitCredentialsPane from "~/components/context/user/GitCredentialsPane.vue";
 
 useHead({
   title: "User | shepard",
@@ -17,6 +18,7 @@ const { routeFragment } = useRouteFragment();
     <ProfilePane v-if="routeFragment === UserFragments.PROFILE" />
     <ApiKeyPane v-if="routeFragment === UserFragments.API_KEYS" />
     <SubscriptionsPane v-if="routeFragment === UserFragments.SUBSCRIPTIONS" />
+    <GitCredentialsPane v-if="routeFragment === UserFragments.GIT_CREDENTIALS" />
   </PaneLayout>
 </template>
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `GitCredentialsApi` hand-written backend-client class routing to `GET/POST/PATCH/DELETE /v2/me/git-credentials[/{appId}]` with typed interfaces `GitCredentialIO`, `CreateGitCredentialIO`, `PatchGitCredentialIO`
- Adds `useV2ShepardApi` composable (mirrors `useShepardApi` but strips `/shepard/api` suffix from `backendApiUrl` to derive the `/v2/` base path)
- Adds `useFetchGitCredentials` and `useManageGitCredentials` composables for list/create/patch/delete operations
- Adds `GitCredentialsPane.vue`: table listing host / display name / username / truncated appId, inline edit and delete action buttons, add-credential dialog, edit dialog (PAT optional on edit), delete confirmation dialog; all PAT fields are `type="password"` with show/hide toggle; save errors surface via `v-alert`
- Wires the pane into `/user` page as a new "Git Credentials" tab (fragment `git-credentials`, icon `mdi-source-repository`)

Depends on backend PR #1069 (`claude/g1-git-credential`) for the `/v2/me/git-credentials` endpoints to be present.

## Test plan

- [ ] Navigate to `/user#git-credentials` — "No git credentials linked yet." shown when empty
- [ ] Click ADD → fill host, username, PAT (display name optional) → Add → credential appears in table
- [ ] PAT field defaults to `type="password"`; eye icon toggles visibility; PAT is never pre-filled on edit dialog
- [ ] Edit icon → dialog pre-filled with host (read-only in display), display name, username; PAT field blank with placeholder "Leave blank to keep current PAT"; save with blank PAT preserves existing credential
- [ ] Edit with new PAT value → credential updated
- [ ] Delete icon → confirmation dialog → confirm → row removed
- [ ] Cancel on any dialog → no mutation, table unchanged
- [ ] Save error (e.g. 400 from backend) surfaces as `v-alert` in dialog
- [ ] Session token refresh (wait > 30s) → new requests still authenticated (watch on configuration re-instantiates API)

https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_