### PR TITLE
fix(FRONTEND-LINT-DEBT-04): add description to bare @ts-expect-error in useCollectionEvents test

### DIFF
--- a/aidocs/agent-findings/dispatcher-runs/2026-05-29-15.md
+++ b/aidocs/agent-findings/dispatcher-runs/2026-05-29-15.md
@@ -1,0 +1,42 @@
+---
+stage: fragment
+last-stage-change: 2026-05-29
+---
+
+# Dispatcher run — 2026-05-29 15:xx UTC
+
+## Inventory
+
+- `git log --since='2 hours ago'` showed 2 recent merges: `BTKVS-A1+A2` and `ROLE-GRANT-STALE-SESSION-03`.
+- `aidocs/16-dispatcher-backlog.md` scanned end-to-end (745 KB / ~2 229 lines).
+- Remote branches: `origin/main` only — no in-flight branches.
+
+## Rows considered
+
+| Row | Size | Decision | Reason |
+|---|---|---|---|
+| FRONTEND-LINT-DEBT-04 | XS | **Dispatched** | One bare `@ts-expect-error` in `useCollectionEvents.test.ts:196`; no gating; independent |
+| UX-WALK-2026-05-29-04 | XS | **Dispatched** | Frontend-only error-toast humanization; three affected situations; no gating |
+| FE-BUILD-01 | XS | Skipped | Already implemented (`permissionTypes.ts` exists; `mapPermissions.ts` imports from it); backlog status is stale |
+| FE-BUILD-02 | XS | Skipped | Already implemented (`searchResultTypes.ts` exists; re-export in place); backlog status is stale |
+| FE-BUILD-03 | XS | Skipped | Already implemented (cast applied in `usePagedDataObjects.ts:88-99`); backlog status is stale |
+| PERF13 | S | Skipped | Gated on PERF11 (not yet shipped) |
+| J1e-PR-08/09 | XS | Skipped | Gated on J1e code migration (PR-01 through PR-07 not done) |
+| SPATIAL-V6-014 | S | Skipped | Gated on SPATIAL-V6 gate v0 |
+| BTKVS-A2-OPS | XS | Skipped | Ops-side infrastructure change; no repo code |
+| IMPORT-Q7-VERIFY | XS | Skipped | Host-boundary item (cube-side); not addressable from repo |
+| NEO-AUDIT-2026-05-24-012 | XS | Skipped | Explicitly deferred to L2e sunset |
+| All TS-INGEST-222GB-* | S | Skipped | Require live-instance access; not code PRs |
+| FRONTEND-LINT-DEBT-02 | M | Skipped | ~20+ `as any` casts across components; medium effort; not trivially fixable in one pass |
+
+## Branches / PRs opened
+
+_(Filled in after sub-agents complete)_
+
+- FRONTEND-LINT-DEBT-04 → branch `frontend-lint-debt-04-ts-comment-explanation` — PR pending
+- UX-WALK-2026-05-29-04 → branch `ux-walk-2026-05-29-04-error-toast-humanize` — PR pending
+
+## Notes
+
+- `npm run lint` and `npm run typecheck` are not runnable in the base environment without `npm install` (node_modules absent, `.nuxt/` absent). Sub-agents run `npm install` in their worktrees first (which triggers `postinstall: nuxt prepare`), then run all gates.
+- FE-BUILD-01/02/03 are already implemented but their backlog rows are still marked `queued`. Suggest a maintenance pass to update those rows to `done` in the next human review session.

--- a/aidocs/agent-findings/dispatcher-runs/2026-05-29-15.md
+++ b/aidocs/agent-findings/dispatcher-runs/2026-05-29-15.md
@@ -31,10 +31,8 @@ last-stage-change: 2026-05-29
 
 ## Branches / PRs opened
 
-_(Filled in after sub-agents complete)_
-
-- FRONTEND-LINT-DEBT-04 → branch `frontend-lint-debt-04-ts-comment-explanation` — PR pending
-- UX-WALK-2026-05-29-04 → branch `ux-walk-2026-05-29-04-error-toast-humanize` — PR pending
+- FRONTEND-LINT-DEBT-04 → branch `frontend-lint-debt-04-ts-comment-explanation` → **PR #1573** ✓ all gates green (lint, test 14/14, typecheck)
+- UX-WALK-2026-05-29-04 → branch `ux-walk-2026-05-29-04-error-toast-humanize` → **PR #1572** ✓ all gates green (lint, test 21/21, typecheck exit 0)
 
 ## Notes
 

--- a/frontend/tests/unit/useCollectionEvents.test.ts
+++ b/frontend/tests/unit/useCollectionEvents.test.ts
@@ -193,7 +193,7 @@ describe("parseBuffer — malformed JSON", () => {
 
     // @ts-expect-error result is assigned in the callback above
     expect(result.events).toHaveLength(0);
-    // @ts-expect-error
+    // @ts-expect-error result is assigned in the callback above
     expect(result.remaining).toBe("");
   });
 


### PR DESCRIPTION
## Summary
- Adds the explanation `result is assigned in the callback above` to the bare `// @ts-expect-error` on line 196 of `frontend/tests/unit/useCollectionEvents.test.ts`
- Fixes the `@typescript-eslint/ban-ts-comment` ESLint violation (FRONTEND-LINT-DEBT-04)
- One-character-range change; no logic or test behaviour altered

## Test plan
- [ ] `npm run lint` passes (ban-ts-comment rule no longer fires on this file)
- [ ] `npm run test` passes (Vitest — no test logic changed)

https://claude.ai/code/session_01TthTVWbkLbhwrYsnVD9keU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthTVWbkLbhwrYsnVD9keU)_