### PR TITLE
fix(FE-BUILD-03-REGEN): join DO_LIST_FIELDS to string; retire as-unknown-as cast

### DIFF
--- a/frontend/composables/context/usePagedDataObjects.ts
+++ b/frontend/composables/context/usePagedDataObjects.ts
@@ -85,9 +85,6 @@ export function usePagedDataObjects(opts: PagedDataObjectsOptions): PagedDataObj
     try {
       let batch: DataObjectListItemV2[];
       if (appId) {
-        // DB-OPT5: cast bypasses stale generated client that lacks the `fields`
-        // param — see FE-BUILD-03 in aidocs/16. Real fix is client regen.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const { items: fetched, total: fetchedTotal } = await v2Api.value.listDataObjectsWithCount({
           collectionAppId: appId,
           name: nameFilter,
@@ -96,7 +93,7 @@ export function usePagedDataObjects(opts: PagedDataObjectsOptions): PagedDataObj
           size: pageSize,
           include: includeTimeBounds ? 'time-bounds' : undefined,
           fields: DO_LIST_FIELDS,
-        } as unknown as Parameters<typeof v2Api.value.listDataObjectsWithCount>[0]);
+        });
         batch = fetched;
         totalItems.value = fetchedTotal;
       } else {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes the `as unknown as Parameters<typeof v2Api.value.listDataObjectsWithCount>[0]` type cast from `usePagedDataObjects.ts`
- Removes the accompanying `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comment that existed solely to support the cast
- Removes the stale workaround comment explaining why the cast existed

## Why this is the correct fix

`DO_LIST_FIELDS` was already being built as a `string` via `.join(",")` at declaration time. The generated client's `ListDataObjectsV2Request` already has `fields?: string` (singular comma-separated string), which matches exactly what was being passed. The `as unknown as` cast was therefore never needed — the types already aligned.

The workaround comment said "Real fix is client regen" but client regen was unnecessary because the client was already correct.

## Verification

- `npm run typecheck` — passes with zero errors after removing the cast
- `npm run lint` — no errors in the changed file (`eslint composables/context/usePagedDataObjects.ts` exits clean)
- `npm run test` — pre-existing test failures in `spdxLicenses.test.ts` and `useFetchRecentCollections.test.ts` are unrelated to this change (confirmed by running tests on `main` before applying the fix)

## Files changed

- `frontend/composables/context/usePagedDataObjects.ts` — removed 4 lines (3-line workaround comment + 1 cast suffix)

Closes FE-BUILD-03-REGEN from `aidocs/16-dispatcher-backlog.md`.

https://claude.ai/code/session_01EKzXwdneYaAquLjuBSgTG1
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKzXwdneYaAquLjuBSgTG1)_