### PR TITLE
fix(FRONTEND-LINT-DEBT-02): replace explicit any casts in test files with typed alternatives

### DIFF
--- a/frontend/components/container/file/FilesTable.vue
+++ b/frontend/components/container/file/FilesTable.vue
@@ -13,10 +13,12 @@ const emit = defineEmits<{
   (e: "download-file" | "delete-file", value: ShepardFile): void;
 }>();
 
+type DataTableHeader = { title: string; key?: string; value?: string; sortable?: boolean; width?: string };
+
 // UI-015: the `header.createdAt` slot below wraps the column title in a
 // `text-no-wrap` span so the two-word "Created at" stays on one line and
 // doesn't push every row half a line down.
-const headers = computed(() => [
+const headers = computed<DataTableHeader[]>(() => [
   ...(props.containerAppId
     ? [{ title: "", key: "thumbnail", sortable: false, width: "64px" }]
     : []),
@@ -54,7 +56,7 @@ const openHistory = (file: ShepardFile) => {
       :header-props="{
         class: 'text-subtitle-2 text-textbody1',
       }"
-      :headers="(headers as any)"
+      :headers="headers"
       :items-for-pagination="files"
       :loading="loading"
     >

--- a/frontend/components/context/collection/CollectionLineageGraph.vue
+++ b/frontend/components/context/collection/CollectionLineageGraph.vue
@@ -28,11 +28,11 @@ const STATUS_COLORS: Record<string, string> = {
 };
 
 function statusColor(do_: DataObjectListItemV2): string {
-  return STATUS_COLORS[(do_ as any).status ?? ""] ?? "#8C8C8C";
+  return STATUS_COLORS[do_.status ?? ""] ?? "#8C8C8C";
 }
 
 function doLabel(do_: DataObjectListItemV2): string {
-  return (do_ as any).name ?? String((do_ as any).id);
+  return do_.name ?? String(do_.id);
 }
 
 function dagreLayout(dos: DataObjectListItemV2[]): Map<number, { x: number; y: number }> {
@@ -40,20 +40,20 @@ function dagreLayout(dos: DataObjectListItemV2[]): Map<number, { x: number; y: n
   g.setGraph({ rankdir: "LR", nodesep: 55, ranksep: 200, marginx: 60, marginy: 40 });
   g.setDefaultEdgeLabel(() => ({}));
 
-  const visibleIds = new Set(dos.map(d => (d as any).id as number));
+  const visibleIds = new Set(dos.map(d => d.id));
 
   for (const d of dos) {
-    g.setNode(String((d as any).id), { width: 90, height: 30 });
+    g.setNode(String(d.id), { width: 90, height: 30 });
   }
   for (const d of dos) {
-    for (const predId of ((d as any).predecessorIds ?? []) as number[]) {
+    for (const predId of d.predecessorIds ?? []) {
       if (visibleIds.has(predId)) {
-        g.setEdge(String(predId), String((d as any).id));
+        g.setEdge(String(predId), String(d.id));
       }
     }
-    const parentId = (d as any).parentId as number | null;
+    const parentId = d.parentId;
     if (parentId && visibleIds.has(parentId)) {
-      g.setEdge(String(parentId), String((d as any).id));
+      g.setEdge(String(parentId), String(d.id));
     }
   }
 
@@ -61,8 +61,8 @@ function dagreLayout(dos: DataObjectListItemV2[]): Map<number, { x: number; y: n
 
   const positions = new Map<number, { x: number; y: number }>();
   for (const d of dos) {
-    const node = g.node(String((d as any).id));
-    positions.set((d as any).id as number, { x: node.x, y: node.y });
+    const node = g.node(String(d.id));
+    positions.set(d.id, { x: node.x, y: node.y });
   }
   return positions;
 }
@@ -74,11 +74,11 @@ const chartOption = computed(() => {
   const dos = visibleDos.value;
   if (!dos.length) return {};
 
-  const visibleIds = new Set(dos.map(d => (d as any).id as number));
+  const visibleIds = new Set(dos.map(d => d.id));
   const positions  = dagreLayout(dos);
 
   const nodes = dos.map(d => {
-    const id  = (d as any).id as number;
+    const id  = d.id;
     const pos = positions.get(id) ?? { x: 0, y: 0 };
     return {
       id:         String(id),
@@ -94,8 +94,8 @@ const chartOption = computed(() => {
 
   const edges: Array<{ source: string; target: string; lineStyle: object }> = [];
   dos.forEach(d => {
-    const id       = (d as any).id as number;
-    const parentId = (d as any).parentId as number | null;
+    const id       = d.id;
+    const parentId = d.parentId;
     if (parentId && visibleIds.has(parentId)) {
       edges.push({
         source:    String(parentId),
@@ -103,7 +103,7 @@ const chartOption = computed(() => {
         lineStyle: { type: "solid", color: "#888", opacity: 0.5 },
       });
     }
-    for (const predId of ((d as any).predecessorIds ?? []) as number[]) {
+    for (const predId of d.predecessorIds ?? []) {
       if (visibleIds.has(predId)) {
         edges.push({
           source:    String(predId),
@@ -114,12 +114,18 @@ const chartOption = computed(() => {
     }
   });
 
+  type TooltipParams = {
+    dataType: string;
+    name: string;
+    data: { value: number; lineStyle?: { type?: string } };
+  };
+
   return {
     backgroundColor: "transparent",
     tooltip: {
-      formatter: (params: any) => {
+      formatter: (params: TooltipParams) => {
         if (params.dataType === "node") {
-          const d = dos.find(x => (x as any).id === params.data.value) as any;
+          const d = dos.find(x => x.id === params.data.value);
           if (!d) return params.name;
           const desc = d.description
             ? `<br/><span style="color:#999;font-size:11px">${String(d.description).substring(0, 120)}${d.description.length > 120 ? "…" : ""}</span>`
@@ -153,7 +159,7 @@ const chartOption = computed(() => {
           position: "bottom",
           fontSize:  11,
           color:    "inherit",
-          formatter: (params: any) => {
+          formatter: (params: { name?: string }) => {
             const n: string = params.name ?? "";
             return n.length > 18 ? n.substring(0, 16) + "…" : n;
           },

--- a/frontend/components/context/configuration/SemanticRepositoryPane.vue
+++ b/frontend/components/context/configuration/SemanticRepositoryPane.vue
@@ -36,8 +36,8 @@ watch(
       return;
     }
     // Only probe when an INTERNAL repository is present.
-    // The TypeScript client predates the INTERNAL type, so cast to any.
-    if (!repos.some(r => (r as any).type === "INTERNAL")) return;
+    // The TypeScript client predates the INTERNAL type; cast to string for the unknown enum value.
+    if (!repos.some(r => (r.type as string) === "INTERNAL")) return;
     const results = await search("aa", 1);
     noLabelsWarning.value = results.length === 0;
   },

--- a/frontend/composables/useLineageGraph.ts
+++ b/frontend/composables/useLineageGraph.ts
@@ -1,0 +1,102 @@
+/**
+ * useLineageGraph — shared graph primitives for ECharts graph visualisations.
+ *
+ * Extracted from CollectionLineageGraph.vue and DataObjectProvGraph.vue (UI16).
+ * Both components share: status/action colour palettes, a label-truncation
+ * function, and the common ECharts series fragments.
+ *
+ * Usage:
+ *   import { truncateLabel, STATUS_COLORS, ACTION_COLORS, DEFAULT_NODE_COLOR, baseGraphSeriesConfig }
+ *     from "~/composables/useLineageGraph";
+ */
+
+// ---------------------------------------------------------------------------
+// Colour palettes
+// ---------------------------------------------------------------------------
+
+/** Colour per DataObject status — used in CollectionLineageGraph */
+export const STATUS_COLORS: Record<string, string> = {
+  DRAFT:     "#8C8C8C",
+  IN_REVIEW: "#FCA54D",
+  READY:     "#4097CC",
+  PUBLISHED: "#7ECA8F",
+  ARCHIVED:  "#B799DB",
+};
+
+/** Colour per provenance action kind — used in DataObjectProvGraph */
+export const ACTION_COLORS: Record<string, string> = {
+  CREATE:  "#7ECA8F",
+  UPDATE:  "#4097CC",
+  DELETE:  "#E56874",
+  READ:    "#8C8C8C",
+  EXECUTE: "#B799DB",
+};
+
+/** Fallback colour for unknown node types */
+export const DEFAULT_NODE_COLOR = "#8C8C8C";
+
+/**
+ * Look up the colour for a given node-type key.
+ *
+ * @param type    - The key to look up (e.g. "DRAFT" or "CREATE").
+ * @param palette - Which palette to consult (defaults to STATUS_COLORS).
+ * @returns The hex colour string, or DEFAULT_NODE_COLOR if the key is missing.
+ */
+export function nodeColor(
+  type: string,
+  palette: Record<string, string> = STATUS_COLORS,
+): string {
+  return palette[type] ?? DEFAULT_NODE_COLOR;
+}
+
+// ---------------------------------------------------------------------------
+// Label truncation
+// ---------------------------------------------------------------------------
+
+/**
+ * Truncate a label to at most `maxLen` characters (inclusive).
+ *
+ * If the label is longer than `maxLen` characters, the returned string is
+ * `label.slice(0, maxLen - 2) + "…"` (so the total length is still maxLen−1
+ * character + 1 ellipsis = maxLen−1 displayed glyphs + the "…" character).
+ *
+ * CollectionLineageGraph uses maxLen = 18 (default).
+ * DataObjectProvGraph uses maxLen = 16.
+ *
+ * @param label  - The raw label string.
+ * @param maxLen - Threshold length; labels equal to or shorter are returned as-is.
+ */
+export function truncateLabel(label: string, maxLen = 18): string {
+  return label.length > maxLen ? label.slice(0, maxLen - 2) + "…" : label;
+}
+
+// ---------------------------------------------------------------------------
+// Shared ECharts series fragment
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the ECharts `series` properties shared by every Shepard graph.
+ *
+ * These are the fields both CollectionLineageGraph (layout:"none") and
+ * DataObjectProvGraph (layout:"force") have in common.  The caller spreads
+ * this result and adds its own `layout`, `nodes`, `edges`, and any layout-
+ * specific overrides.
+ *
+ * The returned object intentionally omits `layout`, `nodes`, and `edges` so
+ * callers are forced to supply them — preventing accidental use of stale data.
+ */
+export function baseGraphSeriesConfig(): Record<string, unknown> {
+  return {
+    type:           "graph",
+    roam:           true,
+    edgeSymbol:     ["none", "arrow"] as [string, string],
+    edgeSymbolSize: [0, 8] as [number, number],
+    emphasis: {
+      focus: "adjacency",
+    },
+    lineStyle: { curveness: 0.15 },
+    label: {
+      color: "inherit",
+    },
+  };
+}

--- a/frontend/tests/unit/useFetchCollectionLabJournalEntries.test.ts
+++ b/frontend/tests/unit/useFetchCollectionLabJournalEntries.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LabJournalEntry } from "@dlr-shepard/backend-client";
 
 // Mock BEFORE importing the module under test so the mock is hoisted.
 vi.mock("~/composables/common/api/useV2ShepardApi", () => ({
@@ -23,7 +24,7 @@ beforeEach(() => {
 /** Flush micro-task queue (watch({ immediate }) fires after the current tick). */
 const flush = () => new Promise<void>(r => setTimeout(r, 0));
 
-const fakeEntry = (id: number, dataObjectId: number, content = "x"): unknown => ({
+const fakeEntry = (id: number, dataObjectId: number, content = "x"): LabJournalEntry => ({
   id,
   dataObjectId,
   journalContent: content,
@@ -89,11 +90,10 @@ describe("useFetchCollectionLabJournalEntries — single bulk fetch", () => {
 
 describe("groupByDataObjectId", () => {
   it("groups multiple entries under the same dataObjectId", () => {
-    const a = fakeEntry(1, 100) as { dataObjectId: number };
-    const b = fakeEntry(2, 100) as { dataObjectId: number };
-    const c = fakeEntry(3, 200) as { dataObjectId: number };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const grouped = groupByDataObjectId([a, b, c] as any);
+    const a = fakeEntry(1, 100);
+    const b = fakeEntry(2, 100);
+    const c = fakeEntry(3, 200);
+    const grouped = groupByDataObjectId([a, b, c]);
     expect(grouped.get(100)).toHaveLength(2);
     expect(grouped.get(200)).toHaveLength(1);
   });
@@ -104,10 +104,9 @@ describe("groupByDataObjectId", () => {
   });
 
   it("preserves input order within a group (createdAt DESC from server)", () => {
-    const newer = fakeEntry(11, 50) as { id: number; dataObjectId: number };
-    const older = fakeEntry(7, 50) as { id: number; dataObjectId: number };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const grouped = groupByDataObjectId([newer, older] as any);
+    const newer = fakeEntry(11, 50);
+    const older = fakeEntry(7, 50);
+    const grouped = groupByDataObjectId([newer, older]);
     const bucket = grouped.get(50);
     expect(bucket).toBeDefined();
     expect(bucket![0]).toEqual(newer);

--- a/frontend/tests/unit/useLineageGraph.test.ts
+++ b/frontend/tests/unit/useLineageGraph.test.ts
@@ -1,0 +1,214 @@
+/**
+ * UI16 — useLineageGraph composable
+ *
+ * Tests the three pure-function exports:
+ *   - truncateLabel
+ *   - nodeColor
+ *   - baseGraphSeriesConfig (structural shape check)
+ */
+import { describe, it, expect } from "vitest";
+import {
+  truncateLabel,
+  nodeColor,
+  baseGraphSeriesConfig,
+  STATUS_COLORS,
+  ACTION_COLORS,
+  DEFAULT_NODE_COLOR,
+} from "~/composables/useLineageGraph";
+
+// ---------------------------------------------------------------------------
+// truncateLabel
+// ---------------------------------------------------------------------------
+
+describe("truncateLabel", () => {
+  // ---- default threshold (maxLen = 18) used by CollectionLineageGraph ----
+
+  it("returns label unchanged when shorter than default threshold", () => {
+    expect(truncateLabel("short")).toBe("short");
+  });
+
+  it("returns label unchanged when exactly at default threshold (18 chars)", () => {
+    const label = "a".repeat(18);
+    expect(truncateLabel(label)).toBe(label);
+  });
+
+  it("truncates when one char over default threshold (19 chars)", () => {
+    const label = "a".repeat(19);
+    expect(truncateLabel(label)).toBe("a".repeat(16) + "…");
+  });
+
+  it("truncates a realistic long name at default threshold", () => {
+    const result = truncateLabel("TR-004_AnomalyInvestigation");
+    // slice(0, 16) = "TR-004_AnomalyIn" + "…"
+    expect(result).toBe("TR-004_AnomalyIn…");
+    expect(result.length).toBe(17); // 16 chars + "…"
+  });
+
+  // ---- explicit maxLen = 16 used by DataObjectProvGraph ----
+
+  it("returns label unchanged when shorter than explicit threshold of 16", () => {
+    const label = "a".repeat(15);
+    expect(truncateLabel(label, 16)).toBe(label);
+  });
+
+  it("returns label unchanged when exactly at threshold of 16", () => {
+    const label = "a".repeat(16);
+    expect(truncateLabel(label, 16)).toBe(label);
+  });
+
+  it("truncates when one char over threshold of 16 (17 chars)", () => {
+    const label = "a".repeat(17);
+    expect(truncateLabel(label, 16)).toBe("a".repeat(14) + "…");
+  });
+
+  it("truncates a realistic long name at threshold 16", () => {
+    const result = truncateLabel("AnomalyDetection", 16);
+    // exactly 16 chars — should not truncate
+    expect(result).toBe("AnomalyDetection");
+  });
+
+  it("truncates a 17-char name at threshold 16", () => {
+    const result = truncateLabel("AnomalyDetection2", 16);
+    expect(result).toBe("AnomalyDetecti…");
+    expect(result.length).toBe(15); // 14 chars + "…"
+  });
+
+  // ---- edge cases ----
+
+  it("handles empty string without error", () => {
+    expect(truncateLabel("")).toBe("");
+  });
+
+  it("handles a single-character string", () => {
+    expect(truncateLabel("X")).toBe("X");
+  });
+
+  it("produces exactly maxLen−1 + 1 ellipsis character when truncating", () => {
+    // With maxLen=10: result should be 8 chars + "…" = 9 total chars
+    const long = "a".repeat(20);
+    const result = truncateLabel(long, 10);
+    expect(result).toBe("a".repeat(8) + "…");
+    // Length in JS: "…" is one code unit
+    expect([...result].length).toBe(9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nodeColor
+// ---------------------------------------------------------------------------
+
+describe("nodeColor", () => {
+  // ---- STATUS_COLORS palette (default) ----
+
+  it("returns the correct colour for DRAFT", () => {
+    expect(nodeColor("DRAFT")).toBe(STATUS_COLORS.DRAFT);
+    expect(nodeColor("DRAFT")).toBe("#8C8C8C");
+  });
+
+  it("returns the correct colour for IN_REVIEW", () => {
+    expect(nodeColor("IN_REVIEW")).toBe("#FCA54D");
+  });
+
+  it("returns the correct colour for READY", () => {
+    expect(nodeColor("READY")).toBe("#4097CC");
+  });
+
+  it("returns the correct colour for PUBLISHED", () => {
+    expect(nodeColor("PUBLISHED")).toBe("#7ECA8F");
+  });
+
+  it("returns the correct colour for ARCHIVED", () => {
+    expect(nodeColor("ARCHIVED")).toBe("#B799DB");
+  });
+
+  it("returns DEFAULT_NODE_COLOR for an unknown status", () => {
+    expect(nodeColor("NONEXISTENT")).toBe(DEFAULT_NODE_COLOR);
+    expect(nodeColor("")).toBe(DEFAULT_NODE_COLOR);
+  });
+
+  // ---- ACTION_COLORS palette (explicit second argument) ----
+
+  it("returns the correct colour for CREATE in ACTION_COLORS", () => {
+    expect(nodeColor("CREATE", ACTION_COLORS)).toBe("#7ECA8F");
+  });
+
+  it("returns the correct colour for UPDATE in ACTION_COLORS", () => {
+    expect(nodeColor("UPDATE", ACTION_COLORS)).toBe("#4097CC");
+  });
+
+  it("returns the correct colour for DELETE in ACTION_COLORS", () => {
+    expect(nodeColor("DELETE", ACTION_COLORS)).toBe("#E56874");
+  });
+
+  it("returns the correct colour for READ in ACTION_COLORS", () => {
+    expect(nodeColor("READ", ACTION_COLORS)).toBe("#8C8C8C");
+  });
+
+  it("returns the correct colour for EXECUTE in ACTION_COLORS", () => {
+    expect(nodeColor("EXECUTE", ACTION_COLORS)).toBe("#B799DB");
+  });
+
+  it("returns DEFAULT_NODE_COLOR for an unknown action kind", () => {
+    expect(nodeColor("UNKNOWN", ACTION_COLORS)).toBe(DEFAULT_NODE_COLOR);
+  });
+
+  // ---- custom palette ----
+
+  it("accepts an arbitrary palette record", () => {
+    const palette = { FOO: "#123456", BAR: "#abcdef" };
+    expect(nodeColor("FOO", palette)).toBe("#123456");
+    expect(nodeColor("BAR", palette)).toBe("#abcdef");
+    expect(nodeColor("BAZ", palette)).toBe(DEFAULT_NODE_COLOR);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// baseGraphSeriesConfig — structural shape
+// ---------------------------------------------------------------------------
+
+describe("baseGraphSeriesConfig", () => {
+  it("returns an object with type 'graph'", () => {
+    expect(baseGraphSeriesConfig().type).toBe("graph");
+  });
+
+  it("enables roam", () => {
+    expect(baseGraphSeriesConfig().roam).toBe(true);
+  });
+
+  it("sets edgeSymbol to ['none', 'arrow']", () => {
+    expect(baseGraphSeriesConfig().edgeSymbol).toEqual(["none", "arrow"]);
+  });
+
+  it("sets lineStyle curveness", () => {
+    const cfg = baseGraphSeriesConfig();
+    expect((cfg.lineStyle as { curveness?: number }).curveness).toBe(0.15);
+  });
+
+  it("sets emphasis.focus to 'adjacency'", () => {
+    const cfg = baseGraphSeriesConfig();
+    expect((cfg.emphasis as { focus?: string }).focus).toBe("adjacency");
+  });
+
+  it("sets label.color to 'inherit'", () => {
+    const cfg = baseGraphSeriesConfig();
+    expect((cfg.label as { color?: string }).color).toBe("inherit");
+  });
+
+  it("does NOT include layout (callers must specify their own)", () => {
+    expect("layout" in baseGraphSeriesConfig()).toBe(false);
+  });
+
+  it("does NOT include nodes (callers must supply them)", () => {
+    expect("nodes" in baseGraphSeriesConfig()).toBe(false);
+  });
+
+  it("does NOT include edges (callers must supply them)", () => {
+    expect("edges" in baseGraphSeriesConfig()).toBe(false);
+  });
+
+  it("returns a new object on each call (no shared mutation risk)", () => {
+    const a = baseGraphSeriesConfig();
+    const b = baseGraphSeriesConfig();
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## FRONTEND-LINT-DEBT-02 — Fix @typescript-eslint/no-explicit-any

Replaces `as any` casts in test files and component shims with proper typed alternatives.

### Changes

- **`useLineageGraph.test.ts`** (new file, brought from main): Replace `(cfg.lineStyle as any).curveness`, `(cfg.emphasis as any).focus`, `(cfg.label as any).color` with inline structural casts `{ curveness?: number }`, `{ focus?: string }`, `{ color?: string }`. Also includes the `useLineageGraph.ts` composable (extracted from `CollectionLineageGraph.vue` as part of UI16).

- **`useFetchCollectionLabJournalEntries.test.ts`**: Type `fakeEntry()` return as `LabJournalEntry` (imported from `@dlr-shepard/backend-client`), eliminating the need for `as any` on `groupByDataObjectId()` calls. Removes 2 `eslint-disable-next-line` comments.

- **`CollectionLineageGraph.vue`**: Remove all `(do_ as any).id/.name/.status/.predecessorIds/.parentId` casts — these fields are already on `DataObjectListItemV2` (which extends `DataObject`). Replace ECharts formatter callback `params: any` with structural types `TooltipParams` and `{ name?: string }`.

- **`FilesTable.vue`**: Add local `DataTableHeader` type alias so the `headers` computed ref is explicitly typed; remove `:headers="(headers as any)"` cast from template.

- **`SemanticRepositoryPane.vue`**: Replace `(r as any).type === "INTERNAL"` with `(r.type as string) === "INTERNAL"` — `SemanticRepository` already has a `.type` field; `INTERNAL` is an undeclared enum value that predates the current client.

### Not fixed (intentional)

- `TimeseriesChart.vue` — ECharts callback types are complex; the two `any` instances there require importing ECharts internal types. Left as-is per task scope.
- `DataObjectProvGraph.vue` — out of scope for this task; has its own `no-explicit-any` instances from the same ECharts callback pattern.

### Test plan

- `npm run lint` passes with no `no-explicit-any` warnings on the changed files
- `npm run test` — 369 tests pass (5 pre-existing failures in `useFetchRecentCollections.test.ts`, present before this PR)
- `npm run typecheck` — clean exit (0)

https://claude.ai/code/session_01KuVxGKS2kP8zLKwjGmy7Jv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuVxGKS2kP8zLKwjGmy7Jv)_