### PR TITLE
feat(SCENEGRAPH-CREATE-FROM-URDF-2-FE): wire Create-scene button to POST /v2/scene-graphs/from-urdf

### DIFF
--- a/frontend/components/container/file/OpenInSceneGraphButton.vue
+++ b/frontend/components/container/file/OpenInSceneGraphButton.vue
@@ -8,14 +8,13 @@
  * `./openInSceneGraphButtonHelpers.ts` for the predicate set + rationale).
  *
  * Two button states, switched by the presence of the back-annotation
- * `urn:shepard:scenegraph:scene-appId` (written by
- * `examples/mffd-rdk-urdf-showcase/scenegraph/build_mffd_scene.py`):
+ * `urn:shepard:scenegraph:scene-appId`:
  *  - scene exists → button reads "Open in scene-graph editor" and
  *    routes to `/scene-graphs/{sceneAppId}`.
  *  - scene does NOT exist → button reads "Create scene from this URDF"
- *    and opens a modal explaining today's bootstrap is script-driven.
- *    Backend "click to mint" flow is filed as
- *    `SCENEGRAPH-CREATE-FROM-URDF-1` in `aidocs/16`.
+ *    and opens a confirm dialog that calls
+ *    `POST /v2/scene-graphs/from-urdf/{fileReferenceAppId}`.
+ *    201 → navigate to new scene; 409 → navigate to existing scene.
  *
  * Annotation source: this component does its own fetch via
  * `AnnotatedReference.fetchAnnotations()` rather than wiring up an event
@@ -30,6 +29,7 @@
  * Vuetify wrapper around them.
  */
 import type { SemanticAnnotation } from "@dlr-shepard/backend-client";
+import { useSceneGraph } from "~/composables/useSceneGraph";
 import {
   hasSceneGraphRole,
   findSceneAppId,
@@ -43,12 +43,18 @@ interface Props {
   collectionId: number;
   dataObjectId: number;
   fileReferenceId: number;
+  /** appId of the FileReference — passed to POST /v2/scene-graphs/from-urdf/{appId}. */
+  fileReferenceAppId?: string;
 }
 const props = defineProps<Props>();
 
 const annotations = ref<SemanticAnnotation[]>([]);
 const isLoading = ref(true);
 const showCreateModal = ref(false);
+const creating = ref(false);
+const createError = ref<string | null>(null);
+
+const { createFromUrdf, error: sgError } = useSceneGraph();
 
 const annotated = computed(
   () =>
@@ -85,7 +91,22 @@ function onClick() {
     navigateTo(sceneGraphRouteFor(id));
     return;
   }
+  createError.value = null;
   showCreateModal.value = true;
+}
+
+async function onConfirmCreate() {
+  if (!props.fileReferenceAppId) return;
+  creating.value = true;
+  createError.value = null;
+  const result = await createFromUrdf(props.fileReferenceAppId);
+  creating.value = false;
+  if (!result) {
+    createError.value = sgError.value?.message ?? "Scene creation failed.";
+    return;
+  }
+  showCreateModal.value = false;
+  navigateTo(sceneGraphRouteFor(result.appId));
 }
 </script>
 
@@ -101,34 +122,47 @@ function onClick() {
       {{ sceneAppId ? "Open in scene-graph editor" : "Create scene from this URDF" }}
     </v-btn>
 
-    <v-dialog v-model="showCreateModal" max-width="540">
+    <v-dialog v-model="showCreateModal" max-width="480">
       <v-card>
         <v-card-title class="d-flex align-center ga-2">
-          <v-icon size="small" color="primary">mdi-information-outline</v-icon>
-          Scene bootstrap is currently script-driven
+          <v-icon size="small" color="primary">mdi-graph-outline</v-icon>
+          Create scene from this URDF
         </v-card-title>
         <v-card-text>
-          <p class="mb-3">
-            No <code>:DigitalTwinScene</code> exists yet for this FileReference.
-            For now, minting a scene from a URDF runs from the command line:
+          <p class="mb-0">
+            Parse <strong>{{ fileReferenceName }}</strong> and mint a new
+            scene graph. The scene will appear under Scene Graphs and this
+            button will switch to "Open in scene-graph editor".
           </p>
-          <pre class="bootstrap-snippet">python3 examples/mffd-rdk-urdf-showcase/scenegraph/build_mffd_scene.py \
-    --host https://&lt;your-shepard-host&gt; \
-    --apikey "$SHEPARD_API_KEY"</pre>
-          <p class="mt-3 mb-0 text-medium-emphasis text-body-2">
-            The script parses the URDF, POSTs the scene to
-            <code>/v2/scene-graphs</code>, and writes the
-            <code>urn:shepard:scenegraph:scene-appId</code> back-annotation on
-            this FileReference. On the next page load the button switches to
-            "Open in scene-graph editor".<br>
-            The "click-to-mint" backend flow is tracked as
-            <strong>SCENEGRAPH-CREATE-FROM-URDF-1</strong> in
-            <code>aidocs/16</code>.
-          </p>
+          <v-alert
+            v-if="createError"
+            type="error"
+            variant="tonal"
+            class="mt-3 mb-0"
+            density="compact"
+          >
+            {{ createError }}
+          </v-alert>
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="showCreateModal = false">Close</v-btn>
+          <v-btn
+            variant="text"
+            :disabled="creating"
+            @click="showCreateModal = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            color="primary"
+            variant="flat"
+            :loading="creating"
+            :disabled="!fileReferenceAppId || creating"
+            data-test="confirm-create-scene-button"
+            @click="onConfirmCreate"
+          >
+            Create
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -138,14 +172,5 @@ function onClick() {
 <style lang="scss" scoped>
 .open-in-scene-graph-wrap {
   display: inline-block;
-}
-.bootstrap-snippet {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 0.825rem;
-  background: rgba(var(--v-theme-on-surface), 0.04);
-  padding: 12px;
-  border-radius: 4px;
-  overflow-x: auto;
-  white-space: pre-wrap;
 }
 </style>

--- a/frontend/composables/useSceneGraph.ts
+++ b/frontend/composables/useSceneGraph.ts
@@ -521,6 +521,53 @@ export function useSceneGraph() {
   }
 
   /**
+   * SCENEGRAPH-CREATE-FROM-URDF-1 — mint a scene from a URDF FileReference.
+   *
+   * POSTs to `/v2/scene-graphs/from-urdf/{fileReferenceAppId}`.
+   * - 201: scene was created → `{ appId, existed: false }`
+   * - 409: scene already existed → `{ appId: existingSceneAppId, existed: true }`
+   * - 4xx/5xx: sets `error.value` and returns `null`
+   */
+  async function createFromUrdf(
+    fileReferenceAppId: string,
+    opts: RequestOptions = {},
+  ): Promise<{ appId: string; existed: boolean } | null> {
+    loading.value = true;
+    error.value = null;
+    try {
+      const headers = await authHeaders(opts);
+      if (!headers) return null;
+      const url = `${v2BaseUrl()}/v2/scene-graphs/from-urdf/${encodeURIComponent(fileReferenceAppId)}`;
+      const response = await fetch(url, { method: "POST", headers });
+      if (response.status === 201) {
+        const data = (await response.json()) as SceneGraphIO;
+        return { appId: data.appId, existed: false };
+      }
+      if (response.status === 409) {
+        const body = (await response.json()) as {
+          existingSceneAppId?: string;
+          detail?: string;
+        };
+        if (body.existingSceneAppId) {
+          return { appId: body.existingSceneAppId, existed: true };
+        }
+      }
+      const detail = await readErrorBody(response);
+      error.value = {
+        status: response.status,
+        message: sceneGraphErrorMessageForStatus(response.status, detail),
+        detail: detail.slice(0, 500),
+      };
+      return null;
+    } catch (e) {
+      setNetworkError(e);
+      return null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /**
    * Download URDF XML. Returns the raw XML string on 2xx; sets `error` on
    * failure. Caller wraps in a Blob + anchor click to trigger the download.
    */
@@ -557,6 +604,7 @@ export function useSceneGraph() {
     error,
     list,
     fetchScene,
+    createFromUrdf,
     addFrame,
     patchFrame,
     deleteFrame,

--- a/frontend/pages/collections/[collectionId]/dataobjects/[dataObjectId]/filereferences/[fileReferenceId]/index.vue
+++ b/frontend/pages/collections/[collectionId]/dataobjects/[dataObjectId]/filereferences/[fileReferenceId]/index.vue
@@ -197,6 +197,7 @@ watch(fileReference, () => {
                   :collection-id="collectionId"
                   :data-object-id="dataObjectId"
                   :file-reference-id="fileReferenceId"
+                  :file-reference-app-id="fileReference.appId"
                 />
               </v-col>
             </v-row>


### PR DESCRIPTION
## Summary
- Adds `createFromUrdf(appId)` to `useSceneGraph.ts` composable — POSTs to the backend endpoint shipped in SCENEGRAPH-CREATE-FROM-URDF-1
- Replaces the static script-driven modal in `OpenInSceneGraphButton.vue` with a real confirm dialog; 201 → navigate to new scene, 409 → navigate to existing scene
- Passes `fileReferenceAppId` from the FileReference detail page to the component

## Test plan
- [ ] `npm run lint` green (verified: no errors on changed files)
- [ ] `npm run test` green (verified: pre-existing `useFetchRecentCollections` failures only; scene graph tests pass)
- [ ] `npm run typecheck` green (verified: no TS errors in changed files)
- [ ] Manual: on a FileReference with no scene-appId annotation, "Create scene from this URDF" opens a confirm dialog; clicking Create → button shows loading, then navigates to `/scene-graphs/{newAppId}`
- [ ] Manual: on 409 (scene already exists), navigates to existing scene's appId without error

Closes SCENEGRAPH-CREATE-FROM-URDF-2-FE (aidocs/16)

https://claude.ai/code/session_01G56WNx29Czvh71RUziqDmZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01G56WNx29Czvh71RUziqDmZ)_