### PR TITLE
aidocs/66 + 67: HMC KIP integration + Unhide publish plugin designs

### DIFF
--- a/aidocs/66-hmc-kip-integration.md
+++ b/aidocs/66-hmc-kip-integration.md
@@ -1,0 +1,198 @@
+# 66 — HMC Kernel Information Profile integration
+
+**Status.** Design — ready for slice planning.
+**Snapshot date.** 2026-05-13.
+**Audience.** Contributors implementing PID-resolution surfaces;
+operators wondering how shepard's data shows up in cross-Helmholtz
+PID resolvers.
+
+**Originating items.** User request 2026-05-13 (KIT publication
+`10.5445/IR/1000173746` / HMC doc `10.3289/HMC_publ_03`). Couples
+to `aidocs/64-provenance-architecture.md` §4, `aidocs/31-rocrate-export.md`,
+`aidocs/63` ADR-0004 (PROV-O choice), and the future `aidocs/67`
+Unhide-publish plugin.
+
+---
+
+## 1. What HMC KIP is, in one paragraph
+
+The Helmholtz Metadata Collaboration **Kernel Information Profile**
+(KIP) defines the minimum set of properties that **every PID
+record** must carry inside the HMC ecosystem. It's the
+"dereferencing contract" — anyone who resolves a Handle/DOI minted
+under the HMC scheme gets back a predictable shape (digital-object
+type, creation date, locator, checksum, license, related identifiers).
+The aim is **cross-community findability** without forcing
+everyone onto one rich ontology. KIP doesn't describe research
+activities; it describes *the existence of a digital object*.
+
+## 2. Where it sits relative to PROV1 / metadata4ing / Unhide
+
+| Layer | What it answers | shepard surface |
+|---|---|---|
+| **PROV1** (`aidocs/55`, shipped) | *Who did what when on this shepard instance?* | `:Activity` Neo4j entity + `/v2/provenance/*` |
+| **metadata4ing** (preseed via ONT1b; PROV1h content-neg planned) | *What method, what tool, what investigated object, what units?* | `Accept: application/ld+json; profile="…/metadata4ing/"` on `/v2/provenance/*` |
+| **HMC KIP** (this doc) | *Given a PID, what kind of digital object is it and where do I get more?* | New `POST /v2/.../publish` mints a PID carrying a KIP record |
+| **Unhide harvest** (`aidocs/67`) | *Find this object across all Helmholtz centres.* | `GET /v2/unhide/feed.jsonld` — m4i-flavoured feed Unhide pulls on schedule |
+
+PROV1 → metadata4ing is **describe-richer**; metadata4ing → KIP
+is **summarise-for-resolution**; KIP → Unhide is **expose-for-discovery**.
+The four layers compose: a researcher dereferences a KIP-shaped
+PID, follows the `locator` to shepard, gets back a metadata4ing
+JSON-LD body (PROV1h), drills down into the live PROV1 activity
+trail if they want.
+
+## 3. The KIP fields, mapped to shepard
+
+Per the HMC publication, the required + recommended KIP fields and
+their shepard sources:
+
+| KIP field | Required | shepard source |
+|---|---|---|
+| `digitalObjectType` | yes | `Collection` → `dlr:Collection`; `DataObject` → `dlr:DataObject`; `FileReference` → `dlr:File`; `FileBundleReference` → `dlr:Dataset`; `LabJournalEntry` → `dlr:LabJournalEntry`. Authoritative type IRI list lives in a new `aidocs/66-types.md` sub-table (placeholder; written when the slice ships). |
+| `digitalObjectLocator` | yes | Fully-qualified URL to the v2 endpoint that returns the entity, e.g. `https://shepard.example.dlr.de/v2/collections/{appId}` |
+| `dateCreated` | yes | Audit-trail `createdAt` from `BasicEntityIO` |
+| `dateModified` | recommended | `updatedAt` from `BasicEntityIO` |
+| `checksum` | recommended | For file-shaped objects only: `ShepardFile.md5` (already on the wire). Container-shaped objects (DataObject / Collection) emit `null` per the KIP "if applicable" semantics. |
+| `policy` | recommended | License string from `Collection` if set; otherwise the instance default from a new `shepard.publish.default-license` config key. |
+| `digitalObjectMutability` | recommended | `mutable` for live entities; `immutable` once snapshotted via `aidocs/41` V2 snapshot. |
+| `referencedBy` / `references` | optional | Outbound: any `:Activity` rows that `prov:used` or `prov:generated` this object. Inbound: any rows pointing AT it. Derived at publish time. |
+| `keywords` | optional | `BasicEntity.attributes["keywords"]` if present; otherwise empty. |
+
+The shapes line up cleanly because PROV1 already captures the
+identity, creation date, locator, and lineage shepard would emit;
+KIP is essentially a *projection* of what shepard already knows.
+
+## 4. The publish surface
+
+### 4.1 `POST /v2/{kind}/{appId}/publish`
+
+Mints a PID and returns the KIP record. `kind` is one of
+`collections`, `dataobjects`, `bundles`, `files`,
+`lab-journal-entries`.
+
+**Auth.** Caller must hold **Manage** on the parent Collection
+(or on the entity itself for top-level Collections).
+
+**Body** (optional):
+```json
+{
+  "pidScheme": "handle" | "doi",       // default 'handle'
+  "license": "CC-BY-4.0",              // overrides defaulted
+  "keywords": ["foo", "bar"]           // overrides Collection.attributes.keywords
+}
+```
+
+**Response.** RFC 7807-shaped on errors; KIP JSON on success:
+```json
+{
+  "pid": "21.11125/abcd-efgh",
+  "kipRecord": {
+    "digitalObjectType": "http://shepard.dlr.de/types/dlr:Collection",
+    "digitalObjectLocator": "https://shepard.example.dlr.de/v2/collections/01HF…",
+    "dateCreated": "2026-01-15T10:23:00Z",
+    "dateModified": "2026-05-13T08:11:00Z",
+    "checksum": null,
+    "policy": "CC-BY-4.0",
+    "digitalObjectMutability": "mutable",
+    "referencedBy": [],
+    "references": [],
+    "keywords": ["foo", "bar"]
+  }
+}
+```
+
+**Side effects.** Stamps `pidScheme`, `pid`, `publishedAt`,
+`publishedBy` properties onto the entity. Fires a
+`PermissionsChangedEvent`-shape audit (PROV1a captures it as a
+`Publish` activity). Idempotent — second call for an already-published
+entity returns the existing record without re-minting.
+
+### 4.2 `GET /v2/.well-known/kip/{pid-suffix}`
+
+The dereferencing endpoint that resolves a PID-suffix back to its
+KIP record. Public (`@PermitAll`). Returns 404 if the PID isn't
+known to this instance.
+
+**Use case.** A Helmholtz PID resolver gets a query for
+`21.11125/abcd-efgh`, the registered locator points at
+`https://shepard.example.dlr.de/v2/.well-known/kip/21.11125/abcd-efgh`,
+shepard returns the KIP record without authentication.
+
+**Permission posture.** Public by design — KIP records are
+findability metadata, not the underlying data. The KIP record's
+`digitalObjectLocator` points at the entity URL which **is**
+permission-gated; an anonymous resolver gets the KIP record but
+hits 401 on the locator if they're not authorised. This mirrors
+the AAS `/v2/aas/.well-known/aas-server` posture (`aidocs/52 §4a.5`).
+
+### 4.3 `GET /v2/{kind}/{appId}/kip`
+
+The authoritative KIP-record view for a known entity. Used by
+the Unhide feed (`aidocs/67`) and by curious clients walking the
+PROV1h activity trail.
+
+Permission-gated (Read on the parent Collection).
+
+## 5. PID-minting integration
+
+Three minter shapes considered:
+
+| Option | Notes |
+|---|---|
+| **(a) Built-in mock minter** | `shepard.publish.minter=mock` (default). Generates `21.shepard/<appId>` as a synthetic Handle. Useful for dev / casual installs. No external dependency. |
+| **(b) ePIC handle service** | `shepard.publish.minter=epic` + creds. Mints real Handles via the ePIC REST API (the standard Helmholtz path). |
+| **(c) DataCite REST** | `shepard.publish.minter=datacite` + creds. Mints DOIs. Useful when an instance is publishing journal-paper-shaped data. |
+
+Pick **all three** behind a `Minter` interface — small adapter
+seam mirroring `aidocs/16` G1b's `GitAdapter` shape. Operators
+pick at install time; the in-process behaviour is identical.
+
+## 6. Storage
+
+New nullable properties on `BasicEntity` (or whichever common
+ancestor is right):
+
+```java
+@Property private String pid;            // e.g. "21.11125/abcd-efgh"
+@Property private String pidScheme;      // "handle" | "doi" | "mock"
+@Property private Date   publishedAt;
+@Property private String publishedBy;    // username
+```
+
+V## migration adds the four properties; backfill not needed (all
+nullable; pre-PID rows simply don't have them).
+
+Index on `pid` for the `.well-known/kip/{pid-suffix}` lookup.
+
+## 7. Phasing
+
+| Slice | What it ships | Size |
+|---|---|---|
+| **KIP1a-baseline** | Property addition + V## migration + `POST /v2/{kind}/{appId}/publish` + `GET /v2/{kind}/{appId}/kip` + mock minter only + `PublishService` + tests | M |
+| **KIP1b-resolver** | `GET /v2/.well-known/kip/{pid-suffix}` + public-endpoint registry entry | S |
+| **KIP1c-epic** | ePIC adapter behind the `Minter` interface; config keys; integration test against ePIC staging | M |
+| **KIP1d-datacite** | DataCite adapter | M; gated on operator demand |
+| **KIP1e-frontend** | Vue "Publish" button on Collection / DataObject panes with the licence picker | S |
+| **KIP1f-unpublish** | `DELETE` the publish state — retain the PID record (KIP records are append-only by convention) but mark `digitalObjectMutability: "retired"`. **Open question** — confirm with maintainer. | S |
+
+Recommended order: **KIP1a → KIP1b → KIP1c → KIP1e → KIP1d → KIP1f**.
+
+## 8. Cross-references
+
+- `aidocs/55` PROV1 — provenance-captured publish action.
+- `aidocs/64` provenance-architecture — positioning KIP relative to
+  PROV-O and m4i.
+- `aidocs/67` Unhide plugin — the natural downstream consumer of
+  the KIP record (the feed cites the PID + locator).
+- `aidocs/31` RO-Crate export — KIP record gets embedded as a
+  `Person` / `Organization` / `DigitalObject` entity in the
+  RO-Crate manifest when published Collections are exported.
+- `aidocs/52` AAS — the `.well-known` posture is borrowed from
+  AAS1-well-known.
+
+External:
+- [HMC KIP — KIT publication](https://publikationen.bibliothek.kit.edu/1000173746)
+- [HMC publication DOI](https://doi.org/10.3289/HMC_publ_03)
+- [ePIC handle service](http://www.pidconsortium.net/)
+- [DataCite REST API](https://support.datacite.org/docs/api)

--- a/aidocs/67-unhide-publish-plugin.md
+++ b/aidocs/67-unhide-publish-plugin.md
@@ -1,0 +1,305 @@
+# 67 — Unhide publish plugin (Helmholtz Knowledge Graph integration)
+
+**Status.** Design — ready for slice planning.
+**Snapshot date.** 2026-05-13.
+**Audience.** Contributors implementing the Helmholtz KG harvest
+seam; operators wondering how a shepard install shows up in
+`unhide.helmholtz-metadaten.de`.
+
+**Originating items.** User request 2026-05-13 ("plugin
+integrating publishing data to docs.dev.unhide.helmholtz-metadaten.de").
+Couples to `aidocs/64` provenance-architecture §4.1, `aidocs/66`
+HMC KIP integration, `aidocs/47` PayloadKind / PayloadStorage SPI,
+and `aidocs/16` ONT1b (metadata4ing preseed).
+
+---
+
+## 1. What Unhide is, in one paragraph
+
+The Helmholtz Knowledge Graph (HKG, also called **Unhide**) is a
+queryable graph aggregating digital assets across the Helmholtz
+Association. Each Helmholtz centre that wants to participate
+registers as a **data provider**. Unhide harvests their metadata
+on a schedule, runs **inward mappings** against an internal data
+model, and lands the harmonised triples in the graph. Consumers
+query via SPARQL (QLever for performance, Virtuoso for features)
+or the web UI at `unhide.helmholtz-metadaten.de`. Unhide is
+**harvest-pull**, never push — shepard never runs code in
+Unhide's infrastructure; it exposes a feed; Unhide reads.
+
+## 2. The integration shape
+
+A first-class shepard **plugin** under the `aidocs/47` PayloadKind
+SPI seam, packaged as `shepard-plugin-unhide`. The plugin:
+
+1. **Exposes a feed endpoint** — `GET /v2/unhide/feed.jsonld` (or
+   the equivalent NQUADS / Turtle serialisation via content
+   negotiation) — listing every Collection (and optionally
+   DataObject) flagged for publication.
+2. **Honours an `If-Modified-Since` / `since=` query param** —
+   Unhide harvests incrementally; the feed pages large catalogues.
+3. **Cites a KIP record per entity** — the feed entry's `dct:identifier`
+   is the PID minted by `aidocs/66`'s `POST /v2/.../publish`; the
+   `dcat:landingPage` is the shepard-locator URL.
+4. **Body shape** is **schema.org + metadata4ing JSON-LD** — Unhide's
+   inward-mappings already handle schema.org (`@type: Dataset`)
+   and m4i terms (`m4i:ProcessingStep`, `m4i:Method`); the feed
+   uses both so the rich provenance + the discoverability shell
+   compose cleanly.
+
+The plugin shape (vs in-tree code) matches `aidocs/47 §3.2`'s
+"plugin from day 1" guidance for new payload-kind-style additions.
+
+## 3. The publish toggle
+
+Reuse the `:CollectionProperties` entity from **CP1a** (already
+shipped). Add a `publishToHelmholtzKG: boolean` flag (defaults
+`false` — operators opt in per Collection):
+
+```cypher
+MATCH (c:Collection {appId: $appId})-[:HAS_PROPERTIES]->(p:CollectionProperties)
+SET p.publishToHelmholtzKG = $flag
+```
+
+REST surface: extend the existing `PATCH /v2/collections/{appId}/properties`
+to accept the new field (CP1b's PATCH already exists; this is just
+one more field).
+
+Permission posture: requires **Manage** on the Collection (matches
+CP1b semantics).
+
+A Collection with `publishToHelmholtzKG = true` AND a minted PID
+(per KIP1a from `aidocs/66`) appears in the feed. Collections
+without a PID are skipped (cleanly, no warning — the operator
+opted in to publishing but hasn't pressed the "publish" button
+yet).
+
+## 4. The feed shape
+
+### 4.1 Top-level structure
+
+`GET /v2/unhide/feed.jsonld` — pagination follows the existing
+`?cursor=&size=` shape (per `aidocs/13 §2.6`'s cursor convention).
+
+```json
+{
+  "@context": [
+    "https://schema.org/",
+    "http://w3id.org/nfdi4ing/metadata4ing/1.4.0/",
+    {
+      "shepard": "http://shepard.dlr.de/types/",
+      "dcat": "http://www.w3.org/ns/dcat#",
+      "prov": "http://www.w3.org/ns/prov#"
+    }
+  ],
+  "@graph": [
+    {
+      "@id": "https://shepard.example.dlr.de/v2/collections/01HF…",
+      "@type": ["schema:Dataset", "m4i:Dataset"],
+      "dct:identifier": "https://hdl.handle.net/21.11125/abcd-efgh",
+      "dcat:landingPage": "https://shepard.example.dlr.de/v2/collections/01HF…",
+      "schema:name": "Cyclic-fatigue test campaign 2026-Q1",
+      "schema:description": "…",
+      "schema:dateCreated": "2026-01-15T10:23:00Z",
+      "schema:license": "https://creativecommons.org/licenses/by/4.0/",
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "@id": "https://orcid.org/0000-0002-1825-0097",
+          "schema:name": "Alice Researcher"
+        }
+      ],
+      "m4i:hasProcessingStep": [
+        {
+          "@id": "https://shepard.example.dlr.de/v2/provenance/entity/01HF…",
+          "@type": "m4i:ProcessingStep"
+        }
+      ]
+    },
+    …
+  ],
+  "_meta": {
+    "lastModified": "2026-05-13T05:11:00Z",
+    "nextCursor": "eyJpZCI6Li4uLCJ0cyI6Li4ufQ=="
+  }
+}
+```
+
+### 4.2 Per-entity expansion
+
+Each entry's body is the union of:
+
+- **schema.org core** — `name`, `description`, `creator`, `dateCreated`,
+  `dateModified`, `keywords`, `license`, `identifier`, `landingPage`.
+  Maps directly from shepard's `Collection` / `DataObject` fields.
+- **m4i provenance** — `m4i:hasProcessingStep` references back to
+  the PROV1h-rendered activity trail (`/v2/provenance/entity/{appId}`
+  with `Accept: application/ld+json; profile=…m4i…`). Unhide can
+  follow the link to enrich its graph.
+- **KIP record reference** — the PID + locator pair embedded
+  directly.
+
+### 4.3 Harvest cadence
+
+Default Unhide harvest cadence is **daily** per their docs. The
+feed sets `Last-Modified` + supports `If-Modified-Since` so an
+unchanged feed returns `304` instead of the full body.
+
+## 5. Configuration — admin-controllable at runtime
+
+The Unhide integration is **admin-configurable at runtime** (per
+user direction, 2026-05-13), mirroring the A3b runtime feature-toggle
+pattern + N1c2 `:SemanticConfig` shape. No restart needed to
+enable / disable publishing, change the feed visibility, or
+update the contact email.
+
+### 5.1 The runtime state — `:UnhideConfig` singleton
+
+A new `:UnhideConfig` Neo4j entity (`HasAppId`, single-instance per
+the A3b feature-toggle pattern). Fields:
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `enabled` | `boolean` | `false` | Master runtime toggle. When `false`, `/v2/unhide/feed.jsonld` returns `404` (feature-off). |
+| `feedPublic` | `boolean` | `false` | If `true`, the feed is `@PermitAll`. If `false`, requires the `harvest` API-key role. Default `false` because feed metadata may be licensed; operators opt in to public exposure. |
+| `contactEmail` | `String` | `null` | Surfaced in the feed `_meta` so Unhide's harvester knows whom to ping. |
+| `harvestKeyAppId` | `String` | `null` | `appId` of the API key Unhide's harvester uses (when `feedPublic=false`). Set when the operator mints / rotates the harvester key. |
+| `lastPublishedAt` | `Date` | `null` | Latest `dateModified` across published Collections — feeds `Last-Modified` header / `If-Modified-Since` short-circuit. Maintained by the publish path, not the admin API. |
+| `updatedAt` / `updatedBy` | audit fields | — | who flipped what when. |
+
+V## migration: `Vnn__Add_appId_constraint_UnhideConfig.cypher`
+(idempotent constraint add) + a startup hook ensuring exactly one
+node exists. Pre-Unhide installs see no change until they flip
+the toggle.
+
+### 5.2 Deploy-time fallbacks (`application.properties`)
+
+These remain as **install-time defaults** — the runtime
+`:UnhideConfig` overrides them once the operator touches the admin
+API. Same precedence pattern as A3b feature toggles and N1c2
+preseed config.
+
+| Key | Default | Purpose |
+|---|---|---|
+| `shepard.unhide.enabled` | `false` | Install default for the master toggle (seeds `:UnhideConfig.enabled` on first start). |
+| `shepard.unhide.feed.public` | `false` | Install default for feed-public flag. |
+| `shepard.unhide.contact-email` | (empty) | Install default for the contact email. |
+| `shepard.unhide.feed.page-size` | `100` | Cursor-paginated page size. **Not runtime-mutable** (no operator demand for per-page-size tuning; revisit if needed). |
+
+Precedence:
+1. **Runtime `:UnhideConfig` value** wins for the mutable fields
+   (enabled / feedPublic / contactEmail / harvestKeyAppId).
+2. **Deploy-time property** is the fallback (used on a fresh
+   install with no `:UnhideConfig` row yet, and as the seed value
+   for the singleton at startup).
+3. `page-size` stays deploy-time only.
+
+### 5.3 Per-Collection toggle (unchanged from §3)
+
+`:CollectionProperties.publishToHelmholtzKG = true|false` —
+already admin-controllable via the existing CP1b `PATCH
+/v2/collections/{appId}/properties` (requires Manage on the
+Collection).
+
+## 6. Admin API + CLI
+
+Mirroring A3b features + N1c semantic-refresh shapes. All under
+`/v2/admin/unhide` — `@RolesAllowed("instance-admin")`.
+
+| Verb / path | What it does |
+|---|---|
+| `GET /v2/admin/unhide/config` | Returns the current `:UnhideConfig` shape (without `harvestKeyAppId` content — just whether one's set). |
+| `PATCH /v2/admin/unhide/config` | RFC 7396 merge-patch on `enabled`, `feedPublic`, `contactEmail`, `harvestKeyAppId`. Returns the updated config. Fires a `PermissionsChangedEvent` (PROV1a captures it as an admin action). |
+| `POST /v2/admin/unhide/harvest-key` | Mints a fresh API key with the `harvest` role and sets `:UnhideConfig.harvestKeyAppId` to its appId. Returns the JWT once (clipboard-shaped) per the existing ApiKey pattern. Rotates if one already exists. |
+| `DELETE /v2/admin/unhide/harvest-key` | Revokes the current harvest key + clears `harvestKeyAppId`. |
+
+**CLI parity** — extend `shepard-admin` with a new `unhide`
+subcommand group:
+
+```
+shepard-admin unhide status                               # show current config
+shepard-admin unhide enable                               # flip enabled → true
+shepard-admin unhide disable                              # flip enabled → false
+shepard-admin unhide set-feed-public <true|false>
+shepard-admin unhide set-contact-email <email>
+shepard-admin unhide rotate-harvest-key                   # POST /v2/admin/unhide/harvest-key
+shepard-admin unhide revoke-harvest-key                   # DELETE /v2/admin/unhide/harvest-key
+```
+
+All commands honour `--output={human,json}` per the existing CLI
+convention.
+
+### 6.1 Audit trail
+
+Every PATCH / harvest-key mint / revoke fires through the existing
+`ProvenanceCaptureFilter` (it's a mutating admin endpoint, so PROV1a
+captures it automatically — no new wiring). The `:Activity` row
+carries `targetKind: "UnhideConfig"` so the audit trail can be
+filtered for "who changed Unhide settings when".
+
+## 7. The Unhide self-registration step
+
+shepard doesn't run code in Unhide. To get harvested, the
+operator does one of:
+
+- **Self-service.** Visit
+  `unhide.helmholtz-metadaten.de/dataprovider/register`,
+  submit the shepard feed URL + contact, wait for HMC team to
+  approve.
+- **HMC outreach.** HMC's data-provider liaison reaches out to
+  Helmholtz centres directly. shepard installs in the wild get
+  approached when the install becomes operator-visible.
+
+shepard's job: emit the feed at a stable URL. Discovery is the
+operator's responsibility.
+
+## 8. The data flow, end to end
+
+```
+Operator → CP1b PATCH → publishToHelmholtzKG=true
+       ↓
+Operator → POST /v2/collections/{appId}/publish → PID minted (KIP1a)
+       ↓
+       shepard exposes /v2/unhide/feed.jsonld with this Collection in the @graph
+       ↓
+Unhide harvester (daily cron) → GET /v2/unhide/feed.jsonld?cursor=…
+       ↓
+       Unhide's inward-mappings extract schema.org + m4i terms
+       ↓
+       Triples land in the Helmholtz KG (Virtuoso + QLever)
+       ↓
+External researcher → SPARQL on Unhide → finds this Collection
+       ↓
+       Click landing page → arrives at shepard's /v2/collections/{appId}
+       ↓
+       Read-permission check → 200 (if public/auth'd) or 401
+```
+
+## 9. Phasing
+
+| Slice | What it ships | Size |
+|---|---|---|
+| **UH1a-baseline** | Plugin module `shepard-plugin-unhide` + the feed endpoint emitting schema.org-only entries + `:CollectionProperties.publishToHelmholtzKG` field via CP1b PATCH + cursor pagination + **`:UnhideConfig` singleton (§5.1) + admin REST surface (§6) + CLI parity** (the admin-configurable shape lands together with the baseline, not as a follow-up — operators need it from day one to flip the master toggle without restarting) | M |
+| **UH1b-m4i** | Extend the feed body with m4i provenance fragments — depends on **PROV1h** content-neg shipping (so the feed can link back to m4i-shaped `/v2/provenance/entity/{appId}`) | S |
+| **UH1c-kip** | Feed cites KIP record (PID + locator) per entity — depends on **KIP1a** | S |
+| **UH1d-frontend** | Per-Collection "Publish to Helmholtz KG" toggle in the UI (alongside the existing CP1b properties pane) + admin `/admin` page tile for the instance-wide toggles (mirrors A3b1 admin metrics strip placement) | S–M |
+| **UH1e-self-test** | `GET /v2/unhide/feed.jsonld?validate=true` returns a SHACL validation report against Unhide's expected shape — diagnostic for operators | S |
+
+Recommended order: **UH1a → UH1d → UH1c → UH1b → UH1e**. UH1a is
+useful even without KIP / PROV1h ready (and ships with the
+runtime admin surface so an operator can flip the master toggle
+without restarting); UH1c gates on KIP1a.
+
+## 10. Cross-references
+
+- `aidocs/64` provenance-architecture §4.1 — positioning Unhide
+  as the harvest layer above metadata4ing + KIP.
+- `aidocs/66` HMC KIP — the PID record format Unhide cites.
+- `aidocs/47 §3.2` — plugin-from-day-1 SPI seam.
+- `aidocs/55` PROV1 — provenance trail Unhide can drill into.
+
+External:
+- [Helmholtz Knowledge Graph docs](https://docs.unhide.helmholtz-metadaten.de/)
+- [Unhide data-storage API](https://codebase.helmholtz.cloud/hmc/hmc-public/unhide/development/data_storage_api)
+- [Unhide internal data model](https://codebase.helmholtz.cloud/hmc/hmc-public/unhide/development/semantics/internal-data-model)
+- [Unhide inward mappings](https://codebase.helmholtz.cloud/hmc/hmc-public/unhide/development/semantics/inwardmappings)


### PR DESCRIPTION
## Summary

Two design docs completing the four-layer Helmholtz-ecosystem framing laid out in `aidocs/64-provenance-architecture.md` (PR #1095, in flight). No code; design-only.

### `aidocs/66-hmc-kip-integration.md`

Helmholtz Metadata Collaboration **Kernel Information Profile** — the PID dereferencing contract that every Helmholtz centre's data should answer to. Design covers:

- **Field mapping** from shepard's `BasicEntity` to KIP slots (`digitalObjectType`, `digitalObjectLocator`, `dateCreated`, `dateModified`, `checksum`, `policy`, `digitalObjectMutability`, `referencedBy`/`references`, `keywords`)
- **`POST /v2/{kind}/{appId}/publish`** mints a PID and returns a KIP record; idempotent; permission-gated (Manage)
- **`GET /v2/.well-known/kip/{pid-suffix}`** public resolver endpoint (matches the AAS1-well-known posture from `aidocs/52 §4a.5`)
- **`GET /v2/{kind}/{appId}/kip`** authenticated KIP view (used by the Unhide feed)
- **Three minter shapes** behind a `Minter` interface seam: `mock` (dev default), `ePIC` (Helmholtz-standard Handle service), `DataCite` (DOIs). Mirrors G1b's `GitAdapter` adapter pattern.
- Phased **KIP1a-f** with recommended order: baseline → resolver → ePIC → frontend → DataCite → unpublish.

### `aidocs/67-unhide-publish-plugin.md`

shepard becomes a data provider to the Helmholtz Knowledge Graph (Unhide) via a **harvest-pull plugin** under `aidocs/47`'s PayloadKind SPI seam.

- **`GET /v2/unhide/feed.jsonld`** — paginated, `If-Modified-Since`-aware, role-gated; emits schema.org + m4i JSON-LD with per-Collection entries citing KIP records
- **Reuses `:CollectionProperties` (CP1a-shipped)** — adds `publishToHelmholtzKG: boolean` flag; PATCH via CP1b's existing endpoint
- **Plugin-from-day-1** packaging — `shepard-plugin-unhide` lives outside the backend core (per `aidocs/47 §3.2`)
- **End-to-end flow** traced from operator action through Unhide harvest to external SPARQL query
- Phased **UH1a-e**; UH1a (schema.org-only feed) is useful standalone, UH1b/c gate on PROV1h / KIP1a respectively

## Why this matters

PR #1095 (aidocs/64) introduces the four-layer composition framing:

```
PROV-O audit (PROV1, shipped)
  → m4i description (ONT1b preseed shipped; PROV1h content-neg next)
    → KIP PID record (this doc, aidocs/66)
      → Unhide harvest (this doc, aidocs/67)
```

aidocs/66 and aidocs/67 close out the design-doc coverage of that path. Implementation slices are scoped + sequenced so future contributors can pick them up without re-deriving the layering decision.

## Test plan

- [ ] Reviewer: confirm the KIP field-mapping table matches your reading of the HMC publication
- [ ] Reviewer: confirm the Unhide feed shape (schema.org + m4i JSON-LD with KIP citation) aligns with what an Unhide data-provider registration expects
- [ ] Reviewer: pick a phasing order if it differs from the recommended baseline → resolver → ePIC progression

## Note

Doc-only PR. Implementation slices land separately when scheduled.

https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV

---
_Generated by Claude Code (orchestration session)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_