### PR TITLE
A3b-ui: /admin page with feature toggle switches

### DIFF
--- a/backend-client/src/apis/AdminFeaturesApi.ts
+++ b/backend-client/src/apis/AdminFeaturesApi.ts
@@ -1,0 +1,107 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import * as runtime from '../runtime';
+
+export interface FeatureToggleIO {
+  name: string;
+  enabled: boolean;
+  description: string;
+}
+
+export interface PatchFeatureToggleIO {
+  enabled: boolean;
+}
+
+export interface PatchFeatureRequest {
+  name: string;
+  patchFeatureToggleIO: PatchFeatureToggleIO;
+}
+
+/**
+ * Admin feature toggles API — /v2/admin/features
+ */
+export class AdminFeaturesApi extends runtime.BaseAPI {
+
+  /**
+   * List all feature toggles (instance-admin only)
+   */
+  async listFeaturesRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureToggleIO[]>> {
+    const queryParameters: any = {};
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request({
+      path: `/v2/admin/features`,
+      method: 'GET',
+      headers: headerParameters,
+      query: queryParameters,
+    }, initOverrides);
+
+    return new runtime.JSONApiResponse<FeatureToggleIO[]>(response);
+  }
+
+  /**
+   * List all feature toggles (instance-admin only)
+   */
+  async listFeatures(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FeatureToggleIO[]> {
+    const response = await this.listFeaturesRaw(initOverrides);
+    return await response.value();
+  }
+
+  /**
+   * Update a feature toggle by name (instance-admin only)
+   */
+  async patchFeatureRaw(requestParameters: PatchFeatureRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FeatureToggleIO>> {
+    if (requestParameters['name'] == null) {
+      throw new runtime.RequiredError(
+        'name',
+        'Required parameter "name" was null or undefined when calling patchFeature().'
+      );
+    }
+
+    if (requestParameters['patchFeatureToggleIO'] == null) {
+      throw new runtime.RequiredError(
+        'patchFeatureToggleIO',
+        'Required parameter "patchFeatureToggleIO" was null or undefined when calling patchFeature().'
+      );
+    }
+
+    const queryParameters: any = {};
+    const headerParameters: runtime.HTTPHeaders = {};
+    headerParameters['Content-Type'] = 'application/json';
+
+    if (this.configuration && this.configuration.accessToken) {
+      const token = this.configuration.accessToken;
+      const tokenString = await token('bearer', []);
+      if (tokenString) {
+        headerParameters['Authorization'] = `Bearer ${tokenString}`;
+      }
+    }
+
+    const response = await this.request({
+      path: `/v2/admin/features/{name}`.replace(`{${'name'}}`, encodeURIComponent(String(requestParameters['name']))),
+      method: 'PATCH',
+      headers: headerParameters,
+      query: queryParameters,
+      body: requestParameters['patchFeatureToggleIO'],
+    }, initOverrides);
+
+    return new runtime.JSONApiResponse<FeatureToggleIO>(response);
+  }
+
+  /**
+   * Update a feature toggle by name (instance-admin only)
+   */
+  async patchFeature(requestParameters: PatchFeatureRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FeatureToggleIO> {
+    const response = await this.patchFeatureRaw(requestParameters, initOverrides);
+    return await response.value();
+  }
+}

--- a/backend-client/src/apis/index.ts
+++ b/backend-client/src/apis/index.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+export * from './AdminFeaturesApi';
 export * from './ApikeyApi';
 export * from './CollectionApi';
 export * from './CollectionReferenceApi';

--- a/frontend/components/context/admin/FeatureTogglesPane.vue
+++ b/frontend/components/context/admin/FeatureTogglesPane.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import {
+  AdminFeaturesApi,
+  type FeatureToggleIO,
+} from "@dlr-shepard/backend-client";
+import { useV2ShepardApi } from "~/composables/common/api/useV2ShepardApi";
+import { useFetchFeatureToggles } from "~/composables/context/admin/useFetchFeatureToggles";
+import { AdminFragments } from "./adminMenuItems";
+
+const { features, isLoading, refresh } = useFetchFeatureToggles();
+
+const patchingName = ref<string | null>(null);
+const patchError = ref<string | null>(null);
+
+async function onToggle(feature: FeatureToggleIO, newValue: boolean) {
+  patchError.value = null;
+  patchingName.value = feature.name;
+  try {
+    await useV2ShepardApi(AdminFeaturesApi).value.patchFeature({
+      name: feature.name,
+      patchFeatureToggleIO: { enabled: newValue },
+    });
+    await refresh();
+  } catch (e) {
+    patchError.value = `Failed to update "${feature.name}". Please try again.`;
+    handleError(e, `patching feature toggle "${feature.name}"`);
+  } finally {
+    patchingName.value = null;
+  }
+}
+</script>
+
+<template>
+  <div :id="AdminFragments.FEATURE_TOGGLES" class="d-flex flex-column ga-4">
+    <h4 class="text-h4">Feature Toggles</h4>
+
+    <v-alert
+      v-if="patchError"
+      type="error"
+      closable
+      @click:close="patchError = null"
+    >
+      {{ patchError }}
+    </v-alert>
+
+    <centered-loading-spinner v-if="isLoading && features.length === 0" />
+
+    <EmptyListIcon
+      v-else-if="!isLoading && features.length === 0"
+      label="No feature toggles registered"
+    />
+
+    <v-list v-else lines="two">
+      <v-list-item
+        v-for="feature in features"
+        :key="feature.name"
+        :disabled="patchingName === feature.name"
+      >
+        <template #prepend>
+          <v-progress-circular
+            v-if="patchingName === feature.name"
+            indeterminate
+            size="24"
+            class="mr-4"
+          />
+        </template>
+
+        <v-list-item-title>
+          <strong>{{ feature.name }}</strong>
+        </v-list-item-title>
+        <v-list-item-subtitle>{{ feature.description }}</v-list-item-subtitle>
+
+        <template #append>
+          <v-switch
+            :model-value="feature.enabled"
+            color="primary"
+            hide-details
+            :disabled="patchingName !== null"
+            @update:model-value="(val) => onToggle(feature, val as boolean)"
+          />
+        </template>
+      </v-list-item>
+    </v-list>
+  </div>
+</template>
+
+<style scoped lang="scss"></style>

--- a/frontend/components/context/admin/adminMenuItems.ts
+++ b/frontend/components/context/admin/adminMenuItems.ts
@@ -1,0 +1,13 @@
+import type { MenuEntry } from "~/components/common/pane-menu/menuListTypes";
+
+export enum AdminFragments {
+  FEATURE_TOGGLES = "feature-toggles",
+}
+
+export const AdminMenuEntries: MenuEntry[] = [
+  {
+    name: "Feature Toggles",
+    fragment: AdminFragments.FEATURE_TOGGLES,
+    icon: "mdi-toggle-switch-outline",
+  },
+];

--- a/frontend/components/layout/HeaderBar.vue
+++ b/frontend/components/layout/HeaderBar.vue
@@ -13,6 +13,13 @@
         Configuration
       </v-btn>
       <v-btn class="nav-item" to="/search">Advanced Search</v-btn>
+      <v-btn
+        v-if="isInstanceAdmin"
+        class="nav-item"
+        :to="{ path: '/admin', hash: '#feature-toggles' }"
+      >
+        Admin
+      </v-btn>
     </v-app-bar-title>
     <template #append>
       <v-btn :to="{ path: '/about', hash: '#version' }" class="nav-item">
@@ -40,6 +47,10 @@ const isSignedIn = computed(
   () => status.value === "authenticated" && !data.value?.error,
 ).value;
 const authIcon = isSignedIn ? "mdi-logout" : "mdi-account";
+
+const isInstanceAdmin = computed(() =>
+  hasInstanceAdminRole(data.value?.accessToken),
+);
 
 const handleAuth = () => {
   if (isSignedIn) {

--- a/frontend/composables/context/admin/useFetchFeatureToggles.ts
+++ b/frontend/composables/context/admin/useFetchFeatureToggles.ts
@@ -1,0 +1,26 @@
+import {
+  AdminFeaturesApi,
+  type FeatureToggleIO,
+} from "@dlr-shepard/backend-client";
+import { useV2ShepardApi } from "~/composables/common/api/useV2ShepardApi";
+
+export function useFetchFeatureToggles() {
+  const features = ref<FeatureToggleIO[]>([]);
+  const isLoading = ref<boolean>(false);
+
+  async function refresh() {
+    isLoading.value = true;
+    try {
+      features.value = await useV2ShepardApi(AdminFeaturesApi).value.listFeatures();
+    } catch (error) {
+      features.value = [];
+      handleError(error, "fetching feature toggles");
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  refresh();
+
+  return { features, isLoading, refresh };
+}

--- a/frontend/pages/admin/index.vue
+++ b/frontend/pages/admin/index.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import {
+  AdminFragments,
+  AdminMenuEntries,
+} from "~/components/context/admin/adminMenuItems";
+
+useHead({
+  title: "Admin | shepard",
+});
+
+const { data } = useAuth();
+
+const isInstanceAdmin = computed(() =>
+  hasInstanceAdminRole(data.value?.accessToken),
+);
+
+// Redirect non-admins to /user
+watchEffect(() => {
+  if (data.value !== undefined && !isInstanceAdmin.value) {
+    navigateTo("/user");
+  }
+});
+
+const { routeFragment } = useRouteFragment();
+</script>
+
+<template>
+  <PaneLayout header="Admin" :menu-entries="AdminMenuEntries">
+    <FeatureTogglesPane
+      v-if="routeFragment === AdminFragments.FEATURE_TOGGLES"
+    />
+  </PaneLayout>
+</template>

--- a/frontend/utils/auth.ts
+++ b/frontend/utils/auth.ts
@@ -1,0 +1,35 @@
+/**
+ * Decode a JWT payload without verifying the signature.
+ * Used client-side only to read claims (e.g. realm roles) from access tokens.
+ */
+export function parseJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    const payload = parts[1];
+    // Convert URL-safe base64 to standard base64
+    const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const json = decodeURIComponent(
+      atob(base64)
+        .split("")
+        .map(c => "%" + c.charCodeAt(0).toString(16).padStart(2, "0"))
+        .join(""),
+    );
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true when the given access token payload contains "instance-admin"
+ * in `realm_access.roles`.
+ */
+export function hasInstanceAdminRole(token: string | undefined | null): boolean {
+  if (!token) return false;
+  const payload = parseJwtPayload(token);
+  if (!payload) return false;
+  const realmRoles =
+    (payload.realm_access as { roles?: string[] } | undefined)?.roles ?? [];
+  return realmRoles.includes("instance-admin");
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `AdminFeaturesApi` (hand-written) in `backend-client/src/apis/` calling `GET /v2/admin/features` and `PATCH /v2/admin/features/{name}`; exported from the package index.
- Adds `useFetchFeatureToggles` composable (under `composables/context/admin/`) that uses `useV2ShepardApi(AdminFeaturesApi)`.
- Adds `FeatureTogglesPane.vue` — a `v-list` of toggles with per-row `v-switch`; toggling immediately calls `PATCH`, shows a spinner on the toggled row while in-flight, and surfaces errors via `v-alert`.
- Adds `adminMenuItems.ts` with `AdminFragments` enum and `AdminMenuEntries` array.
- Adds `frontend/pages/admin/index.vue` — a `PaneLayout`-based page at `/admin`; route guard redirects non-admins to `/user` by decoding `realm_access.roles` from the access-token JWT.
- Adds `frontend/utils/auth.ts` — shared `parseJwtPayload` / `hasInstanceAdminRole` helpers (used by both the page guard and `HeaderBar`).
- Updates `HeaderBar.vue` to show an "Admin" nav link only when `hasInstanceAdminRole` is true.

## Test plan

- [ ] Sign in as a regular user — "Admin" nav link is absent; navigating directly to `/admin` redirects to `/user`.
- [ ] Sign in as a user with Keycloak realm role `instance-admin` — "Admin" nav link appears in the header.
- [ ] Click "Admin" → lands on `/admin#feature-toggles`, shows the Feature Toggles pane with toggles from `GET /v2/admin/features`.
- [ ] Toggle a switch — `PATCH /v2/admin/features/{name}` is called with `{ enabled: <new value> }`; a loading spinner appears on the row while in-flight; the switch reflects the updated state after the response.
- [ ] Simulate a `PATCH` failure (e.g. network error) — a red `v-alert` appears above the list with an error message.
- [ ] When no feature toggles are registered, the pane shows the "No feature toggles registered" empty state.

https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_