### PR TITLE
docs(ROUTE-CLEANUP-LEGACY-01): document /configuration and /user as backward-compat redirects

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -2512,6 +2512,7 @@ them up immediately.
 | #27-ARCHIVED-01/02/03 | Extend ARCHIVED status to Container + Collection (operator-approved). | XS/S/XS | Mirrors COMP-NCR-STATUS shape. |
 | PROV-CAPTURE-READS-FLIP | One-line `application.properties` flip of `shepard.provenance.capture-reads=true` (v2 only). | XS | PROV-RESOLVER-PATHWALK prerequisite shipped. |
 | J1e-PR-07/08/09 | aidocs/34 path-migration row + aidocs/42/44 corrections + reconcile with J2 plan. | XS each | Docs follow-on for the in-flight J1e plugin refactor. |
+| **ROUTE-CLEANUP-LEGACY-01** | Reconciler-surfaced drift: `frontend/pages/configuration/*` and `frontend/pages/user/*` redirect to `/admin` and `/me` respectively. Not nav-reachable, not used — delete or document. | XS | done 2026-05-30. Documented (not deleted) — intentional backward-compat redirects for old bookmarks; one-line comment added to each file. |
 
 ### Blocked on design
 

--- a/frontend/pages/configuration/index.vue
+++ b/frontend/pages/configuration/index.vue
@@ -1,3 +1,4 @@
 <script setup lang="ts">
+// Backward-compat redirect: keeps old /configuration bookmarks working → /admin
 await navigateTo("/admin", { replace: true });
 </script>


### PR DESCRIPTION
## Summary
- Adds one-line comments to `frontend/pages/configuration/index.vue` and `frontend/pages/user/index.vue` explaining they are intentional backward-compat redirects (kept for old bookmarks)
- Updates aidocs/16 ROUTE-CLEANUP-LEGACY-01 row to `done`
- No functional change; redirects are preserved

## Test plan
- [x] `npm run lint` — clean on both modified files (pre-existing lint debt on other files is not introduced by this PR)
- [x] `npm run typecheck` — green

Closes ROUTE-CLEANUP-LEGACY-01 (aidocs/16)

https://claude.ai/code/session_01G56WNx29Czvh71RUziqDmZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01G56WNx29Czvh71RUziqDmZ)_