### PR TITLE
fix(TSDB-DDL-2): chunk-aware TimescaleDB container delete

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/data/timeseries/repositories/TimeseriesRepository.java
+++ b/backend/src/main/java/de/dlr/shepard/data/timeseries/repositories/TimeseriesRepository.java
@@ -135,10 +135,60 @@ public class TimeseriesRepository implements PanacheRepositoryBase<TimeseriesEnt
     }
   }
 
+  /**
+   * Delete all {@code timeseries_data_points} rows for a container via a single
+   * native SQL statement, BEFORE JPA removes the parent {@code timeseries} rows.
+   *
+   * <p><b>Why native SQL before JPQL?</b> The {@code timeseries_data_points} table is a
+   * TimescaleDB hypertable with compression enabled (policy: compress after 7 days,
+   * configured in V1.8.0). When JPA issues the JPQL
+   * {@code DELETE FROM TimeseriesEntity WHERE containerId = ?} below, Postgres fires
+   * the {@code ON DELETE CASCADE} on {@code timeseries_data_points.timeseries_id}.
+   * For compressed chunks the cascade forces chunk decompression before row-level
+   * deletion — an operation that consumes memory proportional to the compressed row
+   * count and fails with HTTP 500 on containers with more than ~100 K data points
+   * (TSDB-DDL-2 in aidocs/16).
+   *
+   * <p><b>This call</b> issues one native DELETE scoped to the container's timeseries IDs.
+   * TimescaleDB processes it chunk-by-chunk without decompressing all rows at once.
+   * After this returns, the ON DELETE CASCADE triggered by the subsequent JPQL DELETE
+   * finds zero {@code timeseries_data_points} rows and completes instantly.
+   *
+   * <p>The DELETE is idempotent: if the container has no data points the query deletes
+   * 0 rows and returns normally.
+   *
+   * @param containerId the numeric container id (FK on the {@code timeseries} table)
+   */
+  @Timed(value = "shepard.timeseries-data-point.delete-by-container")
+  public void deleteDataPointsByContainerId(long containerId) {
+    // TSDB-DDL-2: chunk-aware native DELETE to pre-empt JPA cascade decompression.
+    // Scoped to all timeseries_id values belonging to the container so TimescaleDB
+    // can handle compressed chunks without decompression overhead.
+    int dpRows = entityManager
+      .createNativeQuery(
+        "DELETE FROM timeseries_data_points " +
+        "WHERE timeseries_id IN (SELECT id FROM timeseries WHERE container_id = :containerId)"
+      )
+      .setParameter("containerId", containerId)
+      .executeUpdate();
+
+    Log.infof(
+      "TSDB-DDL-2 deleteDataPointsByContainerId: deleted %d data-point rows for container %d",
+      dpRows, containerId
+    );
+  }
+
   @Timed(value = "shepard.timeseries.delete")
   public void deleteByContainerId(long containerId) {
+    // TSDB-DDL-2: pre-delete data points via native SQL BEFORE this JPQL fires the
+    // ON DELETE CASCADE. Without this step, compressed TimescaleDB chunks must be
+    // decompressed before row-level deletion — an OOM-class failure on large containers.
+    deleteDataPointsByContainerId(containerId);
+
     // Bulk JPQL DELETE on primary table; ON DELETE CASCADE on channel_metadata.timeseries_id
     // propagates the deletion to channel_metadata rows automatically at the DB level.
+    // The timeseries_data_points cascade is a no-op here because deleteDataPointsByContainerId
+    // above already removed all rows.
     var rowCount = entityManager
       .createQuery("delete from TimeseriesEntity where containerId = :containerId")
       .setParameter("containerId", containerId)

--- a/backend/src/test/java/de/dlr/shepard/data/timeseries/repositories/TimeseriesRepositoryDeleteTest.java
+++ b/backend/src/test/java/de/dlr/shepard/data/timeseries/repositories/TimeseriesRepositoryDeleteTest.java
@@ -1,0 +1,174 @@
+package de.dlr.shepard.data.timeseries.repositories;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+/**
+ * Unit tests for the TSDB-DDL-2 chunk-aware container delete path in
+ * {@link TimeseriesRepository}.
+ *
+ * <p>No live database required — the {@link EntityManager} is mocked so the tests
+ * verify that:
+ * <ol>
+ *   <li>The native DELETE on {@code timeseries_data_points} is issued BEFORE the
+ *       JPQL DELETE on {@code timeseries} (ordering invariant).</li>
+ *   <li>The native DELETE SQL targets the right subquery shape.</li>
+ *   <li>Both deletes use the correct {@code containerId} parameter.</li>
+ *   <li>A container with zero data points completes without throwing.</li>
+ * </ol>
+ *
+ * <p>TSDB-DDL-2 in {@code aidocs/16-dispatcher-backlog.md}.
+ */
+public class TimeseriesRepositoryDeleteTest {
+
+  private TimeseriesRepository repository;
+  private EntityManager entityManager;
+
+  @BeforeEach
+  void setUp() {
+    entityManager = mock(EntityManager.class);
+    repository = new TimeseriesRepository();
+    repository.entityManager = entityManager;
+  }
+
+  // ── deleteDataPointsByContainerId: SQL shape and parameter ────────────────
+
+  @Test
+  void deleteDataPointsByContainerId_issuedWithSubqueryAndContainerId() {
+    Query nativeQuery = mock(Query.class);
+    when(entityManager.createNativeQuery(
+      contains("timeseries_data_points")
+    )).thenReturn(nativeQuery);
+    when(nativeQuery.setParameter(anyString(), any())).thenReturn(nativeQuery);
+    when(nativeQuery.executeUpdate()).thenReturn(0);
+
+    repository.deleteDataPointsByContainerId(42L);
+
+    // Verify the native query scopes to the container via a subquery.
+    verify(entityManager).createNativeQuery(
+      contains("WHERE timeseries_id IN (SELECT id FROM timeseries WHERE container_id = :containerId)")
+    );
+    verify(nativeQuery).setParameter("containerId", 42L);
+  }
+
+  @Test
+  void deleteDataPointsByContainerId_zeroRowsDeleted_doesNotThrow() {
+    Query nativeQuery = mock(Query.class);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(nativeQuery);
+    when(nativeQuery.setParameter(anyString(), any())).thenReturn(nativeQuery);
+    when(nativeQuery.executeUpdate()).thenReturn(0);
+
+    assertDoesNotThrow(() -> repository.deleteDataPointsByContainerId(99L));
+  }
+
+  @Test
+  void deleteDataPointsByContainerId_manyRowsDeleted_doesNotThrow() {
+    Query nativeQuery = mock(Query.class);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(nativeQuery);
+    when(nativeQuery.setParameter(anyString(), any())).thenReturn(nativeQuery);
+    // Simulate a large compressed container.
+    when(nativeQuery.executeUpdate()).thenReturn(500_000);
+
+    assertDoesNotThrow(() -> repository.deleteDataPointsByContainerId(7L));
+  }
+
+  // ── deleteByContainerId: ordering invariant ───────────────────────────────
+
+  /**
+   * TSDB-DDL-2 correctness invariant: the native DELETE on
+   * {@code timeseries_data_points} MUST be issued before the JPQL DELETE on
+   * {@code timeseries}. If the order is reversed, the ON DELETE CASCADE fires on
+   * compressed chunks and causes the OOM failure that TSDB-DDL-2 was designed to fix.
+   */
+  @Test
+  void deleteByContainerId_nativeDeleteIssuedBeforeJpqlDelete() {
+    // Native query mock (data points)
+    Query nativeQuery = mock(Query.class);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(nativeQuery);
+    when(nativeQuery.setParameter(anyString(), any())).thenReturn(nativeQuery);
+    when(nativeQuery.executeUpdate()).thenReturn(10);
+
+    // JPQL query mock (timeseries rows)
+    Query jpqlQuery = mock(Query.class);
+    when(entityManager.createQuery(anyString())).thenReturn(jpqlQuery);
+    when(jpqlQuery.setParameter(anyString(), any())).thenReturn(jpqlQuery);
+    when(jpqlQuery.executeUpdate()).thenReturn(2);
+
+    InOrder order = inOrder(entityManager);
+
+    repository.deleteByContainerId(5L);
+
+    // Native DELETE (createNativeQuery) must precede JPQL DELETE (createQuery).
+    order.verify(entityManager).createNativeQuery(anyString());
+    order.verify(entityManager).createQuery(anyString());
+  }
+
+  @Test
+  void deleteByContainerId_bothDeletesUseContainerId() {
+    Query nativeQuery = mock(Query.class);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(nativeQuery);
+    when(nativeQuery.setParameter(anyString(), any())).thenReturn(nativeQuery);
+    when(nativeQuery.executeUpdate()).thenReturn(0);
+
+    Query jpqlQuery = mock(Query.class);
+    when(entityManager.createQuery(anyString())).thenReturn(jpqlQuery);
+    when(jpqlQuery.setParameter(anyString(), any())).thenReturn(jpqlQuery);
+    when(jpqlQuery.executeUpdate()).thenReturn(0);
+
+    repository.deleteByContainerId(77L);
+
+    // Both the native and JPQL queries must receive containerId = 77.
+    verify(nativeQuery).setParameter("containerId", 77L);
+    verify(jpqlQuery).setParameter("containerId", 77L);
+  }
+
+  @Test
+  void deleteByContainerId_noDataPoints_completes() {
+    // Simulates a container that has no data yet (empty timeseries or new container).
+    Query nativeQuery = mock(Query.class);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(nativeQuery);
+    when(nativeQuery.setParameter(anyString(), any())).thenReturn(nativeQuery);
+    when(nativeQuery.executeUpdate()).thenReturn(0);
+
+    Query jpqlQuery = mock(Query.class);
+    when(entityManager.createQuery(anyString())).thenReturn(jpqlQuery);
+    when(jpqlQuery.setParameter(anyString(), any())).thenReturn(jpqlQuery);
+    when(jpqlQuery.executeUpdate()).thenReturn(0);
+
+    assertDoesNotThrow(() -> repository.deleteByContainerId(13L));
+  }
+
+  @Test
+  void deleteByContainerId_largeContainer_completes() {
+    // Simulates a large container with compressed chunks (the TSDB-DDL-2 scenario).
+    Query nativeQuery = mock(Query.class);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(nativeQuery);
+    when(nativeQuery.setParameter(anyString(), any())).thenReturn(nativeQuery);
+    when(nativeQuery.executeUpdate()).thenReturn(1_000_000);
+
+    Query jpqlQuery = mock(Query.class);
+    when(entityManager.createQuery(anyString())).thenReturn(jpqlQuery);
+    when(jpqlQuery.setParameter(anyString(), any())).thenReturn(jpqlQuery);
+    when(jpqlQuery.executeUpdate()).thenReturn(50);
+
+    assertDoesNotThrow(() -> repository.deleteByContainerId(1L));
+
+    // Verify native DELETE ran first (times(1) on createNativeQuery, times(1) on createQuery).
+    verify(entityManager, times(1)).createNativeQuery(anyString());
+    verify(entityManager, times(1)).createQuery(anyString());
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug:** `DELETE /timeseriesContainers/{id}` fails with HTTP 500 on containers with >100K compressed TimescaleDB rows. JPA's `ON DELETE CASCADE` triggers chunk decompression before row-level deletion, exhausting heap memory.
- **Fix:** Before the JPQL `DELETE FROM TimeseriesEntity WHERE containerId = ?` fires the cascade, a new native SQL call explicitly deletes all `timeseries_data_points` rows scoped to the container's timeseries IDs. TimescaleDB handles this DELETE chunk-by-chunk without decompression. The cascade then has zero rows to act on and completes instantly.
- **Tests:** 6 mock-based unit tests added to `TimeseriesRepositoryDeleteTest` verifying the ordering invariant (native DELETE before JPQL DELETE), SQL subquery shape, `containerId` parameter binding on both deletes, and zero-row/large-container cases.

## Files changed

- `backend/src/main/java/de/dlr/shepard/data/timeseries/repositories/TimeseriesRepository.java` — added `deleteDataPointsByContainerId(long containerId)` (native SQL, `@Timed`) and wired it as the first call inside `deleteByContainerId()`.
- `backend/src/test/java/de/dlr/shepard/data/timeseries/repositories/TimeseriesRepositoryDeleteTest.java` — new test class, 6 tests, all mock-based (no live DB required).

## Backlog reference

TSDB-DDL-2 in `aidocs/16-dispatcher-backlog.md`. This is the structural fix; TSDB-DDL-1 (raise decompression limit in compose env) was the immediate unblock.

## Test plan

- [ ] Verify `TimeseriesRepositoryDeleteTest` passes once all plugin JARs are installed in local Maven repo (CI installs them before `mvn test`).
- [ ] Manual smoke: create a container, ingest >100K data points, compress chunks via `SELECT add_compression_policy(...)`, then `DELETE /timeseriesContainers/{id}` — should return 204 without 500.
- [ ] TSDB-DDL-3 (retroactive delete of the tap-laying test data) can now proceed as acceptance test of this fix.

https://claude.ai/code/session_019KGNKPj9XeDVxgDoP3H1mM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019KGNKPj9XeDVxgDoP3H1mM)_