### PR TITLE
aidocs/64 + 65: provenance architecture overview + admin-configurable ontology preseed design

### DIFF
--- a/aidocs/64-provenance-architecture.md
+++ b/aidocs/64-provenance-architecture.md
@@ -1,0 +1,253 @@
+# 64 — Provenance architecture (what's shipped + where it's going)
+
+**Status.** Live reference, kept current with the PROV1 series.
+**Snapshot date.** 2026-05-13.
+**Audience.** Contributors and operators trying to understand
+shepard's provenance / activity-capture stack, and the path from
+PROV-O to a richer engineering-research description.
+
+**Originating items.** PROV1 design in `aidocs/55`; this doc is the
+"what shipped + what's coming" overview rather than the original
+design. Touches `aidocs/63` ADR-0004 (PROV-O over OpenLineage),
+ADR-0019 (preseed default-on).
+
+---
+
+## 1. What's shipped (PROV1a–d, f, g)
+
+The PROV1 series is end-to-end. Five backend slices + one frontend
+slice landed in this session.
+
+### 1.1 Capture layer (PROV1a)
+
+| Component | Path / shape |
+|---|---|
+| `:Activity` Neo4j entity | `de.dlr.shepard.context.provenance.entities.Activity` — `HasAppId`, modelled on `prov:Activity` |
+| Fields | `appId`, `actorSub`, `actorDisplayName` (via `DisplayNameResolver` from U1b), `verb` (`POST` / `PUT` / `PATCH` / `DELETE`), `path`, `responseStatus`, `targetAppId`, `targetKind`, `recordedAt`, `instanceId` |
+| JAX-RS filter | `ProvenanceCaptureFilter` — request+response filter on every mutating endpoint; captures 2xx by default |
+| Service-layer hook | For non-REST flows (migrations, background jobs) — `ProvenanceService.recordServiceActivity(...)` |
+| Constraint | `V15__Add_appId_constraint_Activity.cypher` — appId uniqueness |
+
+**Operator config keys** (all default-safe):
+- `shepard.provenance.enabled=true` — master toggle
+- `shepard.provenance.capture-reads=false` — opt-in read capture (row volume grows ~10×)
+- `shepard.instance.id=local` — per-deployment origin stamp (used by `aidocs/60` Edge sync)
+
+**Permission posture:** casual users see only their own rows;
+`instance-admin` sees all. The capture path never propagates
+failures back to the user write — provenance is observability, not
+a blocker.
+
+### 1.2 Query layer
+
+| Endpoint | What it returns |
+|---|---|
+| `GET /v2/provenance/activities` | Paginated activity stream (PROV1a) |
+| `GET /v2/provenance/count` | Quick cardinality probe (PROV1a) |
+| `GET /v2/provenance/entity/{appId}` | Per-entity trail (PROV1b); `TargetEntityResolver` extracts target identity heuristically from the request path |
+| `GET /v2/provenance/stats?scope=instance\|collection\|user&id=&since=&until=` | Single-Cypher aggregation (PROV1c) — totals + sparkline buckets (auto daily/weekly switch at 90 days) + per-kind histogram + distinct-agent count + cumulative integral + `contentCensus` (entity-kind counts) + `byteTotals` (FB1a's stored `fileSize`) |
+
+The `?profile=metadata|relations|all` output-profile machinery from
+V2S1a applies — clients pick the level of detail.
+
+### 1.3 Export layer (PROV1g)
+
+`Accept: application/prov+json` on
+`/v2/provenance/{activities,entity/{appId}}` emits a W3C PROV-JSON
+subset with `activity` / `agent` / `entity` / `wasAssociatedWith`
+/ `used` / `wasGeneratedBy` blocks. The `ProvJsonRenderer` wraps
+the existing IO shapes; no second model.
+
+### 1.4 Lifecycle (PROV1f)
+
+`ProvenanceRetentionJob` — `@Scheduled` cron, default 2-year
+window via `shepard.provenance.retention-days=730`. Negative value
+keeps forever.
+
+### 1.5 Frontend (PROV1d)
+
+`ActivitySparklineCard.vue` on every Collection detail page.
+Vanilla SVG (no Chart.js dep) — per-bucket bars + cumulative
+polyline overlay + per-kind histogram + distinct-contributors
+count + time-range picker (7d / 30d / 90d / 1y).
+
+### 1.6 What's deferred
+
+| Slice | Why deferred |
+|---|---|
+| `PROV1b2` | Explicit `:USED` / `:GENERATED` Neo4j edges — today `targetAppId` is enough; edges become valuable once SPARQL queries hit the graph |
+| `PROV1c2` | Pre-aggregated `:ActivityRollup` — only on observed need |
+| `PROV1e` | Instance-admin all-instance dashboard — depends on PROV1d (now shipped) + `aidocs/51 §9.5` admin-page strip |
+
+---
+
+## 2. Where PROV-O alone falls short
+
+PROV-O is **abstract** by design: `Activity`, `Agent`, `Entity`,
+`used`, `wasGeneratedBy`. shepard's current capture answers *who
+did what when*, but not:
+
+- *What kind of activity?* — "A POST" doesn't tell a downstream
+  consumer it was a CT scan, a Raman measurement, a parameter
+  sweep, a simulation run.
+- *With what method, on what investigated object?* — PROV-O has
+  no `Method`, `Tool`, `InvestigatedObject`.
+- *With what units?* — PROV-O has no quantitative vocabulary.
+- *What role did the agent play?* — PROV-O has `wasAssociatedWith`
+  but no standardised role taxonomy.
+
+For engineering-research the gap is real. shepard's PROV-O baseline
+makes activities findable and citable; it doesn't make them
+**reusable** in the sense the FAIR principles imply.
+
+---
+
+## 3. metadata4ing — the engineering-research extension
+
+NFDI4Ing's **metadata4ing** ontology (current v1.4.0, December
+2025; `http://w3id.org/nfdi4ing/metadata4ing/`) is a PROV-O-
+compatible upper ontology for the data-generation process.
+
+| Aspect | What it adds beyond PROV-O |
+|---|---|
+| Domain | `m4i:ProcessingStep` (subtype of `prov:Activity`), `m4i:Method`, `m4i:Tool`, `m4i:InvestigatedObject` |
+| Quantities | `m4i:NumericalVariable` + QUDT units — same primitives a typed `TimeseriesReference` would need |
+| Roles | DataCite v4.4 individuals (ContactPerson / DataCollector / DataCurator / …) for `wasAssociatedWith` |
+| RO-Crate | Official m4i ↔ RO-Crate mapping (since v1.3) — composes with shepard's existing RO-Crate export (`aidocs/31`) |
+| Croissant | Data-files-as-input/output modelling — clean fit for FileBundleReference + FileGroup |
+| Compatibility | v1.3 explicitly flexibilised the processing-step ↔ actor relationship to be PROV-O-compatible — m4i wants to be the engineering layer **above** PROV-O |
+| Imports | Already imports PROV-O, DCAT, DCTerms, FOAF, OWL, QUDT, RDF/S, schema.org, SIO, SKOS, SSN, biro, cr, dcc |
+
+**Verdict.** metadata4ing is exactly the layer above PROV1's
+PROV-O baseline. It's not a replacement; it's the vocabulary that
+lets PROV1's abstract `:Activity` carry "this was a CT scan with a
+Zeiss Versa 620 at 80 kV" instead of just "POST". Adoption is
+**additive**.
+
+### 3.1 ONT1b — preseed the ontology
+
+ONT1b ships metadata4ing as the 10th bundle in the N1b/ONT1a
+pre-seed pattern (`backend/src/main/resources/ontologies/metadata4ing.ttl`,
+SHA-256-pinned in `ontologies-manifest.json`, licence CC BY 4.0).
+This makes m4i terms resolvable in the n10s internal repository on
+day one — the annotation picker can offer `m4i:ProcessingStep`,
+`m4i:Method`, etc. directly.
+
+### 3.2 PROV1h — lift PROV-O rendering to m4i
+
+The follow-up slice (not yet scheduled, but the natural next
+PROV step):
+
+- New content-type `Accept: application/ld+json; profile="http://w3id.org/nfdi4ing/metadata4ing/"` on
+  `/v2/provenance/{activities,entity/{appId}}` alongside the
+  existing `application/prov+json`.
+- Mapping rules:
+  - `:Activity` → `m4i:ProcessingStep` (subclass of `prov:Activity`)
+  - `targetAppId` + `targetKind` → `prov:used` / `prov:generated`
+    typed by the Reference kind (`m4i:DataSet` etc.)
+  - `actorSub` + `actorDisplayName` → `prov:wasAssociatedWith`
+    with a DataCite v4.4 role individual
+  - `verb` (POST / PUT / PATCH / DELETE) → `m4i:Method` subclass
+    (Create / Update / Delete) — pragmatic mapping, the verb
+    isn't a real method but it makes the JSON-LD parseable as a
+    typed event
+- Wire format: additive content-type; existing `application/prov+json`
+  callers see no change.
+- New ADR (to be assigned when shipped) records "m4i as PROV-O
+  extension, not replacement" — analogous to ADR-0004's PROV-O
+  pick.
+
+---
+
+## 4. Helmholtz Kernel Information Profile (KIP) — the PID layer
+
+KIP (`aidocs/16` row pending; HMC publication
+`10.3289/HMC_publ_03`) is a **different layer**: it's the
+PID-record contract, not a domain ontology. KIP defines what
+every Handle/DOI resolver must return for a digital object —
+type, creation date, locator, checksum, license.
+
+KIP and metadata4ing compose:
+
+- **metadata4ing** = rich semantic description of what was done
+- **KIP** = minimal PID-resolution record that points to that
+  description
+
+shepard would emit both at publish time:
+
+- KIP-shaped record on the PID-mint hook (lightweight, citation-
+  shaped, suitable for cross-Helmholtz services)
+- metadata4ing-flavoured JSON-LD as the entity body / RO-Crate
+  manifest content (the rich description KIP points at)
+
+Design landing zone: `aidocs/64-hmc-kip-integration.md` (to be
+written when this slice is scheduled; not in scope here).
+
+### 4.1 Unhide (Helmholtz Knowledge Graph) harvest
+
+Unhide (`docs.unhide.helmholtz-metadaten.de`) is harvest-pull —
+shepard exposes a metadata feed, Unhide pulls it on a schedule
+and lands it in the HKG via its internal data model + inward
+mappings. Plugin-shape suits this: `shepard-plugin-unhide` would
+expose `GET /v2/unhide/feed.jsonld` as schema.org + m4i JSON-LD
+of Collections flagged for publication.
+
+Design landing zone: `aidocs/65-unhide-publish-plugin.md` (to be
+written; not in scope here). Plugin would depend on the m4i
+content-negotiation (§3.2) so the feed cites m4i terms natively.
+
+---
+
+## 5. metadata4nfdi — context, not yet aligned
+
+NFDI is rolling out **metadata4nfdi** as the cross-domain
+harmonisation layer above per-domain ontologies (metadata4ing for
+engineering, GO-FAIR for life sciences, NFDI4Earth's vocabularies,
+etc.). Earlier-stage than metadata4ing — currently workshop /
+RFC-shape effort.
+
+**Position.** Align with metadata4ing first; watch metadata4nfdi
+as it stabilises; lift to it when it converges. Going
+metadata4nfdi-first today would put shepard ahead of where the
+standard is.
+
+---
+
+## 6. Recommended phasing
+
+| Phase | Slice | Status / next action |
+|---|---|---|
+| 1 | **ONT1b** — preseed metadata4ing as the 10th bundle | **In flight** (this session's dispatch); will ship as small PR |
+| 2 | **PROV1h** — m4i content-negotiation on `/v2/provenance/*` | Not yet scheduled; ~M; gated on ONT1b |
+| 3 | **KIP record + Unhide plugin** designs (`aidocs/64`, `aidocs/65`) | Design-first; PROV1h-gated |
+| 4 | **metadata4nfdi alignment** | Watch-only until upstream stabilises |
+
+Phases 1 and 2 together convert shepard's provenance from a
+PROV-O-only "audit trail" into a metadata4ing-flavoured "research
+activity log" — the same data, rendered with engineering
+vocabulary at content-negotiation time. Phase 3 unlocks the
+cross-Helmholtz find-and-cite surface. Phase 4 is the long-term
+unification target.
+
+---
+
+## 7. Cross-references
+
+- `aidocs/55-provenance-and-activity-overhaul.md` — the PROV1
+  series design doc; this doc is the "what shipped" overlay.
+- `aidocs/16-dispatcher-backlog.md` — PROV1a–g rows + ONT1b row.
+- `aidocs/63-architecture-decision-log.md` — ADR-0004 (PROV-O
+  over OpenLineage), ADR-0019 (preseed default-on); future
+  m4i-as-extension ADR lands when PROV1h ships.
+- `aidocs/31-rocrate-export.md` — m4i ↔ RO-Crate mapping is the
+  natural composition point.
+- `aidocs/48-internal-semantic-repository-design.md` — n10s
+  internal repo where the pre-seeded m4i terms live.
+- `aidocs/27-convenience-clients-design.md` — the typed-client
+  layer that would surface `m4i:Method` etc. once PROV1h ships.
+
+External:
+- [Metadata4Ing 1.4.0 (NFDI4Ing)](http://w3id.org/nfdi4ing/metadata4ing/1.4.0/)
+- [HMC Kernel Information Profile (KIT publication)](https://publikationen.bibliothek.kit.edu/1000173746)
+- [Helmholtz Knowledge Graph documentation](https://docs.unhide.helmholtz-metadaten.de/)
+- [W3C PROV-O](https://www.w3.org/TR/prov-o/)

--- a/aidocs/65-admin-configurable-ontology-preseed.md
+++ b/aidocs/65-admin-configurable-ontology-preseed.md
@@ -1,0 +1,264 @@
+# 65 — Admin-configurable ontology pre-seeding (with custom-bundle support)
+
+**Status.** Design — ready to implement.
+**Snapshot date.** 2026-05-13.
+**Audience.** Contributors implementing the slice; operators who
+want to know how to control which ontologies land in their
+shepard's internal semantic repository.
+
+**Originating items.** User request 2026-05-13: "make pre-seeding
+configurable by admin which ontologies (except required) to
+include; allow adding ontologies." Couples to `aidocs/48` (n10s
+internal semantic repo), `aidocs/63` ADR-0019 (preseed default-on),
+the N1b/ONT1a/ONT1b shipped baseline (`aidocs/16`), and N1c's
+shipped `POST /v2/admin/semantic/refresh-ontologies` admin API.
+
+---
+
+## 1. The current state
+
+After **N1b** + **ONT1a** + **ONT1b** the repo ships **ten**
+ontology bundles under `backend/src/main/resources/ontologies/`:
+
+| Bundle id | Licence | Notes |
+|---|---|---|
+| `prov-o` | W3C Document Licence | provenance baseline; required by PROV1 |
+| `dublin-core` | CC BY 4.0 | FAIR metadata baseline |
+| `schema-org` | CC BY-SA 3.0 | broad web-vocab |
+| `foaf` | CC BY 1.0 | persons / organisations |
+| `qudt` | CC BY 4.0 | units / quantities |
+| `om-2` | CC BY 4.0 | engineering units alternative |
+| `time` | W3C Document Licence | temporal vocab |
+| `geosparql` | OGC Open Data | geospatial vocab |
+| `obo-relations` | CC0 1.0 | relation predicates (ONT1a) |
+| `metadata4ing` | CC BY 4.0 | engineering-research process modelling (ONT1b) |
+
+The current operator knobs (deploy-time only):
+- `shepard.semantic.internal.preseed-ontologies.enabled=true` — master toggle
+- `shepard.semantic.internal.preseed-ontologies.skip-bundles=qudt,om-2` — CSV opt-out
+
+The N1c admin endpoint `POST /v2/admin/semantic/refresh-ontologies`
+refreshes already-seeded bundles to canonical content; it doesn't
+manage which ones are seeded in the first place.
+
+Two operator gaps:
+1. **No runtime ON/OFF control per bundle** — only the deploy-time
+   CSV skip list. Flipping it requires restarting shepard.
+2. **No way to add a custom ontology** — operators with a
+   domain-specific TTL (e.g. a lab's local extension of m4i) can
+   only add it by editing the classpath, which round-trips through
+   a shepard release.
+
+This doc proposes a slice (**N1c2**) that closes both.
+
+---
+
+## 2. The shape
+
+### 2.1 Required vs optional bundles
+
+Extend the shipped `ontologies-manifest.json` entry schema with a
+`required: boolean` field. The required set is conservative:
+
+| Bundle | Required | Why |
+|---|---|---|
+| `prov-o` | **yes** | PROV1 audit-trail interop |
+| `dublin-core` | **yes** | DCAT / RO-Crate baseline |
+| `skos` | (added) **yes** | every other ontology refers to `skos:Concept` |
+| all others | no | operator choice |
+
+Disabling a `required: true` bundle is **refused** — both the
+admin endpoint and the CLI return RFC 7807 with
+`semantic.bundle.required-cannot-disable`.
+
+### 2.2 Runtime state — `:SemanticConfig` singleton
+
+A new `:SemanticConfig` Neo4j entity (`HasAppId`, but
+single-instance per the A3b feature-toggle pattern). Fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `disabledBundles` | `Set<String>` | bundle ids the operator has disabled; `required: true` bundles are never honoured here |
+| `customBundles` | `Set<String>` | ids of operator-added bundles (the actual files live under `user-dir`, see §2.3) |
+| `updatedAt` / `updatedBy` | audit fields | who flipped what when |
+
+V## migration: `Vnn__Add_appId_constraint_SemanticConfig.cypher`
+(idempotent constraint add) + a startup hook that ensures exactly
+one node exists.
+
+### 2.3 Custom-bundle storage
+
+New config key
+`shepard.semantic.internal.preseed-ontologies.user-dir`
+(default `/var/lib/shepard/ontologies/`). Layout:
+
+```
+/var/lib/shepard/ontologies/
+├── user-manifest.json       # mirrors the shipped manifest shape
+├── lab-vocab.ttl
+└── custom-units.ttl
+```
+
+`user-manifest.json` schema is identical to the shipped one, with
+two extra fields:
+
+```json
+{
+  "id": "lab-vocab",
+  "iriPrefix": "https://example.dlr.de/lab-vocab/",
+  "canonicalUrl": null,          // optional — null = "no canonical refresh; this is a local bundle"
+  "license": "CC BY 4.0",
+  "sha256": "<computed-at-add-time>",
+  "byteSize": 12345,
+  "required": false,             // operator-added bundles never required
+  "filename": "lab-vocab.ttl",
+  "addedBy": "alice",            // for the audit trail
+  "addedAt": "2026-05-13T11:32:00Z"
+}
+```
+
+`OntologySeedService` walks **built-in manifest first, user-manifest
+second**, in that order. The bundle-id namespace is shared — an
+operator trying to add a bundle with id `prov-o` is refused (409
+`semantic.bundle.id-conflicts-with-builtin`).
+
+### 2.4 Admin REST surface
+
+All under `/v2/admin/semantic/ontologies` — `@RolesAllowed("instance-admin")`.
+
+| Verb / path | What it does |
+|---|---|
+| `GET /v2/admin/semantic/ontologies` | Lists every bundle (built-in + user) with `{id, iriPrefix, license, source: "builtin"\|"user", enabled, required, lastSeededAt, sha256}` |
+| `POST /v2/admin/semantic/ontologies/{id}/enable` | Removes `{id}` from `disabledBundles` (no-op if not present). 404 on unknown id. |
+| `POST /v2/admin/semantic/ontologies/{id}/disable` | Adds `{id}` to `disabledBundles`. **409** with RFC 7807 `semantic.bundle.required-cannot-disable` if `required: true`. |
+| `POST /v2/admin/semantic/ontologies` | Upload a new bundle. **Multipart**: `file=<ttl>` + `metadata={"id":..., "iriPrefix":..., "license":...}`. Server computes SHA-256 + byteSize. Writes to `user-dir`, appends to `user-manifest.json`, adds id to `customBundles`. Triggers an immediate seed of the new bundle. Returns the new manifest entry. **409** if id collides with built-in or another user bundle; **400** if TTL parse fails. |
+| `DELETE /v2/admin/semantic/ontologies/{id}` | Remove a **user-added** bundle. Drops the file from `user-dir`, the entry from `user-manifest.json`, the id from `customBundles`. **403** with `semantic.bundle.builtin-not-removable` if the id is a built-in bundle (those land via release upgrades, not API). |
+| `POST /v2/admin/semantic/ontologies/{id}/seed` | Force a re-import of `{id}` (alias to the existing N1c refresh but per-bundle). |
+
+The existing N1c `POST /v2/admin/semantic/refresh-ontologies`
+(bulk refresh) stays — it's the "refresh everything against
+canonical URLs" path; the new per-bundle `seed` endpoint is for
+operator-driven one-off re-imports (e.g. after adding a custom
+bundle).
+
+### 2.5 CLI parity
+
+Extend the `shepard-admin semantic` subcommand group (from N1c):
+
+```
+shepard-admin semantic ontologies list
+shepard-admin semantic ontologies enable <id>
+shepard-admin semantic ontologies disable <id>
+shepard-admin semantic ontologies add <file> --id=<id> --iri-prefix=<iri> --license=<license>
+shepard-admin semantic ontologies remove <id>
+shepard-admin semantic ontologies seed <id>          # per-bundle re-import
+shepard-admin semantic refresh-ontologies             # bulk (existing, N1c)
+```
+
+Output formats: `--output={human,json}` as the rest of the CLI.
+
+### 2.6 `OntologySeedService` changes
+
+Pseudocode for the startup pass post-N1c2:
+
+```java
+SemanticConfig cfg = semanticConfigDAO.findSingleton();          // cached
+List<OntologyEntry> builtin = manifest.loadBuiltin();
+List<OntologyEntry> user    = manifest.loadUser(userDir);
+
+for (OntologyEntry e : Stream.concat(builtin.stream(), user.stream()).toList()) {
+  if (cfg.getDisabledBundles().contains(e.id())) {
+    if (e.required()) {
+      log.warn("Bundle '{}' is required; ignoring runtime disable", e.id());
+    } else {
+      log.info("Bundle '{}' is admin-disabled; skipping", e.id());
+      continue;
+    }
+  }
+  if (skipBundlesProperty.contains(e.id())) {
+    log.info("Bundle '{}' is deploy-time-skipped; skipping", e.id());
+    continue;
+  }
+  importBundle(e);
+}
+```
+
+Precedence order:
+1. **`required: true`** beats everything — required bundles are
+   always seeded.
+2. **`disabledBundles` runtime set** wins over the deploy-time CSV
+   for the same bundle (matches the A3b feature-toggle precedence).
+3. **`shepard.semantic.internal.preseed-ontologies.skip-bundles=`**
+   deploy-time CSV is the fallback / install-time defaults.
+
+### 2.7 The audit trail
+
+Every enable/disable/add/remove call fires a `PermissionsChangedEvent`-shape
+audit through the existing `ProvenanceCaptureFilter` (it's a
+mutating admin endpoint, so PROV1a captures it automatically — no
+new wiring). The actor lands on the `:Activity` row with
+`targetKind: "SemanticBundle"` and `targetAppId: <bundle-id>`.
+
+---
+
+## 3. Phasing
+
+| Slice | What it ships | Size |
+|---|---|---|
+| **N1c2-baseline** | `:SemanticConfig` entity + DAO + V## migration + `required` field on the built-in manifest + precedence rules in `OntologySeedService` | M |
+| **N1c2-admin** | The five REST endpoints (`GET`, `POST .../enable`, `POST .../disable`, `POST .../{id}/seed`, `POST /v2/admin/semantic/ontologies` upload, `DELETE`) | M |
+| **N1c2-cli** | Five new `shepard-admin semantic ontologies …` subcommands | S |
+| **N1c2-frontend** *(deferred)* | A small admin UI on `/admin` to flip toggles + upload — design only in this doc; ships when there's evidence operators want a GUI on top of the API | S–M |
+
+Recommended dispatch shape: **bundle baseline + admin + CLI into
+one slice** (they're tightly coupled), ship as a single PR. Defer
+frontend until the API is proven.
+
+---
+
+## 4. Backwards compatibility
+
+- All existing config keys keep working. The deploy-time
+  `skip-bundles=qudt,om-2` CSV stays valid and forms the install
+  defaults for `disabledBundles` on a fresh `:SemanticConfig`.
+- Fresh installs (no `:SemanticConfig` yet) — the startup hook
+  creates a node with `disabledBundles = <deploy-time CSV>`,
+  `customBundles = ∅`. Operators on the existing skip-bundles
+  workflow see no change.
+- The N1c `POST /v2/admin/semantic/refresh-ontologies` keeps its
+  semantics — it refreshes every **currently enabled** bundle
+  (per the precedence rules above) to canonical content.
+
+No data migration risk; the addition is additive and idempotent.
+
+---
+
+## 5. Out of scope (explicit)
+
+- **Per-Collection ontology selection.** All bundles are
+  instance-wide; a single n10s graph backs the internal
+  repository.
+- **Mid-stream removal of seeded data.** Disabling a bundle stops
+  it being re-imported on next restart / refresh; it does **not**
+  delete already-imported `:Resource` triples. Cleanup is a
+  separate `POST /v2/admin/semantic/ontologies/{id}/purge` design
+  (not in this slice).
+- **External-repo connectors.** This slice is internal-n10s only.
+  External `SemanticRepositoryType.SPARQL` / `JSKOS` / `SKOSMOS`
+  repos are managed via their existing CRUD (`aidocs/48`).
+
+---
+
+## 6. Cross-references
+
+- `aidocs/48-internal-semantic-repository-design.md` — n10s
+  internal repo design.
+- `aidocs/16-dispatcher-backlog.md` — N1b / ONT1a / ONT1b / N1c
+  predecessors; new N1c2 row to be added in the implementation
+  PR.
+- `aidocs/63` ADR-0019 — preseed default-on (the precedence rules
+  here extend, not supersede, that decision).
+- `aidocs/64-provenance-architecture.md` (this same PR) — the m4i
+  preseed shipped via ONT1b is exactly the kind of optional
+  bundle this slice lets an operator disable on a non-engineering
+  install.


### PR DESCRIPTION
## Summary

Two new aidocs covering provenance architecture overview + admin-configurable ontology preseed design.

### `aidocs/64-provenance-architecture.md`

Live "what shipped + where it's going" reference for the PROV1 series. Captures:

- **Shipped slices** — PROV1a (capture), PROV1b (per-entity trail), PROV1c (stats aggregation), PROV1d (Vue sparkline dashboard), PROV1f (retention), PROV1g (PROV-N JSON export)
- **Where PROV-O alone falls short** — abstract; doesn't carry method / tool / investigated-object / units / standardised role taxonomy
- **metadata4ing positioning** — NFDI4Ing's PROV-O-compatible engineering extension. ONT1b (in flight) ships it as the 10th preseed bundle; future PROV1h slice maps `:Activity` → `m4i:ProcessingStep` via content negotiation
- **HMC Kernel Information Profile** — PID-record layer that composes above m4i (`aidocs/64-hmc-kip-integration.md` design landing zone reserved)
- **Unhide harvest plugin** — `aidocs/65-unhide-publish-plugin.md` landing zone reserved
- **metadata4nfdi** — watch-only until the cross-domain layer stabilises

Recommended 4-phase path through these.

### `aidocs/65-admin-configurable-ontology-preseed.md`

Design for the **N1c2 slice** addressing user request: "make pre-seeding configurable by admin which ontologies (except required) to include; allow adding ontologies."

Key shape:

- **`required: boolean`** field on `ontologies-manifest.json`. PROV-O / Dublin Core / SKOS are required (PROV1 + RO-Crate + universal vocab base); the other seven are operator-selectable
- **`:SemanticConfig` Neo4j singleton** (`HasAppId`, single-instance per A3b pattern) — fields `disabledBundles: Set<String>`, `customBundles: Set<String>`
- **Custom-bundle storage** under `shepard.semantic.internal.preseed-ontologies.user-dir` (default `/var/lib/shepard/ontologies/`) with a sibling `user-manifest.json`
- **Five admin endpoints** under `/v2/admin/semantic/ontologies` for list / enable / disable / upload / remove / per-bundle seed, all `@RolesAllowed("instance-admin")`, RFC 7807 errors
- **CLI parity** — `shepard-admin semantic ontologies {list,enable,disable,add,remove,seed}`
- **Precedence**: required > runtime-disabled > deploy-time skip-CSV (matches A3b feature-toggle precedence)
- Backwards-compatible — existing `skip-bundles=qudt,om-2` keeps working as install defaults

Phasing: N1c2-baseline + N1c2-admin + N1c2-cli land as a single PR. Frontend deferred until API is proven.

## Test plan

- [ ] Reviewer: confirm the required-bundle set (PROV-O / Dublin Core / SKOS) — anything to add or drop?
- [ ] Confirm the precedence rules match operator expectations
- [ ] Sanity-check the user-dir path default for the deploy platform

## Note

This is a doc-only PR. Implementation is a follow-up agent dispatch (will follow this PR's merge so the design is durable before any code lands).

https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV

---
_Generated by Claude Code (orchestration session)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_