### PR TITLE
feat(SEMANTIC-ANNOTATE-BULK-REST-1): add POST /v2/annotations/bulk endpoint

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/annotations/io/BulkAnnotationResultIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/annotations/io/BulkAnnotationResultIO.java
@@ -1,0 +1,69 @@
+package de.dlr.shepard.v2.annotations.io;
+
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * SEMANTIC-ANNOTATE-BULK-REST-1 — response body for {@code POST /v2/annotations/bulk}.
+ *
+ * <p>Top-level summary counts plus a per-row result list so callers can
+ * identify exactly which rows failed without re-submitting the whole batch.
+ */
+@Data
+@NoArgsConstructor
+@Schema(
+  name = "BulkAnnotationResult",
+  description = "SEMANTIC-ANNOTATE-BULK-REST-1 — bulk annotation creation result."
+)
+public class BulkAnnotationResultIO {
+
+  @Schema(description = "Total number of annotation payloads received in the request.")
+  private int requested;
+
+  @Schema(description = "Number of annotations successfully created.")
+  private int succeeded;
+
+  @Schema(description = "Number of annotations that failed (validation or permission error).")
+  private int failed;
+
+  @Schema(description = "Per-row result — one entry per input row, in input order.")
+  private List<RowResult> results;
+
+  // ─── per-row shape ────────────────────────────────────────────────────────
+
+  @Data
+  @NoArgsConstructor
+  @Schema(name = "BulkAnnotationRowResult", description = "Result for a single row in a bulk annotation request.")
+  public static class RowResult {
+
+    @Schema(description = "Zero-based index of the row in the input list.")
+    private int index;
+
+    @Schema(description = "True if the annotation was created successfully.")
+    private boolean ok;
+
+    @Schema(nullable = true, description = "UUID v7 of the created annotation. Present only when ok=true.")
+    private String appId;
+
+    @Schema(nullable = true, description = "Human-readable error message. Present only when ok=false.")
+    private String error;
+
+    public static RowResult success(int index, String appId) {
+      RowResult r = new RowResult();
+      r.index = index;
+      r.ok = true;
+      r.appId = appId;
+      return r;
+    }
+
+    public static RowResult failure(int index, String error) {
+      RowResult r = new RowResult();
+      r.index = index;
+      r.ok = false;
+      r.error = error;
+      return r;
+    }
+  }
+}

--- a/backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java
@@ -12,6 +12,8 @@ import de.dlr.shepard.provenance.filters.ProvenanceCaptureFilter;
 import de.dlr.shepard.provenance.services.ProvenanceService;
 import de.dlr.shepard.v2.annotations.daos.SemanticAnnotationV2DAO;
 import de.dlr.shepard.v2.annotations.io.AnnotationIO;
+import de.dlr.shepard.v2.annotations.io.BulkAnnotationResultIO;
+import de.dlr.shepard.v2.annotations.io.BulkAnnotationResultIO.RowResult;
 import de.dlr.shepard.v2.annotations.io.CreateAnnotationIO;
 import de.dlr.shepard.v2.annotations.io.UpdateAnnotationIO;
 import io.quarkus.logging.Log;
@@ -77,6 +79,7 @@ public class SemanticAnnotationV2Rest {
 
   static final int MAX_PAGE_SIZE = 200;
   static final int DEFAULT_PAGE_SIZE = 50;
+  static final int MAX_BULK_SIZE = 100;
 
   static final String PROBLEM_TYPE_BAD_REQUEST = "/problems/annotations.bad-request";
   static final String PROBLEM_TYPE_NOT_FOUND = "/problems/annotations.not-found";
@@ -388,6 +391,150 @@ public class SemanticAnnotationV2Rest {
     Log.infof("SemanticAnnotationV2Rest: created annotation %s on %s/%s by %s",
       annotation.getAppId(), annotation.getSubjectKind(), annotation.getSubjectAppId(), caller);
     return Response.status(Response.Status.CREATED).entity(new AnnotationIO(annotation)).build();
+  }
+
+  // ─── BULK CREATE ───────────────────────────────────────────────────────────
+
+  @POST
+  @Path("/bulk")
+  @Operation(
+    summary = "Bulk-create up to 100 semantic annotations (best-effort).",
+    description =
+      "Accepts a JSON array of up to " + MAX_BULK_SIZE + " annotation payloads and creates each one " +
+      "independently. A failure on one row (validation error, missing permission) does not " +
+      "abort subsequent rows — the batch always runs to completion.\n\n" +
+      "Required fields per row: `subjectAppId`, `subjectKind`, `predicateIri`, " +
+      "and exactly one of `objectLiteral` / `objectIri`.\n\n" +
+      "Auth: caller must be authenticated. Write permission on the subject entity is " +
+      "checked per row; rows whose subject the caller cannot Write produce a failed row " +
+      "result rather than aborting the whole batch.\n\n" +
+      "Returns `200 OK` (never `201` — partial success is possible) with a " +
+      "`{requested, succeeded, failed, results:[…]}` summary.\n\n" +
+      "Provenance: individual `:Activity` nodes are NOT created per row (too expensive " +
+      "for 100-row batches). The filter-level generic Activity is also suppressed via " +
+      "`PROP_SKIP_CAPTURE`. Operators who need per-row provenance should call " +
+      "`POST /v2/annotations` individually."
+  )
+  @APIResponse(
+    responseCode = "200",
+    description = "Batch completed (partial success possible). Body contains per-row results.",
+    content = @Content(schema = @Schema(implementation = BulkAnnotationResultIO.class))
+  )
+  @APIResponse(responseCode = "400", description = "Request body is null or exceeds the 100-row cap (RFC 7807).")
+  @APIResponse(responseCode = "401", description = "Authentication required.")
+  public Response bulkCreate(
+    List<CreateAnnotationIO> body,
+    @Context SecurityContext sc,
+    @HeaderParam("X-AI-Agent") String aiAgentHeader
+  ) {
+    String caller = callerName(sc);
+    if (caller == null) return unauthorized();
+
+    if (body == null) {
+      return problem(PROBLEM_TYPE_BAD_REQUEST, "Missing request body", Response.Status.BAD_REQUEST,
+        "Request body must be a non-null JSON array of annotation payloads.");
+    }
+    if (body.size() > MAX_BULK_SIZE) {
+      return problem(PROBLEM_TYPE_BAD_REQUEST, "Batch too large", Response.Status.BAD_REQUEST,
+        "Batch size " + body.size() + " exceeds the maximum of " + MAX_BULK_SIZE + " rows.");
+    }
+
+    List<RowResult> results = new java.util.ArrayList<>(body.size());
+    int succeeded = 0;
+
+    for (int i = 0; i < body.size(); i++) {
+      try {
+        CreateAnnotationIO row = body.get(i);
+
+        // Per-row validation — mirrors create() field checks
+        if (row == null) {
+          results.add(RowResult.failure(i, "Row is null"));
+          continue;
+        }
+        if (blank(row.getSubjectAppId())) {
+          results.add(RowResult.failure(i, "subjectAppId is required"));
+          continue;
+        }
+        if (blank(row.getSubjectKind())) {
+          results.add(RowResult.failure(i, "subjectKind is required"));
+          continue;
+        }
+        if (blank(row.getPredicateIri())) {
+          results.add(RowResult.failure(i, "predicateIri is required"));
+          continue;
+        }
+        boolean hasLiteral = !blank(row.getObjectLiteral());
+        boolean hasIri = !blank(row.getObjectIri());
+        if (!hasLiteral && !hasIri) {
+          results.add(RowResult.failure(i, "Exactly one of objectLiteral or objectIri must be provided"));
+          continue;
+        }
+        if (hasLiteral && hasIri) {
+          results.add(RowResult.failure(i, "Provide exactly one of objectLiteral or objectIri, not both"));
+          continue;
+        }
+
+        // Per-row permission check — returns a non-null Response on denial
+        Response gate = checkWriteAccessForSubject(row.getSubjectAppId(), row.getSubjectKind(), caller);
+        if (gate != null) {
+          results.add(RowResult.failure(i, "Write access denied for subject " + row.getSubjectAppId()));
+          continue;
+        }
+
+        // Build and persist the annotation
+        SemanticAnnotation annotation = new SemanticAnnotation();
+        annotation.setAppId(AppIdGenerator.next());
+        annotation.setSubjectKind(row.getSubjectKind());
+        annotation.setSubjectAppId(row.getSubjectAppId());
+        annotation.setPropertyIRI(row.getPredicateIri());
+        annotation.setPropertyName(row.getPredicateLabel());
+        annotation.setVocabularyId(row.getVocabularyId());
+        annotation.setValueIRI(row.getObjectIri());
+        annotation.setValueName(hasLiteral ? row.getObjectLiteral() : null);
+        annotation.setNumericValue(row.getNumericValue());
+        annotation.setUnitIRI(row.getUnitIri());
+        String resolvedSourceMode = row.getSourceMode() != null
+          ? row.getSourceMode()
+          : (aiAgentHeader != null && !aiAgentHeader.isBlank() ? "ai" : "human");
+        annotation.setSourceMode(resolvedSourceMode);
+        annotation.setSourceActivityAppId(row.getSourceActivityAppId());
+        annotation.setAgentUsername(caller);
+        annotation.setValidFromMillis(row.getValidFromMillis());
+        annotation.setValidUntilMillis(row.getValidUntilMillis());
+        annotation.setConfidence(row.getConfidence() != null ? row.getConfidence() : 1.0);
+
+        annotationDAO.createOrUpdate(annotation);
+        results.add(RowResult.success(i, annotation.getAppId()));
+        succeeded++;
+
+        Log.debugf("SemanticAnnotationV2Rest bulk: created annotation %s on %s/%s by %s",
+          annotation.getAppId(), annotation.getSubjectKind(), annotation.getSubjectAppId(), caller);
+
+      } catch (RuntimeException e) {
+        // Best-effort: a runtime error on row i must not abort rows i+1..N
+        Log.warnf(e, "SemanticAnnotationV2Rest bulk: row %d failed with exception", i);
+        results.add(RowResult.failure(i, "Internal error: " + e.getMessage()));
+      }
+    }
+
+    Log.infof("SemanticAnnotationV2Rest: bulk create by %s — requested=%d succeeded=%d failed=%d",
+      caller, body.size(), succeeded, body.size() - succeeded);
+
+    // SEMA-V6-007 / CLAUDE.md skip-capture: suppress the generic ProvenanceCaptureFilter
+    // Activity for this request. Per-row activities are omitted for bulk (too expensive).
+    try {
+      if (requestContext != null) {
+        requestContext.setProperty(ProvenanceCaptureFilter.PROP_SKIP_CAPTURE, Boolean.TRUE);
+      }
+    } catch (RuntimeException ignored) { /* best-effort secondary write */ }
+
+    BulkAnnotationResultIO result = new BulkAnnotationResultIO();
+    result.setRequested(body.size());
+    result.setSucceeded(succeeded);
+    result.setFailed(body.size() - succeeded);
+    result.setResults(results);
+
+    return Response.ok(result).build();
   }
 
   // ─── UPDATE ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `POST /v2/annotations/bulk` to `SemanticAnnotationV2Rest` accepting up to 100 `CreateAnnotationIO` entries per call
- Best-effort per row: a failure on row N does not abort rows N+1…100
- Returns `{requested, succeeded, failed, results:[{index, ok, appId?, error?}]}` envelope via new `BulkAnnotationResultIO` + inner `RowResult` class
- `X-AI-Agent` header drives `sourceMode` per-row (same logic as single `POST /v2/annotations`)
- `PROP_SKIP_CAPTURE` set at end to suppress the `ProvenanceCaptureFilter` generic Activity (no per-row Activity — too expensive at 100 rows; follow-up in SEMA-V6-007 scope)
- Full OpenAPI `@Operation` + `@APIResponse` annotations

## Closes / implements

aidocs/16 row: `SEMANTIC-ANNOTATE-BULK-REST-1`

## Test plan

- [ ] `POST /v2/annotations/bulk` with 2 valid entries → 200, `succeeded=2`
- [ ] Mix of valid + invalid entries → partial success, `failed` count correct
- [ ] Body with 101 entries → 400
- [ ] Null body → 400
- [ ] Unauthenticated → 401

https://claude.ai/code/session_019Ur1ntLs4GkhxCvjzZWL4g

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ur1ntLs4GkhxCvjzZWL4g)_