### PR TITLE
feat(UX-WALK-2026-05-29-07): "Visualize all in 3D" CTA on TS container page

### DIFF
--- a/aidocs/agent-findings/dispatcher-runs/2026-05-29-19.md
+++ b/aidocs/agent-findings/dispatcher-runs/2026-05-29-19.md
@@ -1,0 +1,53 @@
+---
+stage: fragment
+last-stage-change: 2026-05-29
+---
+
+# Dispatcher run — 2026-05-29 19:xx UTC
+
+**Trigger:** cron `0 * * * *`  
+**Considered:** 18 rows  
+**Dispatched:** 3  
+**Skipped:** 15  
+**Recent commits at fire time:** `a20d12d`, `d7348a3`, `14bb646`, `a933681`, `06501aa`
+
+---
+
+## Dispatched
+
+| Row | Title | PR | Branch | Size |
+|-----|-------|----|--------|------|
+| UX-WALK-2026-05-29-07 | Add "Visualize all in 3D" CTA to TS container page | pending | `UX-WALK-2026-05-29-07-trace3d-cta` | S |
+| UI21-SIZEBAR-DATA | Richer sizebar metric — per-kind cardinality summary endpoint + frontend swap | pending | `UI21-SIZEBAR-DATA-container-summary` | S |
+| DB-BP1 | DB best-practices catalogue — `aidocs/data/<NN>-db-best-practices.md` | pending | `DB-BP1-best-practices-catalogue` | M |
+
+---
+
+## Skipped
+
+| Row | Reason |
+|-----|--------|
+| FE-BUILD-03-REGEN | Already in-flight — open PR #1585 |
+| PERF11 | Already in-flight — open PR #1586 |
+| RDM-003 | Already in-flight — open PR #1587 |
+| BTKVS-A2-OPS | Already in-flight — open PR #1588 |
+| PROV-CAPTURE-READS-FLIP | Already in-flight — open PR #1589 |
+| J1e-PR-08+09 | Already in-flight — open PR #1590 |
+| HELM-K8S-DEPLOY-01 | Already in-flight — open PR #1583 |
+| #27-ARCHIVED-01 | Already in-flight — open PR #1582 |
+| MFG1/STDRULE-UI-STUB-REQUIRED/TS-AUDIT-2026-05-24-011/UX-ANNO1/M4I-e/MONGO-AUDIT-2026-05-24-011/M4I-f | Already in-flight — PRs #1565–#1568 |
+| PERF13 | Gated on PERF11 (still in-flight as #1586) |
+| L2e | BREAKING — drops /v1/ paths |
+| F1/P5 | Auth/permissions — excluded per hard constraint |
+| ID-MIG1/2/3 | appId→shepardId rename arc — excluded per hard constraint |
+| VIS-S1b | Security-adjacent (JWT access-control filter) — deferred |
+| IOT1 | Needs network access to W3C/QUDT hosts — not safe headless |
+
+---
+
+## Notes
+
+- UX-WALK-2026-05-29-07 was deferred in the 18:00 fire for queue capacity; dispatched now.
+- UI21-SIZEBAR-DATA was filed as a follow-up when UI21 shipped (2026-05-28, `474bdbf58`); the per-kind cardinality endpoint is the clean fix vs. the CC1e proxy count currently used.
+- DB-BP1 is a pure research+doc task; zero code risk; fills a living reference for new contributors.
+- This log will be updated with PR numbers once agents report back.

--- a/frontend/components/container/timeseries/ViewRecipeBuilderDialog.vue
+++ b/frontend/components/container/timeseries/ViewRecipeBuilderDialog.vue
@@ -8,8 +8,10 @@ const props = defineProps<{
   channels: Timeseries[];
   /** v2 channel list carrying shepardId for auto-populate and annotation save. */
   channelsV2?: ChannelV2[];
-  startNs: number;
-  endNs: number;
+  /** Time bounds in nanoseconds. When omitted (container-level CTA with no
+   *  reference window), the render page uses its default live-window query. */
+  startNs?: number;
+  endNs?: number;
 }>();
 
 const open = defineModel<boolean>({ default: false });
@@ -91,8 +93,8 @@ function openTrace3D() {
     path: "/shapes/render",
     query: {
       containerId: String(props.containerId),
-      startNs:    String(props.startNs),
-      endNs:      String(props.endNs),
+      ...(props.startNs != null && { startNs: String(props.startNs) }),
+      ...(props.endNs   != null && { endNs:   String(props.endNs) }),
       colormap:   sel.colormap,
       roles:      btoa(JSON.stringify(roles)),
     },
@@ -109,8 +111,8 @@ function openUrdf() {
       urdfUrl:     encodeURIComponent(urdfUrl.value.trim()),
       packagePath: encodeURIComponent(urdfPackagePath.value.trim()),
       containerId: String(props.containerId),
-      startNs:     String(props.startNs),
-      endNs:       String(props.endNs),
+      ...(props.startNs != null && { startNs: String(props.startNs) }),
+      ...(props.endNs   != null && { endNs:   String(props.endNs) }),
     },
   });
 }
@@ -128,8 +130,8 @@ function openThermography() {
     query: {
       renderer:    "thermography",
       containerId: String(props.containerId),
-      startNs:     String(props.startNs),
-      endNs:       String(props.endNs),
+      ...(props.startNs != null && { startNs: String(props.startNs) }),
+      ...(props.endNs   != null && { endNs:   String(props.endNs) }),
     },
   });
 }

--- a/frontend/pages/containers/timeseries/[containerId]/index.vue
+++ b/frontend/pages/containers/timeseries/[containerId]/index.vue
@@ -104,6 +104,14 @@ const uploadFile = async (file: File): Promise<void> => {
 
 fetchData();
 
+// UX-WALK-2026-05-29-07: "Visualize all in 3D" CTA — one click upstream of the
+// TimeseriesReference-level entry point. Shown when ≥3 channels are loaded so
+// the picker can fill the required x/y/z roles.
+const showVisualize3D = ref(false);
+const canVisualize3D = computed(
+  () => (containerAccessor.measurements.value.length ?? 0) >= 3,
+);
+
 // UX Pattern F (2026-05-24): reactive title — call useHead once with a getter.
 useHead({
   title: () =>
@@ -141,6 +149,15 @@ useHead({
                 :type-label="'Timeseries Container'"
               >
                 <template #buttons>
+                  <v-btn
+                    v-if="canVisualize3D"
+                    size="small"
+                    variant="tonal"
+                    prepend-icon="mdi-cube-outline"
+                    @click="showVisualize3D = true"
+                  >
+                    Visualize all in 3D
+                  </v-btn>
                   <UploadFilesButton
                     v-if="containerAccessor.isAllowedToEditData.value"
                     accept=".csv"
@@ -321,6 +338,12 @@ useHead({
         </ExpansionPanelItem>
       </ExpansionPanels>
     </v-container>
+    <ViewRecipeBuilderDialog
+      v-if="containerAccessor.container.value"
+      v-model="showVisualize3D"
+      :container-id="containerId"
+      :channels="containerAccessor.measurements.value"
+    />
   </PageShell>
 </template>
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a **"Visualize all in 3D"** button to the timeseries container detail page (`/containers/timeseries/[containerId]`), inside the `ContainerTitleAndMetadataDisplay #buttons` slot
- Button is shown only when ≥3 channels are loaded (matching the existing reference-level `canVisualize3D` guard for x/y/z roles)
- Clicking the button opens the existing `ViewRecipeBuilderDialog`, which lets the user pick channel roles and launch Trace3D / URDF / Thermography renderers
- Makes `startNs` and `endNs` props optional in `ViewRecipeBuilderDialog` — when omitted (container-level CTA), the render page falls back to its default live-window query; existing reference-level callers that pass explicit time bounds are unaffected

## Why

Backlog row **UX-WALK-2026-05-29-07** (aidocs/16): shortens the path for researchers who land on the TS container first. Previously the Trace3D entry point required navigating into a specific TimeseriesReference — now it is one click from the container page itself.

Acceptance criterion: *"Add 'Visualize all in 3D' / Trace3D CTA on the TS container page (one click upstream of the current TimeseriesReference-level entry point). Shortens the path for researchers who land on the container first. NICE — not a regression."*

## Gates

- `npm run lint`: 115 pre-existing errors (unrelated to this change); no new errors introduced in changed files
- `npm run test`: 1053/1058 pass; 5 pre-existing failures in `useFetchRecentCollections.test.ts` (confirmed pre-existing by running without this change)
- `npm run typecheck`: **passes cleanly**
- `mvn verify`, redeploy, Playwright: N/A — frontend-only UX addition, no backend surface, no layout change

https://claude.ai/code/session_0125PGVQM9eSDAsWCxcTNxus
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0125PGVQM9eSDAsWCxcTNxus)_