### PR TITLE
G1a-ui: credential-aware git reference management (DataObject pane)

### DIFF
--- a/backend-client/src/apis/GitReferenceApi.ts
+++ b/backend-client/src/apis/GitReferenceApi.ts
@@ -1,0 +1,130 @@
+import * as runtime from '../runtime';
+
+export interface GitReferenceIO {
+  appId: string;
+  repoUrl: string;
+  ref?: string;
+  path?: string;
+}
+
+export interface CreateGitReferenceIO {
+  repoUrl: string;
+  ref?: string;
+  path?: string;
+}
+
+export interface PatchGitReferenceIO {
+  repoUrl?: string;
+  ref?: string | null;
+  path?: string | null;
+}
+
+export class GitReferenceApi extends runtime.BaseAPI {
+
+  async listGitReferences(dataObjectAppId: string): Promise<GitReferenceIO[]> {
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request({
+      path: `/v2/data-objects/${encodeURIComponent(dataObjectAppId)}/git-references`,
+      method: 'GET',
+      headers: headerParameters,
+      query: {},
+    });
+
+    return response.json();
+  }
+
+  async createGitReference(dataObjectAppId: string, body: CreateGitReferenceIO): Promise<GitReferenceIO> {
+    const headerParameters: runtime.HTTPHeaders = {};
+    headerParameters['Content-Type'] = 'application/json';
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request({
+      path: `/v2/data-objects/${encodeURIComponent(dataObjectAppId)}/git-references`,
+      method: 'POST',
+      headers: headerParameters,
+      query: {},
+      body,
+    });
+
+    return response.json();
+  }
+
+  async getGitReference(dataObjectAppId: string, appId: string): Promise<GitReferenceIO> {
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request({
+      path: `/v2/data-objects/${encodeURIComponent(dataObjectAppId)}/git-references/${encodeURIComponent(appId)}`,
+      method: 'GET',
+      headers: headerParameters,
+      query: {},
+    });
+
+    return response.json();
+  }
+
+  async patchGitReference(dataObjectAppId: string, appId: string, body: PatchGitReferenceIO): Promise<GitReferenceIO> {
+    const headerParameters: runtime.HTTPHeaders = {};
+    headerParameters['Content-Type'] = 'application/json';
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request({
+      path: `/v2/data-objects/${encodeURIComponent(dataObjectAppId)}/git-references/${encodeURIComponent(appId)}`,
+      method: 'PATCH',
+      headers: headerParameters,
+      query: {},
+      body,
+    });
+
+    return response.json();
+  }
+
+  async deleteGitReference(dataObjectAppId: string, appId: string): Promise<void> {
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    await this.request({
+      path: `/v2/data-objects/${encodeURIComponent(dataObjectAppId)}/git-references/${encodeURIComponent(appId)}`,
+      method: 'DELETE',
+      headers: headerParameters,
+      query: {},
+    });
+  }
+}

--- a/backend-client/src/apis/index.ts
+++ b/backend-client/src/apis/index.ts
@@ -3,6 +3,7 @@
 export * from './AdminFeaturesApi';
 export * from './ApikeyApi';
 export * from './GitCredentialsApi';
+export * from './GitReferenceApi';
 export * from './CollectionApi';
 export * from './CollectionReferenceApi';
 export * from './DataObjectApi';

--- a/backend-client/src/models/DataObject.ts
+++ b/backend-client/src/models/DataObject.ts
@@ -20,7 +20,13 @@ import { mapValues } from '../runtime';
  */
 export interface DataObject {
     /**
-     * 
+     * Application-level UUID v7 identifier. Null on pre-L2a rows.
+     * @type {string}
+     * @memberof DataObject
+     */
+    readonly appId?: string | null;
+    /**
+     *
      * @type {number}
      * @memberof DataObject
      */
@@ -139,7 +145,8 @@ export function DataObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         return json;
     }
     return {
-        
+
+        'appId': json['appId'] == null ? undefined : json['appId'],
         'id': json['id'],
         'createdAt': (new Date(json['createdAt'])),
         'createdBy': json['createdBy'],

--- a/backend/src/main/java/de/dlr/shepard/common/neo4j/io/BasicEntityIO.java
+++ b/backend/src/main/java/de/dlr/shepard/common/neo4j/io/BasicEntityIO.java
@@ -45,8 +45,12 @@ public class BasicEntityIO implements HasId {
   @Schema(required = true)
   private String name;
 
+  @Schema(readOnly = true, nullable = true, description = "Application-level UUID v7 identifier.")
+  private String appId;
+
   public BasicEntityIO(BasicEntity entity) {
     this.id = entity.getId();
+    this.appId = entity.getAppId();
     this.createdAt = entity.getCreatedAt();
     this.createdBy = entity.getCreatedBy() != null
       ? DisplayNameResolver.effectiveDisplayName(entity.getCreatedBy())
@@ -60,6 +64,7 @@ public class BasicEntityIO implements HasId {
 
   public BasicEntityIO(BasicEntityIO entity) {
     this.id = entity.getId();
+    this.appId = entity.getAppId();
     this.createdAt = entity.getCreatedAt();
     this.createdBy = entity.getCreatedBy() != null ? entity.getCreatedBy() : null;
     this.updatedAt = entity.getUpdatedAt();
@@ -69,6 +74,7 @@ public class BasicEntityIO implements HasId {
 
   public BasicEntityIO(VersionableEntity entity) {
     this.id = entity.getShepardId();
+    this.appId = entity.getAppId();
     this.createdAt = entity.getCreatedAt();
     this.createdBy = entity.getCreatedBy() != null
       ? DisplayNameResolver.effectiveDisplayName(entity.getCreatedBy())
@@ -101,6 +107,7 @@ public class BasicEntityIO implements HasId {
     BasicEntityIO other = (BasicEntityIO) o;
     return (
       Objects.equals(id, other.id) &&
+      Objects.equals(appId, other.appId) &&
       Objects.equals(createdAt, other.createdAt) &&
       Objects.equals(createdBy, other.createdBy) &&
       Objects.equals(updatedAt, other.updatedAt) &&
@@ -113,7 +120,7 @@ public class BasicEntityIO implements HasId {
   public int hashCode() {
     final int prime = 31;
     int result = 0;
-    result = prime * result + Objects.hash(id, createdAt, createdBy, updatedAt, updatedBy, name);
+    result = prime * result + Objects.hash(id, appId, createdAt, createdBy, updatedAt, updatedBy, name);
     return result;
   }
 }

--- a/frontend/components/context/dataobject/GitReferencesPane.vue
+++ b/frontend/components/context/dataobject/GitReferencesPane.vue
@@ -1,0 +1,258 @@
+<script setup lang="ts">
+import type {
+  CreateGitReferenceIO,
+  GitReferenceIO,
+  PatchGitReferenceIO,
+} from "@dlr-shepard/backend-client";
+import { useFetchGitCredentials } from "~/composables/context/useFetchGitCredentials";
+import { useFetchGitReferences } from "~/composables/context/useFetchGitReferences";
+import { useManageGitReferences } from "~/composables/context/useManageGitReferences";
+
+const props = defineProps<{ dataObjectAppId: string }>();
+
+const { gitReferences, isLoading, refresh } = useFetchGitReferences(
+  props.dataObjectAppId,
+);
+const { create, patch, remove, isSaving, saveError } =
+  useManageGitReferences();
+
+const showCreateDialog = ref(false);
+const showEditDialog = ref(false);
+const showDeleteDialog = ref(false);
+const editTarget = ref<GitReferenceIO | null>(null);
+const deleteTarget = ref<GitReferenceIO | null>(null);
+
+const createForm = reactive<CreateGitReferenceIO>({
+  repoUrl: "",
+  ref: undefined,
+  path: undefined,
+});
+
+const editForm = reactive<PatchGitReferenceIO>({
+  repoUrl: undefined,
+  ref: undefined,
+  path: undefined,
+});
+
+function openCreate() {
+  createForm.repoUrl = "";
+  createForm.ref = undefined;
+  createForm.path = undefined;
+  showCreateDialog.value = true;
+}
+
+function openEdit(ref: GitReferenceIO) {
+  editTarget.value = ref;
+  editForm.repoUrl = ref.repoUrl;
+  editForm.ref = ref.ref;
+  editForm.path = ref.path;
+  showEditDialog.value = true;
+}
+
+function openDelete(ref: GitReferenceIO) {
+  deleteTarget.value = ref;
+  showDeleteDialog.value = true;
+}
+
+async function submitCreate() {
+  if (!createForm.repoUrl) return;
+  const result = await create(props.dataObjectAppId, {
+    repoUrl: createForm.repoUrl,
+    ref: createForm.ref || undefined,
+    path: createForm.path || undefined,
+  });
+  if (result) {
+    showCreateDialog.value = false;
+    refresh();
+  }
+}
+
+async function submitEdit() {
+  if (!editTarget.value) return;
+  const result = await patch(
+    props.dataObjectAppId,
+    editTarget.value.appId,
+    editForm,
+  );
+  if (result) {
+    showEditDialog.value = false;
+    refresh();
+  }
+}
+
+async function confirmDelete() {
+  if (!deleteTarget.value) return;
+  const ok = await remove(props.dataObjectAppId, deleteTarget.value.appId);
+  if (ok) {
+    showDeleteDialog.value = false;
+    refresh();
+  }
+}
+
+const { credentials, isLoading: credentialsLoading } = useFetchGitCredentials();
+
+const urlSuggestions = computed(() =>
+  credentials.value.map(c => ({
+    title: `https://${c.host}/${c.username}/`,
+    subtitle: c.displayName ?? c.host,
+  })),
+);
+</script>
+
+<template>
+  <div class="d-flex flex-column ga-4">
+    <div class="d-flex align-center justify-space-between">
+      <h5 class="text-h5">Git References</h5>
+      <v-btn
+        color="primary"
+        variant="flat"
+        prepend-icon="mdi-plus-circle"
+        @click="openCreate"
+      >
+        Add reference
+      </v-btn>
+    </div>
+
+    <v-alert v-if="saveError" type="error" closable>{{ saveError }}</v-alert>
+
+    <centered-loading-spinner v-if="isLoading" />
+
+    <v-table v-else-if="gitReferences.length > 0" class="table">
+      <thead>
+        <tr>
+          <th>Repository URL</th>
+          <th>Ref</th>
+          <th>Path</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="gr in gitReferences" :key="gr.appId">
+          <td>{{ gr.repoUrl }}</td>
+          <td>{{ gr.ref ?? '—' }}</td>
+          <td>{{ gr.path ?? '—' }}</td>
+          <td class="text-right">
+            <v-btn
+              icon="mdi-pencil-outline"
+              variant="plain"
+              density="compact"
+              @click="openEdit(gr)"
+            />
+            <v-btn
+              icon="mdi-delete-outline"
+              variant="plain"
+              density="compact"
+              color="error"
+              @click="openDelete(gr)"
+            />
+          </td>
+        </tr>
+      </tbody>
+    </v-table>
+
+    <div v-else class="text-medium-emphasis">No git references linked yet</div>
+
+    <FormDialog
+      v-model:show-dialog="showCreateDialog"
+      title="Add Git Reference"
+      :loading="isSaving || credentialsLoading"
+      :submit-disabled="!createForm.repoUrl || isSaving"
+      save-button-text="Add"
+      @submit="submitCreate"
+    >
+      <template #form>
+        <v-row class="pt-4">
+          <v-col cols="12">
+            <v-combobox
+              v-model="createForm.repoUrl"
+              :items="urlSuggestions"
+              item-title="title"
+              item-value="title"
+              label="Repository URL"
+              placeholder="https://gitlab.com/user/repo"
+              :hint="
+                urlSuggestions.length === 0
+                  ? 'Add git credentials in your profile to get autocomplete suggestions'
+                  : undefined
+              "
+              persistent-hint
+              required
+            >
+              <template #item="{ item, props: itemProps }">
+                <v-list-item v-bind="itemProps" :subtitle="item.raw.subtitle" />
+              </template>
+            </v-combobox>
+          </v-col>
+          <v-col cols="12">
+            <v-text-field
+              v-model="createForm.ref"
+              label="Ref"
+              placeholder="main"
+              hint="Branch, tag, or commit SHA. Leave blank for repository default."
+              persistent-hint
+              clearable
+            />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field
+              v-model="createForm.path"
+              label="Path"
+              placeholder="data/subdir"
+              hint="Subdirectory within the repository. Leave blank for root."
+              persistent-hint
+              clearable
+            />
+          </v-col>
+        </v-row>
+      </template>
+    </FormDialog>
+
+    <FormDialog
+      v-model:show-dialog="showEditDialog"
+      title="Edit Git Reference"
+      :loading="isSaving"
+      :submit-disabled="!editForm.repoUrl || isSaving"
+      @submit="submitEdit"
+    >
+      <template #form>
+        <v-row class="pt-4">
+          <v-col cols="12">
+            <v-text-field
+              v-model="editForm.repoUrl"
+              label="Repository URL"
+              required
+            />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field
+              v-model="editForm.ref"
+              label="Ref"
+              placeholder="main"
+              hint="Branch, tag, or commit SHA. Leave blank for repository default."
+              persistent-hint
+              clearable
+            />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field
+              v-model="editForm.path"
+              label="Path"
+              placeholder="data/subdir"
+              hint="Subdirectory within the repository. Leave blank for root."
+              persistent-hint
+              clearable
+            />
+          </v-col>
+        </v-row>
+      </template>
+    </FormDialog>
+
+    <ConfirmDeleteDialog
+      v-model:show-dialog="showDeleteDialog"
+      :prompt-text="`Delete git reference to ${deleteTarget?.repoUrl}?`"
+      @confirmed="confirmDelete"
+    />
+  </div>
+</template>
+
+<style scoped lang="scss"></style>

--- a/frontend/composables/context/useFetchGitReferences.ts
+++ b/frontend/composables/context/useFetchGitReferences.ts
@@ -1,0 +1,29 @@
+import {
+  GitReferenceApi,
+  type GitReferenceIO,
+} from "@dlr-shepard/backend-client";
+import { useV2ShepardApi } from "../common/api/useV2ShepardApi";
+
+export function useFetchGitReferences(dataObjectAppId: string) {
+  const gitReferences = ref<GitReferenceIO[]>([]);
+  const isLoading = ref(false);
+
+  function refresh() {
+    isLoading.value = true;
+    useV2ShepardApi(GitReferenceApi)
+      .value.listGitReferences(dataObjectAppId)
+      .then(result => {
+        gitReferences.value = result;
+      })
+      .catch(error => {
+        handleError(error, "listGitReferences");
+      })
+      .finally(() => {
+        isLoading.value = false;
+      });
+  }
+
+  refresh();
+
+  return { gitReferences, isLoading, refresh };
+}

--- a/frontend/composables/context/useManageGitReferences.ts
+++ b/frontend/composables/context/useManageGitReferences.ts
@@ -1,0 +1,70 @@
+import {
+  GitReferenceApi,
+  type CreateGitReferenceIO,
+  type GitReferenceIO,
+  type PatchGitReferenceIO,
+} from "@dlr-shepard/backend-client";
+import { useV2ShepardApi } from "../common/api/useV2ShepardApi";
+
+export function useManageGitReferences() {
+  const isSaving = ref(false);
+  const saveError = ref<string | null>(null);
+
+  async function create(
+    dataObjectAppId: string,
+    body: CreateGitReferenceIO,
+  ): Promise<GitReferenceIO | null> {
+    isSaving.value = true;
+    saveError.value = null;
+    try {
+      return await useV2ShepardApi(GitReferenceApi)
+        .value.createGitReference(dataObjectAppId, body);
+    } catch (error) {
+      handleError(error, "createGitReference");
+      saveError.value = "Failed to create git reference";
+      return null;
+    } finally {
+      isSaving.value = false;
+    }
+  }
+
+  async function patch(
+    dataObjectAppId: string,
+    appId: string,
+    body: PatchGitReferenceIO,
+  ): Promise<GitReferenceIO | null> {
+    isSaving.value = true;
+    saveError.value = null;
+    try {
+      return await useV2ShepardApi(GitReferenceApi)
+        .value.patchGitReference(dataObjectAppId, appId, body);
+    } catch (error) {
+      handleError(error, "patchGitReference");
+      saveError.value = "Failed to update git reference";
+      return null;
+    } finally {
+      isSaving.value = false;
+    }
+  }
+
+  async function remove(
+    dataObjectAppId: string,
+    appId: string,
+  ): Promise<boolean> {
+    isSaving.value = true;
+    saveError.value = null;
+    try {
+      await useV2ShepardApi(GitReferenceApi)
+        .value.deleteGitReference(dataObjectAppId, appId);
+      return true;
+    } catch (error) {
+      handleError(error, "deleteGitReference");
+      saveError.value = "Failed to delete git reference";
+      return false;
+    } finally {
+      isSaving.value = false;
+    }
+  }
+
+  return { create, patch, remove, isSaving, saveError };
+}

--- a/frontend/pages/collections/[collectionId]/dataobjects/[dataObjectId]/index.vue
+++ b/frontend/pages/collections/[collectionId]/dataobjects/[dataObjectId]/index.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import EditDataObjectDescriptionDialog from "~/components/context/data-object/edit-dialog/EditDataObjectDescriptionDialog.vue";
 import DataObjectFileUpload from "~/components/context/data-object/upload-data/DataObjectFileUpload.vue";
+import GitReferencesPane from "~/components/context/dataobject/GitReferencesPane.vue";
 import AddRelationshipDialog from "~/components/context/display-components/relationships/add-dialog/AddRelationshipDialog.vue";
 import { collectionsPath, dataObjectsPathFragment } from "~/utils/constants";
 
@@ -196,6 +197,12 @@ watch(dataObject, () => {
                       :data-object-id="dataObjectId"
                     />
                   </template>
+                </ExpansionPanelItem>
+                <ExpansionPanelItem
+                  v-if="dataObject.appId"
+                  title="Git References"
+                >
+                  <GitReferencesPane :data-object-app-id="dataObject.appId" />
                 </ExpansionPanelItem>
               </ExpansionPanels>
             </v-row>


### PR DESCRIPTION
## Summary

- Adds `GitReferenceApi` and `GitCredentialApi` hand-written API clients targeting `/v2/` routes, exported from `backend-client/src/apis/index.ts`
- Adds `useV2ShepardApi` composable (same shape as `useShepardApi`, basePath from `backendApiUrl`)
- Adds `useFetchGitReferences`, `useManageGitReferences`, and `useFetchGitCredentials` composables under `composables/context/`
- Adds `GitReferencesPane` — table of linked git references with create / edit / delete dialogs; the create dialog uses a `v-combobox` with autocomplete suggestions derived from the user's stored git credentials (`https://{host}/{username}/` prefixes)
- Exposes `appId` on `BasicEntityIO` (additive: existing clients ignore the new field) so the DataObject detail page can pass the UUID to the `/v2/` route
- Wires `GitReferencesPane` into the DataObject detail page as a new "Git References" expansion panel (only rendered when `dataObject.appId` is present)

## Test plan

- [ ] Open a DataObject detail page; a "Git References" panel appears
- [ ] Panel shows "No git references linked yet" when empty
- [ ] Click "Add reference"; combobox shows credential-derived URL suggestions when credentials exist; helper text appears when none exist
- [ ] Submit the form; row appears in the table
- [ ] Edit a row; changes persist on save
- [ ] Delete a row; confirm dialog appears; row is removed after confirmation
- [ ] Error banner appears if a save/delete call fails
- [ ] DataObject detail pages for pre-L2a rows (null `appId`) do not show the panel

https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_