### PR TITLE
feat(#27-ARCHIVED-01): add ARCHIVED to Collection and Container status enums

### DIFF
--- a/backend-client/src/models/BasicContainer.ts
+++ b/backend-client/src/models/BasicContainer.ts
@@ -63,11 +63,18 @@ export interface BasicContainer {
      */
     name: string;
     /**
-     * 
+     *
      * @type {ContainerType}
      * @memberof BasicContainer
      */
     readonly type: ContainerType;
+    /**
+     * Lifecycle status. One of DRAFT, IN_REVIEW, READY, PUBLISHED, ARCHIVED.
+     * Absent when null (not yet set on legacy nodes).
+     * @type {string}
+     * @memberof BasicContainer
+     */
+    readonly status?: string | null;
 }
 
 
@@ -95,7 +102,7 @@ export function BasicContainerFromJSONTyped(json: any, ignoreDiscriminator: bool
         return json;
     }
     return {
-        
+
         'id': json['id'],
         'createdAt': (new Date(json['createdAt'])),
         'createdBy': json['createdBy'],
@@ -103,15 +110,16 @@ export function BasicContainerFromJSONTyped(json: any, ignoreDiscriminator: bool
         'updatedBy': json['updatedBy'],
         'name': json['name'],
         'type': ContainerTypeFromJSON(json['type']),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function BasicContainerToJSON(value?: Omit<BasicContainer, 'id'|'createdAt'|'createdBy'|'updatedAt'|'updatedBy'|'type'> | null): any {
+export function BasicContainerToJSON(value?: Omit<BasicContainer, 'id'|'createdAt'|'createdBy'|'updatedAt'|'updatedBy'|'type'|'status'> | null): any {
     if (value == null) {
         return value;
     }
     return {
-        
+
         'name': value['name'],
     };
 }

--- a/backend-client/src/models/FileContainer.ts
+++ b/backend-client/src/models/FileContainer.ts
@@ -87,6 +87,13 @@ export interface FileContainer {
      * @memberof FileContainer
      */
     readonly defaultCollectionIdList?: Array<number> | null;
+    /**
+     * Lifecycle status. One of DRAFT, IN_REVIEW, READY, PUBLISHED, ARCHIVED.
+     * Absent when null (not yet set on legacy nodes).
+     * @type {string}
+     * @memberof FileContainer
+     */
+    readonly status?: string | null;
 }
 
 
@@ -126,10 +133,11 @@ export function FileContainerFromJSONTyped(json: any, ignoreDiscriminator: boole
         'type': ContainerTypeFromJSON(json['type']),
         'oid': json['oid'],
         'defaultCollectionIdList': json['defaultCollectionIdList'] == null ? undefined : json['defaultCollectionIdList'],
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function FileContainerToJSON(value?: Omit<FileContainer, 'id'|'appId'|'createdAt'|'createdBy'|'updatedAt'|'updatedBy'|'type'|'oid'|'defaultCollectionIdList'> | null): any {
+export function FileContainerToJSON(value?: Omit<FileContainer, 'id'|'appId'|'createdAt'|'createdBy'|'updatedAt'|'updatedBy'|'type'|'oid'|'defaultCollectionIdList'|'status'> | null): any {
     if (value == null) {
         return value;
     }

--- a/backend-client/src/models/SpatialDataContainer.ts
+++ b/backend-client/src/models/SpatialDataContainer.ts
@@ -63,11 +63,18 @@ export interface SpatialDataContainer {
      */
     name: string;
     /**
-     * 
+     *
      * @type {ContainerType}
      * @memberof SpatialDataContainer
      */
     readonly type: ContainerType;
+    /**
+     * Lifecycle status. One of DRAFT, IN_REVIEW, READY, PUBLISHED, ARCHIVED.
+     * Absent when null (not yet set on legacy nodes).
+     * @type {string}
+     * @memberof SpatialDataContainer
+     */
+    readonly status?: string | null;
 }
 
 
@@ -103,10 +110,11 @@ export function SpatialDataContainerFromJSONTyped(json: any, ignoreDiscriminator
         'updatedBy': json['updatedBy'],
         'name': json['name'],
         'type': ContainerTypeFromJSON(json['type']),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function SpatialDataContainerToJSON(value?: Omit<SpatialDataContainer, 'id'|'createdAt'|'createdBy'|'updatedAt'|'updatedBy'|'type'> | null): any {
+export function SpatialDataContainerToJSON(value?: Omit<SpatialDataContainer, 'id'|'createdAt'|'createdBy'|'updatedAt'|'updatedBy'|'type'|'status'> | null): any {
     if (value == null) {
         return value;
     }

--- a/backend-client/src/models/StructuredDataContainer.ts
+++ b/backend-client/src/models/StructuredDataContainer.ts
@@ -69,11 +69,18 @@ export interface StructuredDataContainer {
      */
     readonly type: ContainerType;
     /**
-     * 
+     *
      * @type {string}
      * @memberof StructuredDataContainer
      */
     readonly oid: string;
+    /**
+     * Lifecycle status. One of DRAFT, IN_REVIEW, READY, PUBLISHED, ARCHIVED.
+     * Absent when null (not yet set on legacy nodes).
+     * @type {string}
+     * @memberof StructuredDataContainer
+     */
+    readonly status?: string | null;
 }
 
 
@@ -111,10 +118,11 @@ export function StructuredDataContainerFromJSONTyped(json: any, ignoreDiscrimina
         'name': json['name'],
         'type': ContainerTypeFromJSON(json['type']),
         'oid': json['oid'],
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function StructuredDataContainerToJSON(value?: Omit<StructuredDataContainer, 'id'|'createdAt'|'createdBy'|'updatedAt'|'updatedBy'|'type'|'oid'> | null): any {
+export function StructuredDataContainerToJSON(value?: Omit<StructuredDataContainer, 'id'|'createdAt'|'createdBy'|'updatedAt'|'updatedBy'|'type'|'oid'|'status'> | null): any {
     if (value == null) {
         return value;
     }

--- a/backend-client/src/models/TimeseriesContainer.ts
+++ b/backend-client/src/models/TimeseriesContainer.ts
@@ -63,11 +63,18 @@ export interface TimeseriesContainer {
      */
     name: string;
     /**
-     * 
+     *
      * @type {ContainerType}
      * @memberof TimeseriesContainer
      */
     readonly type: ContainerType;
+    /**
+     * Lifecycle status. One of DRAFT, IN_REVIEW, READY, PUBLISHED, ARCHIVED.
+     * Absent when null (not yet set on legacy nodes).
+     * @type {string}
+     * @memberof TimeseriesContainer
+     */
+    readonly status?: string | null;
 }
 
 
@@ -95,7 +102,7 @@ export function TimeseriesContainerFromJSONTyped(json: any, ignoreDiscriminator:
         return json;
     }
     return {
-        
+
         'id': json['id'],
         'createdAt': (new Date(json['createdAt'])),
         'createdBy': json['createdBy'],
@@ -103,15 +110,16 @@ export function TimeseriesContainerFromJSONTyped(json: any, ignoreDiscriminator:
         'updatedBy': json['updatedBy'],
         'name': json['name'],
         'type': ContainerTypeFromJSON(json['type']),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
-export function TimeseriesContainerToJSON(value?: Omit<TimeseriesContainer, 'id'|'createdAt'|'createdBy'|'updatedAt'|'updatedBy'|'type'> | null): any {
+export function TimeseriesContainerToJSON(value?: Omit<TimeseriesContainer, 'id'|'createdAt'|'createdBy'|'updatedAt'|'updatedBy'|'type'|'status'> | null): any {
     if (value == null) {
         return value;
     }
     return {
-        
+
         'name': value['name'],
     };
 }

--- a/backend/src/main/java/de/dlr/shepard/common/neo4j/entities/BasicContainer.java
+++ b/backend/src/main/java/de/dlr/shepard/common/neo4j/entities/BasicContainer.java
@@ -13,6 +13,20 @@ import org.neo4j.ogm.annotation.Relationship;
 @NoArgsConstructor
 public class BasicContainer extends BasicEntity implements HasPermissions {
 
+  /**
+   * Lifecycle status string. Nullable; null on legacy nodes means "not yet set".
+   *
+   * <p>Allowed values: {@code DRAFT}, {@code IN_REVIEW}, {@code READY},
+   * {@code PUBLISHED}, {@code ARCHIVED}. Mirrors the same vocabulary on
+   * {@link de.dlr.shepard.common.neo4j.entities.AbstractDataObject}.
+   *
+   * <p>Additive nullable field — no Neo4j migration needed. Pre-existing
+   * {@code :*Container} nodes without this property are read as {@code null}.
+   * {@code ARCHIVED} was added in #27-ARCHIVED-01; transition guards are
+   * deferred to #27-ARCHIVED-02.
+   */
+  private String status;
+
   @ToString.Exclude
   @Relationship(type = Constants.HAS_PERMISSIONS)
   private Permissions permissions;

--- a/backend/src/main/java/de/dlr/shepard/common/neo4j/io/BasicContainerIO.java
+++ b/backend/src/main/java/de/dlr/shepard/common/neo4j/io/BasicContainerIO.java
@@ -1,5 +1,6 @@
 package de.dlr.shepard.common.neo4j.io;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import de.dlr.shepard.common.neo4j.entities.BasicContainer;
 import de.dlr.shepard.common.neo4j.entities.ContainerType;
 import java.util.Arrays;
@@ -17,11 +18,31 @@ public class BasicContainerIO extends BasicEntityIO {
   @Schema(readOnly = true, required = true)
   private ContainerType type;
 
+  /**
+   * Lifecycle status of this container. Nullable; null means "not yet set".
+   *
+   * <p>Allowed values: {@code DRAFT}, {@code IN_REVIEW}, {@code READY},
+   * {@code PUBLISHED}, {@code ARCHIVED}. {@code ARCHIVED} was introduced in
+   * backlog row #27-ARCHIVED-01; status transition guards are deferred to
+   * #27-ARCHIVED-02.
+   *
+   * <p>Absent from the wire when null ({@code @JsonInclude(NON_NULL)}) for
+   * forward-compatibility — clients that only know the pre-#27-ARCHIVED-01
+   * schema see no change until an operator sets a value.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Schema(
+    nullable = true,
+    enumeration = { "DRAFT", "IN_REVIEW", "READY", "PUBLISHED", "ARCHIVED" }
+  )
+  private String status;
+
   public BasicContainerIO(BasicContainer container) {
     super(container);
     type = Arrays.stream(ContainerType.values())
       .filter(containerType -> containerType.getTypeName().equals(container.getClass().getSimpleName()))
       .findFirst()
       .orElse(ContainerType.BASIC);
+    status = container.getStatus();
   }
 }

--- a/frontend/components/context/display-components/containers/ContainerTitleAndMetadataDisplay.vue
+++ b/frontend/components/context/display-components/containers/ContainerTitleAndMetadataDisplay.vue
@@ -5,6 +5,9 @@ interface ContainerTitleAndMetadataDisplayProps {
   typeLabel: string;
   nItems?: number;
   database?: string;
+  /** Lifecycle status string (DRAFT / IN_REVIEW / READY / PUBLISHED / ARCHIVED).
+   *  When present, a StatusChip is rendered next to the title. Null/undefined = no chip. */
+  status?: string | null;
 }
 
 defineProps<ContainerTitleAndMetadataDisplayProps>();
@@ -13,8 +16,9 @@ defineProps<ContainerTitleAndMetadataDisplayProps>();
 <template>
   <v-container class="pt-0 pl-0 pr-0" fluid>
     <v-row no-gutters>
-      <v-col class="ml-n1 pb-6" cols="12">
+      <v-col class="ml-n1 pb-6 d-flex align-center ga-3" cols="12">
         <h1 class="text-h1">{{ name }}</h1>
+        <StatusChip v-if="status" :status="status" />
       </v-col>
     </v-row>
     <v-row class="text-body-2 text-medium-emphasis">

--- a/frontend/pages/containers/files/[containerId]/index.vue
+++ b/frontend/pages/containers/files/[containerId]/index.vue
@@ -79,6 +79,7 @@ useHead({
               :n-items="containerAccessor.files.value?.length"
               :name="containerAccessor.fileContainer.value.name"
               :type-label="'File Container'"
+              :status="containerAccessor.fileContainer.value.status"
             >
               <template #buttons>
                 <UploadFilesButton

--- a/frontend/pages/containers/spatialdata/[containerId]/index.vue
+++ b/frontend/pages/containers/spatialdata/[containerId]/index.vue
@@ -48,6 +48,7 @@ useHead({
               :id="containerAccessor.spatialData.value.id"
               :name="containerAccessor.spatialData.value.name"
               :type-label="'Spatial Data Container'"
+              :status="containerAccessor.spatialData.value.status"
             >
               <template #buttons>
                 <EditPermissionsButton

--- a/frontend/pages/containers/structureddata/[containerId]/index.vue
+++ b/frontend/pages/containers/structureddata/[containerId]/index.vue
@@ -134,6 +134,7 @@ useHead({
                 :n-items="containerAccessor.items.value.length"
                 :name="containerAccessor.container.value.name"
                 :type-label="'Structured Data Container'"
+                :status="containerAccessor.container.value.status"
               >
                 <template #buttons>
                   <UploadFilesButton

--- a/frontend/pages/containers/timeseries/[containerId]/index.vue
+++ b/frontend/pages/containers/timeseries/[containerId]/index.vue
@@ -139,6 +139,7 @@ useHead({
                 :n-items="containerAccessor.measurements.value.length"
                 :name="containerAccessor.container.value.name"
                 :type-label="'Timeseries Container'"
+                :status="containerAccessor.container.value.status"
               >
                 <template #buttons>
                   <UploadFilesButton


### PR DESCRIPTION
## Summary

- **`ARCHIVED` was already present** in `AbstractDataObjectIO` (covering `Collection` and `DataObject`). This PR extends parity to all `*Container` types.
- Adds a nullable `String status` field to `BasicContainer` entity and `BasicContainerIO` wire shape, with OpenAPI `@Schema enumeration = { "DRAFT", "IN_REVIEW", "READY", "PUBLISHED", "ARCHIVED" }`.
- Updates `backend-client` TypeScript models (`BasicContainer`, `TimeseriesContainer`, `FileContainer`, `StructuredDataContainer`, `SpatialDataContainer`) with `status?: string | null`.
- Updates `ContainerTitleAndMetadataDisplay.vue` to accept a `status` prop and render `<StatusChip>` next to the container title when set.
- All four container pages (`timeseries`, `files`, `structureddata`, `spatialdata`) pass `:status="container.status"` to the display component.

**No migration needed**: `status` is a nullable string in the Neo4j property bag. Pre-existing nodes without the property read as `null` (no chip shown). `StatusChip.vue` already maps `ARCHIVED → { color: 'secondary', label: 'Archived' }`.

**Out of scope for this PR** (deferred):
- Status transition guards (#27-ARCHIVED-02)
- Archive action in the kebab menu (#27-ARCHIVED-03)

## Enums changed

| Entity / IO class | Where |
|---|---|
| `BasicContainer` (entity) | `backend/src/main/java/de/dlr/shepard/common/neo4j/entities/BasicContainer.java` |
| `BasicContainerIO` (wire) | `backend/src/main/java/de/dlr/shepard/common/neo4j/io/BasicContainerIO.java` |
| `BasicContainer.ts` (TS client) | `backend-client/src/models/BasicContainer.ts` |
| `TimeseriesContainer.ts` | `backend-client/src/models/TimeseriesContainer.ts` |
| `FileContainer.ts` | `backend-client/src/models/FileContainer.ts` |
| `StructuredDataContainer.ts` | `backend-client/src/models/StructuredDataContainer.ts` |
| `SpatialDataContainer.ts` | `backend-client/src/models/SpatialDataContainer.ts` |

`Collection`, `DataObject`, `AbstractDataObjectIO` already had `ARCHIVED` before this PR (from COMP-NCR-STATUS work).

## Test plan

- [ ] Backend main source compiles cleanly (`mvn compile -DnoPlugins` passes — verified locally)
- [ ] Pre-existing test compile failures (SpatialDataIT, GitArtifactCacheQuarkusTest) are pre-existing in the environment, not introduced by this PR (verified via git stash comparison)
- [ ] Frontend typecheck passes (`npm run typecheck` — no errors)
- [ ] Frontend lint: 83 pre-existing errors unchanged, 0 new errors introduced (verified via git stash comparison)
- [ ] Frontend unit tests: 5 pre-existing failures unchanged (verified via git stash comparison)
- [ ] Setting `status: "ARCHIVED"` on a container entity will cause the grey "Archived" chip to appear next to the container name header

https://claude.ai/code/session_01QEp5QciNCYETmtABKWPTNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEp5QciNCYETmtABKWPTNx)_