### PR TITLE
CLAUDE.md: plugin-first + admin-configurable rules + aidocs/68 overview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,3 +195,115 @@ feature-matrix currency (`aidocs/44`) rules above.
 (Internal refactors, performance work, security fixes, dependency
 bumps — none of these need a docs update unless they change a
 user-visible behaviour.)
+
+## Always: think plugin-first for new features
+
+The `aidocs/47 §2` PayloadKind / PayloadStorage SPI seam exists
+**because** shepard's value grows from extension, not from a
+monolithic core. When adding a new feature, the default question
+is "should this be a plugin?" — **not** "should this be in-tree?"
+
+The plugin-first heuristic, in order:
+
+1. **New payload kinds** (HDF5, video, AAS submodels, lab-bench
+   recordings, …) → **plugin from day one**. The SPI is the
+   reason; resist the temptation to add a one-off `data/<kind>/`
+   sibling to `data/file` / `data/timeseries` / etc.
+2. **New external integrations** (Helmholtz Unhide harvest feed,
+   git host adapters, AAS registry sync, Databus catalogue,
+   DBpedia rich references, …) → **plugin shape**. They have
+   their own release cadence, their own dependency tree, and
+   their own failure modes; isolating them from core is the
+   structural fix.
+3. **New cross-cutting infrastructure** (`PayloadKind` SPI,
+   `FileStorage` SPI, `Minter` interface, `GitAdapter`
+   interface, `SemanticConnector` interface) → **in-tree
+   interfaces** + **plugin implementations**. The interface
+   stays in core (so every plugin compiles against it); the
+   adapters live outside.
+4. **Domain features that touch existing payload kinds** —
+   default in-tree, but ask: is there a clean seam where this
+   could be a plugin? If yes, prefer the plugin even at slightly
+   higher friction; it pays back the moment a second team wants
+   a variant.
+
+When a design doc starts with "add a new `de.dlr.shepard.<feature>/`
+package", stop and ask whether `shepard-plugin-<feature>` is the
+right shape instead. The `aidocs/47` SPI keeps growing precisely
+because every "just add it in-tree" call accreted cost over time.
+
+The exceptions (things that stay in-tree by necessity):
+
+- Authentication / permissions surfaces (`PermissionsService`,
+  `JWTFilter`, role mechanisms) — security perimeter, not
+  pluggable.
+- Identity primitives (`appId`, `User`, `Collection`,
+  `DataObject` core graph) — the shapes every plugin compiles
+  against.
+- The runtime SPI registry itself.
+
+Everything else: **plugin first**. Cite this rule in the design
+doc; if a feature lands in-tree, the design doc must say why.
+
+## Always: surface operator knobs in the admin config
+
+Whenever a new feature ships a runtime knob — a feature toggle, a
+default that operators legitimately need to flip, an integration
+endpoint they need to authenticate, a retention window, a cap —
+the **default posture is admin-configurable at runtime**, not
+deploy-time-only.
+
+The pattern is established by:
+
+- **A3b** — `:FeatureToggleRegistry` + `GET/PATCH /v2/admin/features`
+  with CLI parity.
+- **N1c2** — `:SemanticConfig` singleton + `/v2/admin/semantic/ontologies`
+  enable/disable/upload/remove + CLI parity (`aidocs/65`).
+- **UH1a** — `:UnhideConfig` singleton + `/v2/admin/unhide/config`
+  PATCH + CLI parity (`aidocs/67 §5–6`).
+
+The shape:
+
+- A small `:*Config` Neo4j entity (`HasAppId`, single-instance
+  per the A3b pattern). Field set is the runtime-mutable subset
+  of the feature's knobs.
+- `GET /v2/admin/<feature>/config` returns the current shape.
+- `PATCH /v2/admin/<feature>/config` (RFC 7396 merge-patch,
+  `@RolesAllowed("instance-admin")`) flips fields at runtime.
+- Optional sister endpoints for mint-and-rotate of feature-bound
+  credentials (per-feature `harvest` API keys, per-feature
+  signing keys, …).
+- CLI parity under `shepard-admin <feature> {status,enable,
+  disable,set-<field>,…}` with shared `--output={human,json}` +
+  `--url` + `--api-key` flags (per the L1 baseline).
+- Precedence: **runtime `:*Config` value wins**; deploy-time
+  `application.properties` is the install default that seeds the
+  singleton on first start. The deploy-time key stays valid so an
+  operator can ship a baked-in default in their IaC, but it
+  doesn't override a runtime flip.
+- Mutations land in `:Activity` via `ProvenanceCaptureFilter`
+  (PROV1a, automatic — admin endpoints capture by default), so
+  the audit trail can be filtered for "who changed `<feature>`
+  settings when".
+
+When a design doc proposes a new `shepard.<feature>.*`
+deploy-time-only config key, ask: is there a use case for an
+operator to flip this without a restart? If yes, the design must
+include the `:*Config` + admin REST + CLI parity from day one —
+not as a follow-up.
+
+The exceptions (knobs that legitimately stay deploy-time-only):
+
+- Cluster identity / topology (`shepard.instance.id`, DB URLs,
+  the OIDC issuer URL) — these can't be flipped at runtime
+  without re-bootstrapping.
+- Pre-startup ordering invariants (`shepard.migrations.*`,
+  `shepard.health.recovery.interval`) — the runtime hook runs
+  before the DB is up.
+- Buffer sizes / page sizes where there's no operator need to
+  tune at runtime (e.g. `shepard.unhide.feed.page-size`).
+
+Everything else: **admin-configurable at runtime**. The same
+durability test applies — if the design doc only ships
+deploy-time-only config and there's no exception reason, the
+review should send it back for the `:*Config` shape.

--- a/aidocs/68-plugin-vs-core-overview.md
+++ b/aidocs/68-plugin-vs-core-overview.md
@@ -1,0 +1,213 @@
+# 68 — Plugin-vs-core architecture overview
+
+**Status.** Discussion draft.
+**Snapshot date.** 2026-05-13.
+**Audience.** Maintainer + contributors. The frame for "what's
+core, what's a plugin, what should move."
+
+**Originating items.** User direction 2026-05-13 ("write an
+overview over plugins and core features. we will discuss") +
+CLAUDE.md's new "always think plugin-first" rule. Couples to
+`aidocs/47` (PayloadKind / PayloadStorage SPI), `aidocs/45`
+(FileStorage SPI), `aidocs/38` (Git integration / `GitAdapter`),
+`aidocs/57` (client generators / `Minter`-shape adapters),
+`aidocs/66`/`67` (KIP + Unhide).
+
+---
+
+## 1. The frame
+
+Three buckets:
+
+| Bucket | What lives there | Reversibility of choice |
+|---|---|---|
+| **Core** | Things every shepard install runs. Auth, permissions, the entity graph, the SPI registry. Removing core breaks the product. | hard / one-way |
+| **Plugin-by-interface** | Implementations swapped behind an in-tree interface. Different installs choose different plugins; some installs run none. The interface stays in core. | moderate — interface is durable, implementation isn't |
+| **Plugin-by-package** | Standalone modules (`shepard-plugin-*`) consumed via discovery / a registry. Operators pick which to deploy. | easy — install / uninstall doesn't touch core |
+
+The slippery shapes are at the **core ↔ plugin-by-interface**
+boundary (the interface is part of core but does the implementation
+need to live in-tree?) and at the **plugin-by-interface ↔
+plugin-by-package** boundary (when does a swappable adapter
+graduate to a separate module?).
+
+## 2. Current state — what's where
+
+### 2.1 Identifiably core
+
+| Surface | Why core |
+|---|---|
+| `auth/*` — JWT filter, API-key auth, OIDC integration | Security perimeter; pluggable auth is a different product. |
+| `permission/*` — `PermissionsService`, `Roles`, `:HAS_ROLE` graph | Permission enforcement is the only enforcement point; replicating into plugins multiplies trust boundaries. |
+| `Collection` / `DataObject` / `User` / `BasicEntity` / `appId` (L2 chain) | The graph shape every plugin compiles against. |
+| `:Activity` (PROV1) capture filter | Cross-cutting audit; capturing in-tree means every endpoint contributes automatically. |
+| `MigrationsRunner`, the V## migration system | Startup-ordering invariants; plugins can declare migrations but the runner is core. |
+| The SPI registry itself (`PayloadKindRegistry`, future `MinterRegistry`, future `AdapterRegistry` family) | Discovery is core; the things discovered are plugins. |
+
+These shouldn't move. The CLAUDE.md "plugin-first" rule explicitly
+exempts them.
+
+### 2.2 Plugin-by-interface (interface in core, swappable implementations)
+
+| Interface | Implementations on / planned | Status |
+|---|---|---|
+| **`GitAdapter`** (`context/references/git/adapters/`) | GitLab (G1b ✓), GitHub + Gitea (G1d ✓), Codeberg/Forgejo via host-CSV widener | shipped; the seam is durable |
+| **`Minter`** (`aidocs/66 §5`) | mock (default), ePIC (Handle), DataCite (DOI) | designed (KIP1a) — interface lands in core; ePIC + DataCite are operator-selectable |
+| **`GitAdapter` for non-git protocols?** | (hypothetical) — out of scope today | n/a |
+| **`SemanticConnector`** (`context/semantic/`) | Internal n10s (N1a ✓), external SPARQL (existing), JSKOS / SKOSMOS (existing) | shipped pre-fork; the seam is durable |
+| **`FileStorage`** (`aidocs/45` FS1 design) | GridFS (existing, in-tree), S3/MinIO (FS1b designed) | designed; interface introduction is in-tree |
+| **`PayloadKind` + `PayloadStorage`** (`aidocs/47 §2`) | file, structured, spatial, timeseries, HDF5 (planned plugin), video (planned plugin), git (could be) | designed; not yet introduced as the kind-discovery seam |
+
+The interface-in-core pattern is the right shape for adapters
+where the **failure mode of a missing plugin is "feature off"**
+rather than "shepard won't start."
+
+### 2.3 Plugin-by-package (separate `shepard-plugin-*` modules)
+
+Currently shipping:
+
+- **None.** All "plugin-by-package" candidates today are
+  designed-not-yet-shipped.
+
+Designed / planned:
+
+| Plugin | Source aidoc | Status |
+|---|---|---|
+| `shepard-plugin-hdf-hsds` | `aidocs/35` (A5 series) | partially shipped in-tree as `data/hdf` (A5a ✓ + A5b ✓); should be **extracted to a plugin** when PayloadKind SPI (`aidocs/47` PL1a) lands |
+| `shepard-plugin-video` | `aidocs/53 §2` (VID1 series) | designed; ships as a plugin from day one |
+| `shepard-plugin-unhide` | `aidocs/67` | designed; ships as a plugin (UH1a) |
+| `shepard-plugin-aas` | `aidocs/52` (AAS1 series) | designed; could be plugin or in-tree per `aidocs/52` open question |
+| `shepard-plugin-ref-dbpedia-databus` | `aidocs/58 §7` | designed; explicitly plugin (REF1) |
+| `shepard-plugin-file-gridfs` + `shepard-plugin-file-s3` | `aidocs/45 §6` (FS1a/b) | designed; current GridFS is in-tree and would split |
+| `shepard-plugin-spatial-postgis` | `aidocs/47 PL1b` | designed; current spatial is in-tree and would split |
+
+### 2.4 In-tree today, **plugin candidates per the new rule**
+
+These are the items where the new CLAUDE.md "plugin-first" rule
+would have flagged the design. Most landed before the rule, so
+the question is whether to **extract** them later:
+
+| Feature | Currently | Plugin extraction cost | Recommended |
+|---|---|---|---|
+| **HDF5 / HSDS** (`data/hdf` + V25 + REST) | in-tree (A5a/b shipped) | M — move package, pin SPI version, extract config | **extract on PL1a's heels** — already smelly with HSDS sidecar |
+| **Internal semantic repository (n10s)** | in-tree (N1a/b/c shipped) | M — depends on `SemanticConnector` becoming a published SPI | **leave in-tree until external n10s clients want the SPI** — single-impl seams aren't worth the split |
+| **Spatial / PostGIS** | in-tree (legacy upstream) | M — already designed (PL1b) | **wait for PL1a** — natural extraction point |
+| **File / GridFS** | in-tree (legacy upstream) | L — biggest blast radius | **wait for FS1a** — needs the FileStorage SPI to land first |
+| **Timeseries / Timescale** | in-tree (legacy upstream) | L — heaviest entanglement (continuous aggregates, hypertable specifics) | **stays in-tree** for the foreseeable; the SPI shape isn't well-formed yet |
+| **Templates (T1)** | in-tree (T1a-d shipped) | S — small package, clean boundary | **could split** if templates become a community contribution surface; otherwise leave |
+| **PROV1 capture** | in-tree | L — would need to swap the capture filter per-install | **stays in-tree** — see §2.1 (cross-cutting audit) |
+| **Lab journal + rendering (J1)** | in-tree | M — markdown render is a `MarkdownRenderer` class, the editor UI is Vue | **leave** — single domain shape |
+
+### 2.5 Frontend
+
+Frontend (`frontend/`) is one Nuxt app, no plugin model today.
+Component-level plugins (e.g. drop-in viewers per payload kind)
+would be a substantial design — not in scope today, but worth
+noting as a future axis. The closest current shape is the per-
+DataObject "pane" pattern (FileBundleReferences pane, Git
+references pane, etc.) — each pane is one Vue component bound
+to one backend feature. **Plugin-shaped frontend** would mean
+those panes registering themselves at runtime from a manifest.
+
+## 3. The plugin-discovery shape
+
+Designed in `aidocs/47 §2.5`, not yet wired:
+
+- `shepard.plugins.<plugin-id>.enabled=true/false` config keys
+- A `PluginManifest` that each plugin emits at startup
+- The `PayloadKindRegistry` reads the manifests and binds
+  factories
+- Plugins discovered via SPI service-loader (Java's
+  `ServiceLoader` pattern over the Quarkus uber-jar shape) or
+  via separate `@QuarkusBuildItem` registration
+
+The **registry interfaces are core**; the plugin packages live
+outside. `aidocs/47` calls this DX3.
+
+The point at which "in-tree" becomes "plugin-by-package" is when
+the discovery seam lands — until then, plugins-by-interface are
+just well-structured in-tree code.
+
+## 4. Boundaries — where things tend to leak
+
+Recurring patterns that show up as design debt:
+
+| Leak | Example | Fix |
+|---|---|---|
+| **Plugin needs a Cypher migration** | HDF5 wants its own V## constraint | Plugins declare migrations under `<plugin>/src/main/resources/neo4j/migrations/`; the runner discovers across the classpath. Already works post-A1e (every classpath migration runs). |
+| **Plugin needs new IO shapes on a core endpoint** | Video extends `BasicEntityIO` with `videoOffsetMs` | Use `OutputProfile` (V2S1) to lift the kind-specific shape into a profile parameter, not a hardcoded field. |
+| **Plugin needs to fire `:Activity` events** | Unhide harvest counts as an activity? | Plugin calls the existing `ProvenanceService.recordServiceActivity(...)` — the service is core, the call site is the plugin. |
+| **Plugin needs config that survives restart** | UH1a's `enabled` toggle | Per the new "admin-configurable" rule: `:*Config` singleton, admin REST, CLI parity. |
+| **Plugin needs operator-readable docs** | Each plugin's installation runbook | One `docs/reference/plugins/<plugin-id>.md` per plugin; index in `aidocs/49 §2.2`. |
+
+## 5. Open questions for discussion
+
+1. **Should the HDF5/HSDS work (A5 series) be extracted to a
+   plugin now, or wait for PL1a?** A5a/b shipped in-tree; the
+   extraction is moderate cost and would be cleaner before A5c
+   (HdfReference) compounds the in-tree footprint.
+
+2. **Should we land PayloadKind SPI (PL1a) before the next new
+   payload kind?** Currently new payload kinds (HDF, video, git)
+   each invent their own shape. PL1a is a one-time cost that
+   pays back per kind.
+
+3. **Plugin-by-package distribution.** When plugins land,
+   how do operators install? Three shapes:
+   - Compose-side: separate `Dockerfile` per plugin, sidecar
+     extension to `backend/`. Friction high.
+   - JAR drop-in: plugin JARs into `backend/plugins/`,
+     discovered via `ServiceLoader`. Friction low; needs SPI to
+     be stable.
+   - Forked Dockerfile per install: monolithic image bakes in
+     selected plugins at build time. Friction medium; loses
+     "install/uninstall without rebuild."
+   The third is current shape (everything in-tree). The first
+   doesn't match the SPI model. The second is the design
+   target.
+
+4. **Where does the convenience-wrapper (`shepard-py` /
+   `shepard-ts`, `aidocs/27`) sit?** Currently a separate
+   layer on top of generated clients, lives in `clients/` and
+   `clients-v2/`. **Plugin-shaped?** Probably not — it's a
+   user-facing library, not a shepard-side feature. Leave as is.
+
+5. **Frontend plugins.** Worth a design doc? Or punt until a
+   real third-party Vue pane emerges?
+
+## 6. Recommended path forward
+
+In the spirit of "decisions over indecisions, with explicit
+reversibility":
+
+1. **Land PL1a (PayloadKind SPI) next** after the current open
+   queue clears. It's the gate item for half the remaining
+   plugin candidates.
+2. **Extract HDF5/HSDS to `shepard-plugin-hdf-hsds`** as the
+   first plugin-by-package; it's the cleanest test of the SPI
+   shape because the sidecar already isolates the failure mode.
+3. **Ship VID1 as a plugin from day one** (new payload kind;
+   matches the rule).
+4. **Land UH1a as a plugin from day one** (external integration;
+   matches the rule). `aidocs/67` already designs it this way.
+5. **Leave existing in-tree code in-tree** until the SPI is
+   stable enough that extraction is mechanical.
+
+The plugin-first rule applies to **new** features. Retroactively
+plugin-ifying every in-tree feature is a different (much bigger)
+exercise that should only happen when there's evidence of
+real third-party demand.
+
+## 7. Cross-references
+
+- `aidocs/47` PayloadKind / PayloadStorage SPI — the gate item.
+- `aidocs/45` FS1 — FileStorage SPI; precedes FS1a/b split.
+- `aidocs/38` Git integration — `GitAdapter` interface example.
+- `aidocs/57` Client generators — `Minter`-shape adapters; ADR-0022.
+- `aidocs/66` KIP — `Minter` interface seam.
+- `aidocs/67` Unhide — first plugin-from-day-one external integration.
+- `aidocs/52` AAS — open question whether plugin or in-tree.
+- `CLAUDE.md §"Always: think plugin-first for new features"` — the
+  rule this overview elaborates.
+- `CLAUDE.md §"Always: surface operator knobs in the admin config"` —
+  the runtime-knob durability rule.


### PR DESCRIPTION
## Summary

Two new durable rules in `CLAUDE.md`, plus a companion discussion overview:

- **"Always: think plugin-first for new features"** — codifies a four-tier heuristic (new payload kinds → plugin, new external integrations → plugin, new cross-cutting infrastructure → in-tree interface + plugin impls, domain features → default in-tree but prefer plugin where there's a clean seam). Lists the exceptions that stay in-tree (auth/permissions, identity primitives, SPI registry).
- **"Always: surface operator knobs in the admin config"** — codifies the `:*Config` Neo4j singleton + `GET/PATCH /v2/admin/<feature>/config` + CLI parity pattern established by A3b / N1c2 / UH1a. Defines precedence (runtime > deploy-time) and the legitimate deploy-time-only exceptions (cluster identity, pre-startup ordering, buffer sizes).
- `aidocs/68-plugin-vs-core-overview.md` — discussion-shaped overview frames the three buckets (Core / Plugin-by-interface / Plugin-by-package), maps current state, lists in-tree extraction candidates, and proposes a path forward (PL1a SPI first → extract HDF5/HSDS → ship VID1 + UH1a as plugins from day one).

## Test plan

- [ ] Rules are durable and reviewer-actionable (each cites concrete prior art)
- [ ] aidocs/68 cross-references resolve (`aidocs/47`, `45`, `38`, `57`, `66`, `67`)

https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNjq9bqR9LeQTk3ju6BHsV)_