### PR TITLE
fix(UX-WALK-2026-05-29-04): humanize ID-ERROR backend messages in error toast

### DIFF
--- a/aidocs/agent-findings/dispatcher-runs/2026-05-29-15.md
+++ b/aidocs/agent-findings/dispatcher-runs/2026-05-29-15.md
@@ -1,0 +1,42 @@
+---
+stage: fragment
+last-stage-change: 2026-05-29
+---
+
+# Dispatcher run — 2026-05-29 15:xx UTC
+
+## Inventory
+
+- `git log --since='2 hours ago'` showed 2 recent merges: `BTKVS-A1+A2` and `ROLE-GRANT-STALE-SESSION-03`.
+- `aidocs/16-dispatcher-backlog.md` scanned end-to-end (745 KB / ~2 229 lines).
+- Remote branches: `origin/main` only — no in-flight branches.
+
+## Rows considered
+
+| Row | Size | Decision | Reason |
+|---|---|---|---|
+| FRONTEND-LINT-DEBT-04 | XS | **Dispatched** | One bare `@ts-expect-error` in `useCollectionEvents.test.ts:196`; no gating; independent |
+| UX-WALK-2026-05-29-04 | XS | **Dispatched** | Frontend-only error-toast humanization; three affected situations; no gating |
+| FE-BUILD-01 | XS | Skipped | Already implemented (`permissionTypes.ts` exists; `mapPermissions.ts` imports from it); backlog status is stale |
+| FE-BUILD-02 | XS | Skipped | Already implemented (`searchResultTypes.ts` exists; re-export in place); backlog status is stale |
+| FE-BUILD-03 | XS | Skipped | Already implemented (cast applied in `usePagedDataObjects.ts:88-99`); backlog status is stale |
+| PERF13 | S | Skipped | Gated on PERF11 (not yet shipped) |
+| J1e-PR-08/09 | XS | Skipped | Gated on J1e code migration (PR-01 through PR-07 not done) |
+| SPATIAL-V6-014 | S | Skipped | Gated on SPATIAL-V6 gate v0 |
+| BTKVS-A2-OPS | XS | Skipped | Ops-side infrastructure change; no repo code |
+| IMPORT-Q7-VERIFY | XS | Skipped | Host-boundary item (cube-side); not addressable from repo |
+| NEO-AUDIT-2026-05-24-012 | XS | Skipped | Explicitly deferred to L2e sunset |
+| All TS-INGEST-222GB-* | S | Skipped | Require live-instance access; not code PRs |
+| FRONTEND-LINT-DEBT-02 | M | Skipped | ~20+ `as any` casts across components; medium effort; not trivially fixable in one pass |
+
+## Branches / PRs opened
+
+_(Filled in after sub-agents complete)_
+
+- FRONTEND-LINT-DEBT-04 → branch `frontend-lint-debt-04-ts-comment-explanation` — PR pending
+- UX-WALK-2026-05-29-04 → branch `ux-walk-2026-05-29-04-error-toast-humanize` — PR pending
+
+## Notes
+
+- `npm run lint` and `npm run typecheck` are not runnable in the base environment without `npm install` (node_modules absent, `.nuxt/` absent). Sub-agents run `npm install` in their worktrees first (which triggers `postinstall: nuxt prepare`), then run all gates.
+- FE-BUILD-01/02/03 are already implemented but their backlog rows are still marked `queued`. Suggest a maintenance pass to update those rows to `done` in the next human review session.

--- a/frontend/tests/unit/errorBus.test.ts
+++ b/frontend/tests/unit/errorBus.test.ts
@@ -11,10 +11,12 @@
  * stacking on pages with multiple simultaneous fetches.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { ErrorType } from "~/utils/errorBus";
 
 let handleError: typeof import("~/utils/errorBus").handleError;
 let onError: typeof import("~/utils/errorBus").onError;
 let _resetDedupStateForTests: typeof import("~/utils/errorBus")._resetDedupStateForTests;
+let humanizeIdError: typeof import("~/utils/errorBus").humanizeIdError;
 
 beforeEach(async () => {
   vi.resetModules();
@@ -23,6 +25,7 @@ beforeEach(async () => {
   onError = mod.onError;
   _resetDedupStateForTests = mod._resetDedupStateForTests;
   _resetDedupStateForTests();
+  humanizeIdError = mod.humanizeIdError;
 });
 
 afterEach(() => {
@@ -51,6 +54,58 @@ function buildResponseError(status: number, bodyText = ""): Error {
   };
   return err;
 }
+
+// ---------------------------------------------------------------------------
+// humanizeIdError unit tests (UX-WALK-2026-05-29-04)
+// ---------------------------------------------------------------------------
+
+function makeError(exception: string, message: string, status = 404): ErrorType {
+  return { status, exception, message };
+}
+
+describe("humanizeIdError — ID ERROR transformation", () => {
+  it('maps "Collection with id N is null or deleted" to a friendly collection message', async () => {
+    const input = makeError("ID ERROR", "Collection with id 7 is null or deleted");
+    const result = humanizeIdError(input);
+    expect(result.exception).toBe("");
+    expect(result.message).toContain("collection");
+    expect(result.message).not.toMatch(/\bid \d+\b/);
+  });
+
+  it('maps "DataObject with id N is null or deleted" to a friendly data object message', async () => {
+    const input = makeError("ID ERROR", "DataObject with id 3 is null or deleted");
+    const result = humanizeIdError(input);
+    expect(result.exception).toBe("");
+    expect(result.message).toContain("data object");
+    expect(result.message).not.toMatch(/\bid \d+\b/);
+  });
+
+  it("maps an unknown entity ID ERROR to the generic friendly message", async () => {
+    const input = makeError("ID ERROR", "Foo with id 99 is null or deleted");
+    const result = humanizeIdError(input);
+    expect(result.exception).toBe("");
+    expect(result.message).toContain("isn't available");
+    expect(result.message).not.toMatch(/\bid \d+\b/);
+  });
+
+  it("passes through errors whose exception is not ID ERROR unchanged", async () => {
+    const input = makeError("Not Found", "Collection with id 7 is null or deleted");
+    const result = humanizeIdError(input);
+    expect(result).toEqual(input);
+  });
+
+  it("passes through ordinary errors unchanged", async () => {
+    const input = makeError("Internal Server Error", "Something went wrong", 500);
+    const result = humanizeIdError(input);
+    expect(result).toEqual(input);
+  });
+
+  it("preserves the original status code", async () => {
+    const input = makeError("ID ERROR", "Collection with id 1 is null or deleted", 404);
+    const result = humanizeIdError(input);
+    expect(result.status).toBe(404);
+  });
+});
 
 describe("handleError — suppression rules", () => {
   it("suppresses AbortError (DOMException)", async () => {

--- a/frontend/utils/errorBus.ts
+++ b/frontend/utils/errorBus.ts
@@ -83,7 +83,34 @@ async function parseResponseError(error: ResponseError): Promise<ErrorType> {
       errorObject.message = errorString.replace(/^"|"$/g, "");
     }
   }
-  return errorObject;
+  return humanizeIdError(errorObject);
+}
+
+/**
+ * UX-WALK-2026-05-29-04: Transform backend `ID ERROR` exceptions into
+ * user-friendly messages before they reach the toast.
+ *
+ * The backend emits `{ exception: "ID ERROR", message: "Collection with id 19
+ * is null or deleted" }` when a Neo4j node is missing or the caller has no
+ * access. This leaks a substrate-internal integer ID that means nothing to an
+ * end user. Replace both fields with friendly copy; the backend continues
+ * logging the raw detail.
+ */
+export function humanizeIdError(e: ErrorType): ErrorType {
+  if (!/^ID ERROR$/i.test(e.exception ?? "")) return e;
+  const msg = e.message ?? "";
+  let friendly: string;
+  if (/collection/i.test(msg)) {
+    friendly =
+      "This collection isn't available — it may have been deleted or you may not have access.";
+  } else if (/dataobject/i.test(msg)) {
+    friendly =
+      "This data object isn't available — it may have been deleted or you may not have access.";
+  } else {
+    friendly =
+      "This item isn't available — it may have been deleted or you may not have access.";
+  }
+  return { ...e, exception: "", message: friendly };
 }
 
 /**


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Adds `humanizeIdError()` helper in `frontend/utils/errorBus.ts`
- Transforms backend `ID ERROR` exception + internal-ID message into a user-friendly message before reaching the toast
- Affects three situations: `fetching collection`, `fetching collection roles`, `fetchTreeviewItem`
- Backend logging is unaffected; only the toast text changes

## Test plan
- [ ] `npm run lint` passes (changed files clean; pre-existing lint debt in other files unrelated to this PR)
- [ ] `npm run test` passes, including 6 new `humanizeIdError` unit tests (21 total in errorBus.test.ts)
- [ ] `npm run typecheck` passes (exit 0)
- [ ] Manually: on a 404 collection navigation, toast shows "This collection isn't available..." instead of the internal ID

https://claude.ai/code/session_01TthTVWbkLbhwrYsnVD9keU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthTVWbkLbhwrYsnVD9keU)_