### PR TITLE
J1e-PR-06-AUTOFETCH-01: pre-spawn hook for ?file=<url>

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -2308,7 +2308,7 @@ extension in the single-user image) that:
 
 | ID | Item | Size | Status | Notes |
 |---|---|---|---|---|
-| J1e-PR-06-AUTOFETCH-01 | Add `pre_spawn_hook` to `jupyterhub_config.py` that reads `?file=`, validates allowlist, fetches via auth_state, writes to user volume. | M | queued | Allowlist hostnames come from `JUPYTERHUB_SHEPARD_ALLOWED_HOSTS` env (default `shepard.nuclide.systems,shepard-api.nuclide.systems`). |
+| J1e-PR-06-AUTOFETCH-01 | Add `pre_spawn_hook` to `jupyterhub_config.py` that reads `?file=`, validates allowlist, fetches via auth_state, writes to user volume. | M | in-flight | Allowlist hostnames come from `JUPYTERHUB_SHEPARD_ALLOWED_HOSTS` env (default `shepard.nuclide.systems,shepard-api.nuclide.systems`). PR open `j1e-pr-06-autofetch-01`: hook + 4 module-level helpers (is_url_allowed/sanitize_filename/derive_filename/render_readme) + 14 unit tests + quickstart.md + install.md §4.4. |
 | J1e-PR-06-AUTOFETCH-02 | Frontend: ensure "Open in Jupyter" action emits the canonical `?file=` URL with proper encoding + tests the round-trip. | S | queued | Reference-edit UI per `plugins/jupyter/docs/quickstart.md`. |
 | J1e-PR-06-AUTOFETCH-03 | Plugin docs: `plugins/jupyter/docs/quickstart.md` section on "Open in Jupyter" — what it does, what it doesn't (no write-back), workaround for the unallow-listed case. | XS | queued | Required by CLAUDE.md "plugins ship their own documentation" rule. |
 | J1e-PR-06-AUTOFETCH-04 | Operator workaround for now: kernel-side cell using `SHEPARD_OIDC_ACCESS_TOKEN`. Document in `plugins/jupyter/docs/quickstart.md §Troubleshooting`. | XS | done (this row's notes) | The 4-line `requests.get` snippet is the bridge until -01 ships. |

--- a/plugins/jupyter/compose-profile.yml
+++ b/plugins/jupyter/compose-profile.yml
@@ -65,6 +65,12 @@ services:
       # Operators wanting a different image set
       # JUPYTERHUB_SINGLEUSER_IMAGE in their env file.
       DOCKER_NOTEBOOK_IMAGE: ${JUPYTERHUB_SINGLEUSER_IMAGE:-jupyter/scipy-notebook:python-3.11}
+      # --- J1e-PR-06 auto-fetch allowlist ---
+      # Comma-separated list of hostnames the pre-spawn hook is allowed to
+      # fetch `?file=<url>` from. SSRF defense — anything not in this set
+      # is rejected without an outbound call. Default covers the canonical
+      # nuclide.systems hosts; operators on other domains override.
+      JUPYTERHUB_SHEPARD_ALLOWED_HOSTS: ${JUPYTERHUB_SHEPARD_ALLOWED_HOSTS:-shepard.nuclide.systems,shepard-api.nuclide.systems}
     volumes:
       # Persistent user state (notebooks, dotfiles).
       - jupyterhub_data:/data

--- a/plugins/jupyter/config/jupyterhub_config.py
+++ b/plugins/jupyter/config/jupyterhub_config.py
@@ -17,8 +17,286 @@
 # generic.
 
 import os
+import re
+from datetime import datetime, timezone
+from urllib.parse import unquote, urlparse
 
 c = get_config()  # noqa: F821  — jupyterhub injects `get_config` at runtime
+
+
+# --------------------------------------------------------------------- #
+# J1e-PR-06-AUTOFETCH-01 — pre-spawn helpers
+#
+# The `pre_spawn_hook` below reads `?file=<url>` from the spawn request,
+# validates it against an operator-configured allowlist, fetches the
+# bytes using the user's OIDC access token, and writes them into the
+# user's notebook volume at `/shepard-imports/<filename>` so they appear
+# at `/home/jovyan/work/shepard-imports/<filename>` once the kernel starts.
+#
+# All four helpers below are module-level pure functions so they're
+# importable + unit-testable from `plugins/jupyter/tests/`. The hook
+# itself stays inside this file.
+# --------------------------------------------------------------------- #
+
+_FILENAME_STAR_RE = re.compile(
+    r"filename\*\s*=\s*(?P<charset>[^']*)'(?P<lang>[^']*)'(?P<value>[^;]+)",
+    re.IGNORECASE,
+)
+_FILENAME_RE = re.compile(
+    r'filename\s*=\s*"?(?P<value>[^";]+)"?',
+    re.IGNORECASE,
+)
+
+
+def _default_allowed_hosts() -> set[str]:
+    """Parse `JUPYTERHUB_SHEPARD_ALLOWED_HOSTS` (comma-separated) into a set."""
+    raw = os.environ.get(
+        "JUPYTERHUB_SHEPARD_ALLOWED_HOSTS",
+        "shepard.nuclide.systems,shepard-api.nuclide.systems",
+    )
+    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+
+
+def is_url_allowed(url: str, allowed_hosts: set[str]) -> bool:
+    """Return True iff `url` parses cleanly to an https/http URL whose
+    hostname is in `allowed_hosts`. SSRF defense: anything else returns
+    False WITHOUT triggering a fetch."""
+    if not url or not isinstance(url, str):
+        return False
+    try:
+        parsed = urlparse(url)
+    except (ValueError, TypeError):
+        return False
+    if parsed.scheme not in ("http", "https"):
+        return False
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return False
+    return host in allowed_hosts
+
+
+def sanitize_filename(name: str, max_length: int = 255) -> str:
+    """Strip path traversal segments and bound the length. Never returns
+    an empty string — falls back to `download.bin` for edge cases."""
+    if not name:
+        return "download.bin"
+    # Cut to basename — drop any path component, forward or backward.
+    name = name.replace("\\", "/").split("/")[-1]
+    # Strip traversal dots; collapse leading dots that hide files.
+    name = name.lstrip(".") or "download.bin"
+    # Drop NULs + control chars.
+    name = re.sub(r"[\x00-\x1f]", "", name)
+    if not name or name in (".", ".."):
+        return "download.bin"
+    if len(name) > max_length:
+        # Preserve the extension if there is one.
+        if "." in name:
+            stem, _, ext = name.rpartition(".")
+            ext = ext[:32]  # cap extension length too
+            keep = max_length - len(ext) - 1
+            name = f"{stem[:keep]}.{ext}" if keep > 0 else name[:max_length]
+        else:
+            name = name[:max_length]
+    return name
+
+
+def derive_filename(url: str, content_disposition: str | None) -> str:
+    """Pick a filename: Content-Disposition first (RFC 5987 then plain),
+    then URL path tail, then `download.bin`. Always sanitized."""
+    if content_disposition:
+        # RFC 5987: filename*=UTF-8''my%20file.pdf
+        m = _FILENAME_STAR_RE.search(content_disposition)
+        if m:
+            try:
+                return sanitize_filename(unquote(m.group("value").strip()))
+            except (UnicodeDecodeError, ValueError):
+                pass
+        m = _FILENAME_RE.search(content_disposition)
+        if m:
+            return sanitize_filename(m.group("value").strip())
+    # Fall back to URL path tail.
+    try:
+        parsed = urlparse(url)
+        tail = unquote((parsed.path or "").rstrip("/").split("/")[-1])
+        if tail:
+            return sanitize_filename(tail)
+    except (ValueError, TypeError):
+        pass
+    return "download.bin"
+
+
+def render_readme(
+    filename: str,
+    source_url: str,
+    status: str,
+    fetched_at: datetime | None = None,
+) -> str:
+    """Build the per-import README sidecar. `status` is one of
+    `OK`, `401`, `403`, `allowlist-miss`, `timeout`, `no-token`, or a
+    free-form short error string."""
+    ts = (fetched_at or datetime.now(timezone.utc)).isoformat()
+    return (
+        f"# Shepard import — {filename}\n"
+        f"- Source URL: {source_url}\n"
+        f"- Fetched at: {ts}\n"
+        f"- Status: {status}\n"
+        f"- This is a pre-fetch. Modifications stay in this notebook "
+        f"volume — they do NOT write back to Shepard.\n"
+    )
+
+
+def _pre_spawn_hook(spawner):  # pragma: no cover — exercised live in JH
+    """Capture `?file=<url>` from the spawn URL and fetch into the user
+    volume. Secondary-write: all failures are caught, logged WARN, and
+    surfaced via a README sidecar — the kernel always spawns."""
+    import asyncio
+    import docker
+    import requests
+
+    log = spawner.log
+    file_urls: list[str] = []
+
+    # Source 1: Tornado handler query string (the `?file=` case).
+    handler = getattr(spawner, "handler", None)
+    if handler is not None:
+        try:
+            file_urls = handler.get_arguments("file") or []
+        except Exception as exc:  # noqa: BLE001
+            log.warning("J1e-PR-06: failed to read ?file= arguments: %s", exc)
+
+    # Source 2: user_options (form-submitted).
+    if not file_urls:
+        opt = (spawner.user_options or {}).get("file")
+        if isinstance(opt, str):
+            file_urls = [opt]
+        elif isinstance(opt, list):
+            file_urls = [u for u in opt if isinstance(u, str)]
+
+    if not file_urls:
+        return  # nothing to do — common case
+
+    allowed = _default_allowed_hosts()
+
+    # Retrieve the OIDC access token from auth_state.
+    access_token = ""
+    try:
+        auth_state = asyncio.get_event_loop().run_until_complete(
+            spawner.user.get_auth_state()
+        ) if not asyncio.get_event_loop().is_running() else None
+    except Exception:  # noqa: BLE001
+        auth_state = None
+    # In JH's async pre_spawn context the event loop IS running — use
+    # the awaitable form via `await` if we're in a coroutine, else fall
+    # back to spawner.environment which the auth_state_hook already set.
+    if access_token == "":
+        access_token = (spawner.environment or {}).get(
+            "SHEPARD_OIDC_ACCESS_TOKEN", ""
+        )
+
+    # Resolve the user's notebook volume on the host filesystem.
+    username = spawner.user.name
+    volume_name = f"jupyterhub-user-{username}"
+    try:
+        client = docker.from_env()
+        try:
+            volume = client.volumes.get(volume_name)
+        except docker.errors.NotFound:
+            volume = client.volumes.create(name=volume_name)
+        mountpoint = volume.attrs["Mountpoint"]
+    except Exception as exc:  # noqa: BLE001
+        log.warning("J1e-PR-06: cannot resolve user volume %s: %s", volume_name, exc)
+        return
+
+    import_dir = os.path.join(mountpoint, "shepard-imports")
+    try:
+        os.makedirs(import_dir, exist_ok=True)
+    except OSError as exc:
+        log.warning("J1e-PR-06: cannot create %s: %s", import_dir, exc)
+        return
+
+    for raw_url in file_urls:
+        if not is_url_allowed(raw_url, allowed):
+            host = urlparse(raw_url).hostname if raw_url else "<empty>"
+            log.warning("J1e-PR-06: allowlist miss for host=%s", host)
+            placeholder = sanitize_filename(
+                derive_filename(raw_url or "", None)
+            )
+            try:
+                with open(
+                    os.path.join(import_dir, f"README-{placeholder}.md"),
+                    "w",
+                    encoding="utf-8",
+                ) as fh:
+                    fh.write(render_readme(placeholder, raw_url, "allowlist-miss"))
+            except OSError:
+                pass
+            continue
+
+        if not access_token:
+            log.warning("J1e-PR-06: no access token in auth_state; skipping fetch")
+            placeholder = derive_filename(raw_url, None)
+            try:
+                with open(
+                    os.path.join(import_dir, f"README-{placeholder}.md"),
+                    "w",
+                    encoding="utf-8",
+                ) as fh:
+                    fh.write(render_readme(placeholder, raw_url, "no-token"))
+            except OSError:
+                pass
+            continue
+
+        status = "OK"
+        filename = derive_filename(raw_url, None)
+        try:
+            resp = requests.get(
+                raw_url,
+                headers={"Authorization": f"Bearer {access_token}"},
+                stream=True,
+                timeout=(10, 300),
+                allow_redirects=False,
+            )
+            filename = derive_filename(
+                raw_url, resp.headers.get("Content-Disposition")
+            )
+            if resp.status_code != 200:
+                status = str(resp.status_code)
+                log.warning(
+                    "J1e-PR-06: fetch host=%s status=%s",
+                    urlparse(raw_url).hostname,
+                    resp.status_code,
+                )
+            else:
+                target = os.path.join(import_dir, filename)
+                with open(target, "wb") as out:
+                    for chunk in resp.iter_content(chunk_size=1024 * 1024):
+                        if chunk:
+                            out.write(chunk)
+                log.info(
+                    "J1e-PR-06: fetched host=%s -> %s",
+                    urlparse(raw_url).hostname,
+                    filename,
+                )
+        except requests.Timeout:
+            status = "timeout"
+            log.warning("J1e-PR-06: timeout fetching host=%s", urlparse(raw_url).hostname)
+        except Exception as exc:  # noqa: BLE001
+            status = f"error: {type(exc).__name__}"
+            log.warning(
+                "J1e-PR-06: fetch error host=%s err=%s",
+                urlparse(raw_url).hostname,
+                exc,
+            )
+
+        try:
+            with open(
+                os.path.join(import_dir, f"README-{filename}.md"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write(render_readme(filename, raw_url, status))
+        except OSError as exc:
+            log.warning("J1e-PR-06: README write failed: %s", exc)
 
 # --------------------------------------------------------------------- #
 # OIDC (GenericOAuth) authenticator pointed at the Keycloak realm
@@ -104,3 +382,23 @@ c.JupyterHub.hub_connect_ip = "jupyterhub"
 c.ConfigurableHTTPProxy.api_url = "http://127.0.0.1:8001"
 c.JupyterHub.db_url = "sqlite:////data/jupyterhub.sqlite"
 c.JupyterHub.cookie_secret_file = "/data/jupyterhub_cookie_secret"
+
+# --------------------------------------------------------------------- #
+# J1e-PR-06-AUTOFETCH-01 — wire the pre-spawn hook + options_from_form
+# so `?file=<url>` is captured into `spawner.user_options["file"]`.
+# --------------------------------------------------------------------- #
+
+
+def _options_from_form(form_data, spawner=None):
+    """Map JupyterHub spawn form values into `user_options`. We accept a
+    list of `file` values so an operator can extend to bulk later. The
+    request's query-string `?file=` arrives here as `form_data['file']`
+    because Tornado's RequestHandler.get_arguments aggregates both."""
+    files = form_data.get("file", []) if isinstance(form_data, dict) else []
+    if isinstance(files, str):
+        files = [files]
+    return {"file": [f for f in files if isinstance(f, str) and f]}
+
+
+c.Spawner.options_from_form = _options_from_form
+c.Spawner.pre_spawn_hook = _pre_spawn_hook

--- a/plugins/jupyter/docs/install.md
+++ b/plugins/jupyter/docs/install.md
@@ -97,6 +97,7 @@ already added):
 | `JUPYTERHUB_PUBLIC_URL` | yes | `https://shepard.nuclide.systems/jupyterhub` | Path-mounted public URL the user is redirected back to after sign-in. Must match Keycloak's valid-redirect-URI. |
 | `JUPYTERHUB_SINGLEUSER_IMAGE` | no | `jupyter/scipy-notebook:python-3.11` | The image spawned per user. Override for domain-specific notebook environments. |
 | `SHEPARD_BACKEND_URL` | no | `http://backend:8080` | Used by the kernel to call back into Shepard. The `backend` hostname is the compose service name. |
+| `JUPYTERHUB_SHEPARD_ALLOWED_HOSTS` | no | `shepard.nuclide.systems,shepard-api.nuclide.systems` | Comma-separated allowlist of hostnames the **`?file=<url>` auto-fetch pre-spawn hook** (J1e-PR-06) will fetch from. SSRF defense — see §4.5. Add your deployment's actual hostnames here; the default only covers `nuclide.systems`. |
 
 The Shepard backend itself does **not** need any new env vars — the
 hub URL is stored at runtime in `:JupyterConfig.hubUrl` and configured
@@ -191,7 +192,38 @@ generate a real secret:**
    drop the `shepard.example.org` template default once
    `shepard.nuclide.systems` is the live host).
 
-### 4.4 Caveat — shared cookie domain
+### 4.4 `?file=<url>` auto-fetch allowlist (J1e-PR-06)
+
+JupyterHub's pre-spawn hook reads a `?file=<encoded-url>` query param
+from the spawn URL, fetches that URL using the user's forwarded OIDC
+token, and writes the result into the per-user notebook volume at
+`/home/jovyan/work/shepard-imports/`.
+
+**The allowlist is the SSRF perimeter.** The hook validates the URL's
+hostname against `JUPYTERHUB_SHEPARD_ALLOWED_HOSTS` (comma-separated)
+BEFORE any outbound call. Hosts not in the list are rejected with a
+README sidecar noting `Status: allowlist-miss` — the kernel still
+spawns, the user sees what happened, no outbound request is made.
+
+For the live `nuclide.systems` deployment, the default
+(`shepard.nuclide.systems,shepard-api.nuclide.systems`) is correct.
+For other deployments, add your real hostname(s) — both the user-facing
+host (where "Open in Jupyter" URLs are constructed) and the API host
+(where the fetch resolves) — to `infrastructure/.env`:
+
+```ini
+JUPYTERHUB_SHEPARD_ALLOWED_HOSTS=shepard.example.org,shepard-api.example.org
+```
+
+This is a **deploy-time** knob (defines the security perimeter, not a
+runtime toggle); change requires a `docker compose up -d jupyterhub`
+to take effect. The runtime `:JupyterConfig` admin endpoint does not
+expose it — by design.
+
+User-facing behavior (status codes, manual fallback) is documented in
+[`plugins/jupyter/docs/quickstart.md §Open in Jupyter`](./quickstart.md#open-in-jupyter).
+
+### 4.5 Caveat — shared cookie domain
 
 Path-mounting shares the cookie domain with Shepard. JupyterHub's
 session cookie defaults to `Path=/jupyterhub` so it doesn't collide

--- a/plugins/jupyter/docs/quickstart.md
+++ b/plugins/jupyter/docs/quickstart.md
@@ -1,0 +1,101 @@
+---
+stage: feature-defined
+last-stage-change: 2026-05-29
+last-content-change: 2026-05-29
+---
+
+# shepard-plugin-jupyter — User quickstart
+
+**Audience:** Shepard users who want to analyse data in a Jupyter
+notebook without leaving the Shepard surface.
+
+## Open in Jupyter
+
+Any FileReference (and, soon, any DataObject with a fetchable payload)
+shows an **"Open in Jupyter"** action in its detail view. Clicking it:
+
+1. Redirects you to JupyterHub at
+   `https://shepard.<your-domain>/jupyterhub/hub/spawn?file=<encoded-url>`.
+2. JupyterHub signs you in via the same Keycloak realm as Shepard
+   (no second login if you're already in).
+3. **Before the kernel boots**, a pre-spawn hook on the JupyterHub
+   side reads the `?file=` query param, validates the URL against an
+   operator-configured allowlist, fetches the bytes using your
+   forwarded OIDC token, and drops the file in your notebook workspace
+   at:
+
+   ```
+   ~/work/shepard-imports/<filename>
+   ```
+
+4. A sidecar `README-<filename>.md` lands next to it noting the source
+   URL, the fetch timestamp, and the HTTP status. Worth reading on
+   first launch.
+
+**The pre-fetched file is yours to modify**, but modifications stay
+inside the notebook volume — they do **not** write back to Shepard.
+If you produce derived data worth keeping, upload it via the regular
+Shepard API or the `shepard-py` client (already on the kernel's path).
+
+### Allowlist behavior — what to expect when it misses
+
+For SSRF defense, the pre-spawn hook only fetches from hostnames the
+operator listed in `JUPYTERHUB_SHEPARD_ALLOWED_HOSTS` (default
+`shepard.nuclide.systems,shepard-api.nuclide.systems`).
+
+If you click "Open in Jupyter" on a Shepard surface served from a host
+**not** in the allowlist (e.g. a staging instance the operator forgot
+to add), the kernel still boots — but `shepard-imports/` contains only
+a `README-*.md` with `Status: allowlist-miss` and the URL you can fetch
+manually instead. Ask the operator to add the host to the allowlist;
+see the install guide §4.
+
+### Other status values
+
+The README's `Status:` field tells you what happened:
+
+| Status | Meaning | What to do |
+|---|---|---|
+| `OK` | File fetched cleanly. | Use it in your notebook. |
+| `401` / `403` | Shepard refused the token. | Re-authenticate via the Shepard UI, then re-spawn. |
+| `allowlist-miss` | Host not allow-listed. | Ask the operator. |
+| `timeout` | Server didn't respond in 5 min. | Re-spawn or fetch in a cell manually. |
+| `no-token` | OIDC access token wasn't available. | Sign out + back in to Shepard, then retry. |
+| `error: <Name>` | Unexpected failure. | Show the README to the operator. |
+
+## Troubleshooting
+
+### "My file isn't in `shepard-imports/`"
+
+Check `~/work/shepard-imports/README-*.md` first — it explains what
+happened. If you see no README at all, the auto-fetch didn't run (the
+spawn URL probably didn't carry `?file=`); use the manual fallback
+below.
+
+### Manual fallback — kernel-side fetch
+
+Until **J1e-PR-06-AUTOFETCH-01** is deployed (or for files the
+allowlist rejects), use the forwarded OIDC token directly:
+
+```python
+import os, requests
+token = os.environ["SHEPARD_OIDC_ACCESS_TOKEN"]
+url = "https://shepard-api.nuclide.systems/v2/files/<appId>/payload"
+
+resp = requests.get(url, headers={"Authorization": f"Bearer {token}"})
+resp.raise_for_status()
+with open("my-download.bin", "wb") as f:
+    f.write(resp.content)
+```
+
+The token environment variable is set by JupyterHub's `auth_state_hook`
+on every kernel spawn. It expires when your OIDC session does — re-spawn
+to refresh.
+
+## See also
+
+- [Install guide](./install.md) — operator-side setup, including the
+  allowlist env var.
+- Backlog row
+  [`J1e-PR-06-OPEN-IN-JUPYTER-AUTOFETCH`](../../../aidocs/16-dispatcher-backlog.md)
+  — design + status of the auto-fetch pipeline.

--- a/plugins/jupyter/tests/test_pre_spawn_hook.py
+++ b/plugins/jupyter/tests/test_pre_spawn_hook.py
@@ -1,0 +1,174 @@
+"""Unit tests for the J1e-PR-06-AUTOFETCH-01 pre-spawn helpers.
+
+The hook itself (`_pre_spawn_hook`) needs a live JupyterHub spawner +
+docker daemon to exercise meaningfully — those paths are validated by
+the make-redeploy smoke test. These unit tests cover the pure helpers
+the hook delegates to: URL allowlist validation, filename derivation +
+sanitization, and README rendering. Together they form the SSRF defense
+and the user-facing failure-surfacing contract.
+
+Run from the repo root:
+
+    python3 -m unittest plugins.jupyter.tests.test_pre_spawn_hook -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from datetime import datetime, timezone
+
+
+def _load_module():
+    """Load jupyterhub_config.py as a plain module so we can import its
+    helpers without needing JH's `get_config` injection. We stub the
+    `get_config` builtin + the `os.environ` keys the module reads at
+    import time, then strip out the global config assignments after."""
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "config",
+        "jupyterhub_config.py",
+    )
+    src = open(path, encoding="utf-8").read()
+    # Stub the env vars the module reads at import (OIDC issuer etc.) so
+    # we don't trip KeyError before reaching the helpers we want to test.
+    os.environ.setdefault("SHEPARD_OIDC_ISSUER_URL", "https://example/realm")
+    os.environ.setdefault("JUPYTERHUB_KEYCLOAK_CLIENT_ID", "jupyterhub")
+    os.environ.setdefault("JUPYTERHUB_KEYCLOAK_CLIENT_SECRET", "stub")
+    module = types.ModuleType("jupyterhub_config_under_test")
+    module.__file__ = path
+
+    class _StubConfig:
+        def __getattr__(self, name):
+            return self
+
+        def __setattr__(self, name, value):
+            pass
+
+    module.__dict__["get_config"] = lambda: _StubConfig()
+    exec(compile(src, path, "exec"), module.__dict__)
+    return module
+
+
+CONFIG = _load_module()
+
+
+class TestAllowlist(unittest.TestCase):
+    ALLOWED = {"shepard.nuclide.systems", "shepard-api.nuclide.systems"}
+
+    def test_allowed_host_passes(self):
+        self.assertTrue(
+            CONFIG.is_url_allowed(
+                "https://shepard-api.nuclide.systems/v2/files/abc", self.ALLOWED
+            )
+        )
+
+    def test_disallowed_host_blocked(self):
+        self.assertFalse(
+            CONFIG.is_url_allowed("https://evil.example.com/payload.bin", self.ALLOWED)
+        )
+
+    def test_non_http_scheme_blocked(self):
+        # file:// and javascript: must never reach the fetcher.
+        self.assertFalse(
+            CONFIG.is_url_allowed("file:///etc/passwd", self.ALLOWED)
+        )
+        self.assertFalse(
+            CONFIG.is_url_allowed("javascript:alert(1)", self.ALLOWED)
+        )
+
+    def test_empty_or_garbage_blocked(self):
+        self.assertFalse(CONFIG.is_url_allowed("", self.ALLOWED))
+        self.assertFalse(CONFIG.is_url_allowed(None, self.ALLOWED))  # type: ignore[arg-type]
+        self.assertFalse(CONFIG.is_url_allowed("not a url at all", self.ALLOWED))
+
+
+class TestFilenameDerivation(unittest.TestCase):
+    def test_content_disposition_plain(self):
+        self.assertEqual(
+            CONFIG.derive_filename(
+                "https://example/x",
+                'attachment; filename="report.pdf"',
+            ),
+            "report.pdf",
+        )
+
+    def test_content_disposition_rfc5987(self):
+        self.assertEqual(
+            CONFIG.derive_filename(
+                "https://example/x",
+                "attachment; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf",
+            ),
+            "résumé.pdf",
+        )
+
+    def test_falls_back_to_url_path(self):
+        self.assertEqual(
+            CONFIG.derive_filename(
+                "https://shepard-api.nuclide.systems/v2/files/abc/payload/report.csv",
+                None,
+            ),
+            "report.csv",
+        )
+
+    def test_falls_back_to_default_when_path_empty(self):
+        self.assertEqual(
+            CONFIG.derive_filename("https://shepard-api.nuclide.systems/", None),
+            "download.bin",
+        )
+
+
+class TestFilenameSanitization(unittest.TestCase):
+    def test_path_traversal_stripped(self):
+        self.assertEqual(
+            CONFIG.sanitize_filename("../../etc/passwd"), "passwd"
+        )
+
+    def test_leading_dots_stripped(self):
+        # Hidden-file dotnames would let an upload occupy a name the
+        # kernel won't display by default. Strip + fall back.
+        self.assertEqual(CONFIG.sanitize_filename("..."), "download.bin")
+
+    def test_max_length_enforced(self):
+        long_name = ("a" * 400) + ".bin"
+        result = CONFIG.sanitize_filename(long_name)
+        self.assertLessEqual(len(result), 255)
+        self.assertTrue(result.endswith(".bin"))
+
+    def test_empty_becomes_default(self):
+        self.assertEqual(CONFIG.sanitize_filename(""), "download.bin")
+        self.assertEqual(CONFIG.sanitize_filename("/"), "download.bin")
+
+
+class TestReadmeRendering(unittest.TestCase):
+    FIXED_TS = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_ok_status(self):
+        out = CONFIG.render_readme(
+            "report.pdf",
+            "https://shepard-api.nuclide.systems/v2/files/abc",
+            "OK",
+            fetched_at=self.FIXED_TS,
+        )
+        self.assertIn("# Shepard import — report.pdf", out)
+        self.assertIn("- Status: OK", out)
+        self.assertIn("2026-05-29T12:00:00+00:00", out)
+        self.assertIn("do NOT write back to Shepard", out)
+
+    def test_allowlist_miss_status_documented(self):
+        out = CONFIG.render_readme(
+            "payload.bin",
+            "https://evil.example.com/payload.bin",
+            "allowlist-miss",
+            fetched_at=self.FIXED_TS,
+        )
+        self.assertIn("- Status: allowlist-miss", out)
+        self.assertIn("https://evil.example.com/payload.bin", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Captures `?file=<url>` from the JupyterHub spawn URL and pre-fetches the bytes into the user's notebook volume at `~/work/shepard-imports/<filename>` before the kernel boots, using the user's forwarded OIDC token (`SHEPARD_OIDC_ACCESS_TOKEN`, already shipped via `auth_state_hook`).

- **SSRF perimeter:** `JUPYTERHUB_SHEPARD_ALLOWED_HOSTS` (comma-separated, default `shepard.nuclide.systems,shepard-api.nuclide.systems`). Allowlist is checked **before** any outbound call — a miss writes a README sidecar with `Status: allowlist-miss` and never opens a socket.
- **Fire-and-forget:** all fetch failures (401/403/timeout/network/no-token) are caught, logged WARN, surfaced via the per-import README sidecar; the kernel always spawns.
- **Path-traversal + length-capped filenames:** Content-Disposition first (RFC 5987 supported), URL tail fallback, `download.bin` last-resort; sanitized to 255 bytes max with extension preservation.
- **Helpers extracted as module-level pure functions** (`is_url_allowed`, `sanitize_filename`, `derive_filename`, `render_readme`) so they're importable + testable without the JH runtime.

## What's tested

- `plugins/jupyter/tests/test_pre_spawn_hook.py` — 14 stdlib-unittest tests covering:
  - allowlist hit / miss / non-http-scheme / empty input
  - Content-Disposition (plain + RFC 5987 UTF-8) / URL-tail / default fallback
  - path-traversal stripping / leading-dot stripping / max-length enforcement
  - README rendering for OK + allowlist-miss states
- `python3 -m unittest plugins.jupyter.tests.test_pre_spawn_hook` → 14 / 14 pass

## What's NOT in scope (separate backlog rows)

- **J1e-PR-06-AUTOFETCH-02** — frontend "Open in Jupyter" action emits the canonical `?file=` URL with proper encoding + round-trip tests.
- **J1e-PR-06-AUTOFETCH-04** — kernel-side manual fallback snippet (`requests.get` with `SHEPARD_OIDC_ACCESS_TOKEN`) — already documented as the bridge until -01 ships; now lives in `quickstart.md §Troubleshooting`.
- The live pre-spawn integration test (real JH + real docker volume) is validated by the make-redeploy smoke test, not the unit suite.

## Docs touched

- `plugins/jupyter/docs/quickstart.md` (new) — §"Open in Jupyter" walkthrough + status code table + manual fallback.
- `plugins/jupyter/docs/install.md` — §3 env table now lists `JUPYTERHUB_SHEPARD_ALLOWED_HOSTS`; new §4.4 explains the SSRF perimeter (existing §4.4 cookie caveat shifted to §4.5).

## Test plan

- [ ] Operator-side: `make redeploy-jupyter` (or `docker compose up -d jupyterhub`), then click "Open in Jupyter" on a FileReference — verify `~/work/shepard-imports/<filename>` materialises before kernel ready.
- [ ] Allowlist-miss path: spawn with `?file=https://evil.example/x` query param — verify no outbound call (check `docker logs shepard-jupyterhub`), README sidecar `Status: allowlist-miss` present.
- [ ] 401 path: spawn with `?file=` pointing at a Shepard resource the user can't read — verify kernel spawns + README sidecar shows `Status: 401`.
- [x] Unit tests (`python3 -m unittest plugins.jupyter.tests.test_pre_spawn_hook -v`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)