### PR TITLE
docs(J1e-PR-06-AUTOFETCH-03): remove stale "until deployed" qualifier in quickstart

### DIFF
--- a/plugins/jupyter/docs/quickstart.md
+++ b/plugins/jupyter/docs/quickstart.md
@@ -74,8 +74,7 @@ below.
 
 ### Manual fallback — kernel-side fetch
 
-Until **J1e-PR-06-AUTOFETCH-01** is deployed (or for files the
-allowlist rejects), use the forwarded OIDC token directly:
+For files the allowlist rejects, use the forwarded OIDC token directly:
 
 ```python
 import os, requests


### PR DESCRIPTION
## Summary

- J1e-PR-06-AUTOFETCH-01 shipped in PR #1574 (commit 27af5a7, 2026-05-29), making the "Until J1e-PR-06-AUTOFETCH-01 is deployed" qualifier in `plugins/jupyter/docs/quickstart.md` stale.
- The "Manual fallback" section remains intact and still shows the code snippet — only the introductory sentence was trimmed to remove the now-false conditional.
- No other files were modified.

## Changes

`plugins/jupyter/docs/quickstart.md` lines 77–78 (before):
```
Until **J1e-PR-06-AUTOFETCH-01** is deployed (or for files the
allowlist rejects), use the forwarded OIDC token directly:
```

After:
```
For files the allowlist rejects, use the forwarded OIDC token directly:
```

## Test plan

- [ ] Pure doc edit — no code, no tests, no migrations needed.
- [ ] Verify `plugins/jupyter/docs/quickstart.md` no longer references "Until J1e-PR-06-AUTOFETCH-01 is deployed" and the manual fallback code snippet is still present.

https://claude.ai/code/session_01BZUiBhoxFsyCQAo6ULN6Ev

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZUiBhoxFsyCQAo6ULN6Ev)_