### PR TITLE
docs(D1c): task-shaped help pages — share, export, process-step

### DIFF
--- a/docs/help/export-rocrate.md
+++ b/docs/help/export-rocrate.md
@@ -1,0 +1,157 @@
+---
+layout: default
+title: Export a collection as RO-Crate
+description: How to download a collection as a self-contained RO-Crate ZIP package for archiving or sharing
+permalink: /help/export-rocrate/
+audience: user
+stage: deployed
+---
+# Export a collection as RO-Crate
+
+An **RO-Crate export** bundles a collection's metadata and data
+payloads into a single ZIP file that follows the
+[RO-Crate 1.1 specification](https://www.researchobject.org/ro-crate/).
+The result is a self-contained, machine-readable archive — useful for:
+
+- Handing a dataset to a collaborator at another institute who has no
+  shepard account.
+- Submitting to a data repository that accepts RO-Crate deposits.
+- Long-term archiving at a suitable infrastructure.
+
+## Quick export from the UI
+
+1. Open the collection you want to export.
+2. In the collection action bar, click **Export → Download RO-Crate**.
+3. The browser downloads a `<collectionId>-export.zip`.
+
+The ZIP contains an `ro-crate-metadata.json` manifest describing the
+collection and its DataObjects, plus the actual payload files (CSVs
+for timeseries channels, raw files for FileReferences, JSON for
+structured-data references). Lab-journal entries are included by
+default.
+
+## Presigned download URL (S3 storage)
+
+If your shepard instance uses S3-compatible object storage (MinIO,
+AWS S3, etc.) you can request a **presigned URL** instead of
+streaming the ZIP through the browser. The ZIP is built server-side
+and uploaded to object storage; the returned URL is valid for 30
+minutes and downloads the ZIP directly from storage — good for large
+collections:
+
+```
+POST /v2/collections/{appId}/export-url
+Content-Type: application/json
+
+{}
+```
+
+Response:
+
+```json
+{
+  "url": "https://minio.example.dlr.de/exports/abc123.zip?X-Amz-...",
+  "fileName": "01HF...-export.zip",
+  "expiresAt": "2026-05-29T15:30:00Z"
+}
+```
+
+Open or `curl` the `url` within the validity window to download.
+If your instance uses GridFS (MongoDB) instead of S3 the endpoint
+returns 503 — fall back to the streaming export below.
+
+## Streaming export (legacy / GridFS instances)
+
+```
+GET /shepard/api/collections/{collectionId}/export
+```
+
+Replace `{collectionId}` with the numeric id from the collection
+detail page (or retrieve it via `GET /v2/collections/{appId}`).
+
+The server streams the ZIP directly in the response body. This works
+on all storage backends but holds a server thread for the duration of
+the download.
+
+## Filtered export
+
+If you only need part of a collection — specific payload kinds, a
+time window for timeseries channels, or just selected files — include
+an `ExportSelection` body in the presigned-URL request:
+
+```
+POST /v2/collections/{appId}/export-url
+Content-Type: application/json
+
+{
+  "payloads": {
+    "include": ["FileReference", "TimeseriesReference"],
+    "excludeIds": ["<referenceId-to-skip>"],
+    "perPayload": {
+      "<timeseriesReferenceId>": {
+        "timeRange": {
+          "start": "2024-06-02T08:00:00Z",
+          "end":   "2024-06-02T10:00:00Z"
+        },
+        "columns": ["pressure_bar", "temperature_K"]
+      }
+    }
+  },
+  "metadata": {
+    "annotations": true,
+    "permissions": false
+  }
+}
+```
+
+The `ExportSelection` is optional — an empty body `{}` or no body
+at all produces the full collection export.
+
+**Snapshot-based export:** if you have created a
+[snapshot](/reference/snapshots/) of the collection, pass its `appId`
+to get a reproducible subset:
+
+```json
+{ "snapshotAppId": "<snapshot-appId>" }
+```
+
+Only DataObjects captured in that snapshot will appear in the ZIP.
+
+## What the ZIP contains
+
+```
+my-collection-export.zip
+├── ro-crate-metadata.json        ← RO-Crate 1.1 manifest
+├── <dataObjectId>/
+│   ├── <dataObjectId>.json       ← DataObject metadata + attributes
+│   ├── <fileId>.<ext>            ← attached files (FileReferences)
+│   ├── <timeseriesId>.csv        ← timeseries data (one CSV per reference)
+│   ├── <structuredDataId>.json   ← structured-data payloads
+│   └── ...
+└── ...
+```
+
+Lab-journal markdown entries are embedded in the DataObject metadata
+by default. To exclude them, set `"labJournal": false` under `metadata`
+in the `ExportSelection`.
+
+## Permissions and privacy
+
+You need at least **Reader** access to export a collection. The export
+includes everything you can see — the same access rules that govern
+the REST surface apply inside the export.
+
+If you want to share the ZIP with someone outside your organisation
+but prefer not to expose usernames, add
+`"permissions": true, "redactFields": ["PERMISSION_USERNAME"]` to the
+`metadata` block. shepard replaces every username in the
+`-permissions.json` sidecar files with `[REDACTED]` but still records
+the structure so the crate remains self-describing.
+
+## Further reading
+
+- [User guide](/user-guide/) — overview of collections and DataObjects.
+- [Publish a DataObject or Collection](/help/publish-data-object/) —
+  mint a persistent identifier instead of downloading the raw crate.
+- [RO-Crate specification](https://www.researchobject.org/ro-crate/) —
+  the upstream standard the ZIP conforms to.

--- a/docs/help/process-step.md
+++ b/docs/help/process-step.md
@@ -1,0 +1,174 @@
+---
+layout: default
+title: Model a process step
+description: How to represent a manufacturing step, test run, or analysis stage as a DataObject with lineage, annotations, and data containers
+permalink: /help/process-step/
+audience: user
+stage: deployed
+---
+# Model a process step
+
+A **process step** in shepard is a regular
+[DataObject](/reference/data-object/) that carries:
+
+- a name and description of the step,
+- one or more **predecessor** links pointing at the DataObjects it
+  was produced from,
+- data containers (timeseries channels, files, structured-data records)
+  holding the step's actual measurements and outputs,
+- semantic annotations capturing domain context (equipment, standards,
+  operator, batch, …), and
+- optionally, child DataObjects for investigation sub-trees or
+  intermediate sub-steps.
+
+This page walks through a concrete example — an AFP layup step
+followed by an NDT inspection — but the pattern applies to any
+sequential workflow: test campaigns, satellite commissioning phases,
+analysis pipelines, or quality gates.
+
+## Before you start
+
+You need a **Collection** to hold the process steps. If you don't have
+one yet, create it from the Collections page — every DataObject lives
+inside exactly one Collection.
+
+## Step 1: create the first step
+
+1. Open the target Collection.
+2. Click **New DataObject** (the `+` button at the top of the
+   DataObjects list).
+3. Fill in:
+   - **Name** — something unambiguous: `AFP Layup — Q1 Run 1` or
+     `Hot-fire TR-004`.
+   - **Description** (optional) — what happened, what equipment was
+     used, any context that does not fit an annotation.
+   - **Status** — use `DRAFT` while the step is in progress; advance
+     to `IN_REVIEW` or `READY` once results are finalised.
+4. Leave **Predecessor** empty for the first step in a chain.
+5. Click **Create**.
+
+## Step 2: link the next step to its predecessor
+
+When you create the step that follows:
+
+1. Click **New DataObject** again.
+2. In the **Predecessors** field, start typing the name of the
+   previous step and pick it from the autocomplete.
+3. Click **Create**.
+
+The predecessor link appears immediately in the **Dataset Lineage**
+graph on the Collection page. Dashed orange arrows point from a
+predecessor to its successor; solid arrows indicate parent → child.
+
+You can add or change predecessors at any time by editing the
+DataObject (pencil icon) and updating the **Predecessors** field.
+
+## Step 3: attach data to the step
+
+Each process step can carry any combination of payload containers:
+
+| What you have | What to create |
+|---|---|
+| Sensor time-series (force, temperature, pressure, vibration …) | Timeseries reference — see [Upload data](/help/upload-data/) |
+| PDFs, images, CAD files, scan results | File reference |
+| Structured measurement results (JSON) | Structured-data reference |
+| A link to an external resource (ERP record, CAD tool URL) | URI reference |
+
+From the DataObject detail page, click **Add Reference** and pick the
+appropriate type.
+
+## Step 4: annotate the step
+
+Semantic annotations capture the context that makes the step findable
+and comparable later:
+
+1. On the DataObject detail page, find the **Annotations** panel and
+   click **+**.
+2. Pick a **Property** (e.g. "has instrument", "performed by", "is
+   part of campaign", "material batch") and a **Value** (a controlled
+   term from the loaded ontologies, or a free-text IRI if you need a
+   custom term).
+3. Click **Add**.
+
+Typical annotations for a manufacturing step:
+
+| Property | Example value |
+|---|---|
+| has instrument | Automated Fibre Placement robot ABC-001 |
+| operator | `urn:example:persons:engineer-42` |
+| material batch | `CF/LMPAEK-2024-BL-047` |
+| performed in | LUMEN test facility, Test bench 2 |
+| conforms to | DIN EN 9100 |
+
+For bulk annotation across many DataObjects in a campaign, see
+[Annotate a container with semantic tags](/help/annotate-container/).
+
+## Step 5: handle a rework loop
+
+If a step fails inspection and needs to be redone, **do not delete the
+failed step** — that would erase the history. Instead:
+
+1. Keep the failed step with status `IN_REVIEW` or create a dedicated
+   investigation child (click **New DataObject**, set the failed step
+   as **Parent**).
+2. Create a new DataObject for the rework step, linking the failed
+   step as its **Predecessor**.
+3. Create the re-test or verification step, linking the rework step
+   as its predecessor.
+
+The lineage graph then shows the full chain: original → failure →
+rework → re-test. An auditor walking the graph can see exactly what
+happened without any information being lost.
+
+Example chain for an AFP anomaly:
+
+```
+AFP Layup Q1 Run 1 (READY)
+  └─► NDT Inspection Q1 Run 1 (IN_REVIEW — fail)
+        └─► Rework AFP Q1 (READY)
+              └─► NDT Inspection Q1 Run 2 (READY — pass)
+```
+
+## Viewing the full process chain
+
+- **Lineage graph** — open the Collection, scroll to **Dataset
+  Lineage**, and expand the panel. The graph renders all
+  Predecessor/Successor and Parent/Child links in the collection.
+- **Sidebar navigator** — the left sidebar on the Collection page
+  shows a tree of DataObjects; expand a node with the chevron (`›`)
+  to see its children and navigate quickly between steps.
+- **Provenance panel** — open any DataObject and expand the
+  **Provenance** panel to see who created it, what actions were taken,
+  and when. See [Trace dataset provenance](/help/provenance-tracing/).
+
+## REST equivalent
+
+For programmatic ingestion (e.g. a test-rig script that creates a
+DataObject at the end of each run):
+
+```
+POST /v2/collections/{collectionAppId}/data-objects
+Content-Type: application/json
+
+{
+  "name": "Hot-fire TR-005",
+  "description": "Hold / repair run after TR-004 anomaly.",
+  "status": "DRAFT",
+  "predecessorIds": ["{tr-004-appId}"]
+}
+```
+
+`predecessorIds` is a list of DataObject `appId` values (UUID v7).
+The full DataObject IO schema is documented at
+`/shepard/doc/swagger-ui` under the **DataObject** tag.
+
+## Further reading
+
+- [Upload data](/help/upload-data/) — attach files, timeseries, and
+  structured data to a DataObject.
+- [Explore collection lineage](/help/collection-lineage/) — navigate
+  the predecessor/successor graph.
+- [Annotate a container with semantic tags](/help/annotate-container/) —
+  attach ontology terms to the containers inside a DataObject.
+- [Trace dataset provenance](/help/provenance-tracing/) — who did what
+  on a DataObject and when.

--- a/docs/help/share-collection.md
+++ b/docs/help/share-collection.md
@@ -1,0 +1,121 @@
+---
+layout: default
+title: Share a collection with collaborators
+description: How to add teammates as readers, writers, or managers on a collection and control its visibility
+permalink: /help/share-collection/
+audience: user
+stage: deployed
+---
+# Share a collection with collaborators
+
+By default a new collection is **Private** — only you (the owner) can
+see or edit it. This page shows how to grant access to colleagues and
+how to change the collection's overall visibility.
+
+## Roles at a glance
+
+| Role | Can read | Can write | Can manage permissions |
+|---|---|---|---|
+| **Reader** | Yes | No | No |
+| **Writer** | Yes | Yes | No |
+| **Manager** | Yes | Yes | Yes |
+| **Owner** | Yes | Yes | Yes (+ delete) |
+
+A **Manager** can add and remove other users (except the owner). An
+owner cannot be changed through the permissions panel — contact your
+instance admin if you need to transfer ownership.
+
+## Step 1: open the Permissions panel
+
+1. Open the collection.
+2. Click **Settings** in the collection action bar (or the gear icon
+   at the top right of the collection detail page).
+3. Select **Members / Permissions**.
+
+The panel shows the current owner, and the reader, writer, and manager
+lists.
+
+## Step 2: add a collaborator
+
+1. In the **Readers**, **Writers**, or **Managers** field, type the
+   colleague's username and press Enter (or pick from the autocomplete).
+2. Repeat for each person.
+3. Click **Save**.
+
+The collaborator immediately sees the collection in their collections
+list without needing to do anything on their end.
+
+To remove a collaborator, click the `×` next to their name and save.
+
+## Step 3: add a user group (optional)
+
+If your instance has user groups configured, you can grant access to
+a whole group at once:
+
+1. Switch to the **Groups** tab in the permissions panel.
+2. Type the group name and pick **Reader group** or **Writer group**.
+3. Click **Save**.
+
+Groups are managed by your instance admin at `/shepard/api/usergroups`.
+
+## Visibility modes
+
+Each collection has a visibility setting in addition to the individual
+access lists:
+
+| Mode | Who can read |
+|---|---|
+| **Private** | Only the owner, managers, writers, and readers you listed. |
+| **PublicReadable** | Anyone logged in to this shepard instance. No need to list them individually. |
+| **Public** | Broader read; governed by your instance's public-access policy. |
+
+To change the visibility:
+
+1. In the **Members / Permissions** panel, find the **Visibility** selector.
+2. Pick `Private`, `PublicReadable`, or `Public`.
+3. Click **Save**.
+
+`PublicReadable` is useful for a campaign you want all institute
+members to browse without having to invite each person. Only the
+users and groups you explicitly listed as writers or managers can
+make changes.
+
+## REST equivalent
+
+For scripted onboarding (adding a whole team at once), send a single
+`PUT` to the permissions endpoint:
+
+```
+PUT /shepard/api/collections/{collectionId}/permissions
+Content-Type: application/json
+
+{
+  "permissionType": "Private",
+  "reader": ["alice", "bob"],
+  "writer": ["carol"],
+  "manager": [],
+  "readerGroupIds": [],
+  "writerGroupIds": []
+}
+```
+
+`GET /shepard/api/collections/{collectionId}/permissions` returns the
+current state so you can diff it before updating.
+
+To find the numeric `collectionId` from an `appId` (UUID v7), use
+`GET /v2/collections/{appId}` — the response carries both `id` and
+`appId`.
+
+## What if you cannot see the Permissions panel?
+
+You need **Manager** or **Owner** role to edit permissions. If you only
+have Writer or Reader access you can see the collection but not modify
+its access list. Ask the collection owner or a Manager to add you as
+a Manager, or to invite your collaborator directly.
+
+## Further reading
+
+- [User guide: Permissions section](/user-guide/#permissions) — full
+  permission model with all role definitions.
+- [Trace dataset provenance](/help/provenance-tracing/) — see who
+  performed actions on a collection, including permission changes.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Adds the three remaining task-shaped help pages from backlog row **D1c** (`upload-data.md` already existed on `main`):

- `docs/help/share-collection.md` — how to add teammates as readers/writers/managers, change visibility (Private / PublicReadable / Public), use user groups, and use the REST permissions endpoint.
- `docs/help/export-rocrate.md` — how to download a collection as an RO-Crate ZIP via the UI, via the presigned-URL endpoint (`POST /v2/collections/{appId}/export-url`, FS1g), and via the legacy streaming export. Covers `ExportSelection` filtering (payload kinds, time windows, per-column picks), snapshot-scoped export, the ZIP layout, and permission/redaction options.
- `docs/help/process-step.md` — how to model a manufacturing step, test run, or analysis stage: create a DataObject, link predecessors, attach data containers, annotate with ontology terms, handle rework loops without breaking lineage, and navigate the full chain. Includes a REST snippet for programmatic ingestion.

All three pages:
- Follow the casual-task voice and structure of the existing `help/` pages (`upload-data.md`, `publish-data-object.md`, `annotate-container.md`).
- Carry `stage: deployed` frontmatter.
- Complement (not duplicate) the feature-shaped content in `docs/user-guide.md`.

## Test plan

- [ ] Verify each page renders correctly in the docs site (Jekyll `layout: default` + `permalink`).
- [ ] Check that all internal cross-links (`/help/upload-data/`, `/help/provenance-tracing/`, etc.) resolve.
- [ ] Confirm REST endpoint references match what is live (`/shepard/api/collections/{id}/permissions`, `/v2/collections/{appId}/export-url`).

https://claude.ai/code/session_018sqhQ9iQKKZURa6PKLngHL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018sqhQ9iQKKZURa6PKLngHL)_