### PR TITLE
docs(PRE-MUT-SNAP1): add pre-mutation snapshot contract design doc

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -30,452 +30,455 @@ section and the `upgrade-overlay` section.
 
 | stage | count |
 |---|---|
-| `fragment` | 47 |
-| `concept` | 25 |
+| `fragment` | 48 |
+| `concept` | 26 |
 | `idea` | 13 |
 | `feature-defined` | 108 |
 | `audited-by-personas` | 74 |
 | `feedback-implemented` | 2 |
 | `tests-implemented` | 4 |
-| `deployed` | 70 |
+| `deployed` | 71 |
 | `decommissioned` | 49 |
 | `upgrade-vX:vY` (overlay) | 0 |
-| **total docs** | **392** |
+| **total docs** | **395** |
 | **UNTAGGED** | **0** |
 
-## fragment (47)
+## fragment (48)
 
 | doc | title | last-stage-change | last-touched |
 |---|---|---|---|
-| [`aidocs/agent-findings/00-synergy-index.md`](agent-findings/00-synergy-index.md) | 00 — Synergy index | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/batch-api-audit-2026-05-27.md`](agent-findings/batch-api-audit-2026-05-27.md) | Batch API — Per-Substrate Primitives Audit (2026-05-27) | — | 2026-05-27 |
+| [`aidocs/agent-findings/00-synergy-index.md`](agent-findings/00-synergy-index.md) | 00 — Synergy index | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/batch-api-audit-2026-05-27.md`](agent-findings/batch-api-audit-2026-05-27.md) | Batch API — Per-Substrate Primitives Audit (2026-05-27) | — | 2026-05-29 |
 | [`aidocs/agent-findings/dispatcher-runs/2026-05-29-15.md`](agent-findings/dispatcher-runs/2026-05-29-15.md) | Dispatcher run — 2026-05-29 15:18 UTC | 2026-05-29 | 2026-05-29 |
 | [`aidocs/agent-findings/dispatcher-runs/2026-05-29-16.md`](agent-findings/dispatcher-runs/2026-05-29-16.md) | Dispatcher run — 2026-05-29 16:xx UTC | 2026-05-29 | 2026-05-29 |
 | [`aidocs/agent-findings/dispatcher-runs/2026-05-29-17.md`](agent-findings/dispatcher-runs/2026-05-29-17.md) | Dispatcher run — 2026-05-29 17:xx UTC | 2026-05-29 | 2026-05-29 |
 | [`aidocs/agent-findings/dispatcher-runs/2026-05-29-18.md`](agent-findings/dispatcher-runs/2026-05-29-18.md) | Dispatcher run — 2026-05-29 18:xx UTC | 2026-05-29 | 2026-05-29 |
 | [`aidocs/agent-findings/dispatcher-runs/2026-05-29-19.md`](agent-findings/dispatcher-runs/2026-05-29-19.md) | Dispatcher run — 2026-05-29 19:xx UTC | 2026-05-29 | 2026-05-29 |
-| [`aidocs/agent-findings/mffd-afp-spatial-analysis-cases.md`](agent-findings/mffd-afp-spatial-analysis-cases.md) | MFFD AFP Spatial Data — Analysis Cases | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/mffd-wiki-analysis-findings.md`](agent-findings/mffd-wiki-analysis-findings.md) | MFFD Confluence Wiki Analysis — Findings | 2026-05-28 | 2026-05-28 |
-| [`aidocs/agent-findings/mffd-wiki-reading-guide.md`](agent-findings/mffd-wiki-reading-guide.md) | MFFD Confluence Wiki — Complete Systematic Review | — | 2026-05-28 |
-| [`aidocs/agent-findings/synergy-2026-05-23-ai-accountability.md`](agent-findings/synergy-2026-05-23-ai-accountability.md) | S-08 — AI accountability dashboard: MCP × Permission audit log × F(AI)²R | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/synergy-2026-05-23-channel-as-individual.md`](agent-findings/synergy-2026-05-23-channel-as-individual.md) | S-01 — Channel-as-individual: HSDS HDF5 × AAS TimeSeriesData × sTC | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/synergy-2026-05-23-openlineage-fair2r.md`](agent-findings/synergy-2026-05-23-openlineage-fair2r.md) | S-02 — OpenLineage RunEvent × F(AI)²R × PROV-O: EASA evidence for free | 2026-05-23 | 2026-05-27 |
-| [`aidocs/agent-findings/synergy-2026-05-23-pidinst-three-exports.md`](agent-findings/synergy-2026-05-23-pidinst-three-exports.md) | S-05 — One PID, three exports: PIDINST × SOSA/SSN × AAS Nameplate | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/synergy-2026-05-23-roundtrip-wiki.md`](agent-findings/synergy-2026-05-23-roundtrip-wiki.md) | S-03 — Round-trip wiki: Confluence import × Wiki-writer × Snapshot chain | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/synergy-2026-05-23-shacl-driven-mcp.md`](agent-findings/synergy-2026-05-23-shacl-driven-mcp.md) | S-07 — SHACL × MCP tools × ShapesValidateRest: one validator, two surfaces | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/synergy-2026-05-23-snapshots-garage-gap.md`](agent-findings/synergy-2026-05-23-snapshots-garage-gap.md) | S-06 — Snapshots × Garage S3 (no versioning): Shepard absorbs the gap | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/synergy-2026-05-23-trace3d-video-sync.md`](agent-findings/synergy-2026-05-23-trace3d-video-sync.md) | S-04 — Trace3D × Video × DataBinding: synchronized 3D-trace + camera-PiP | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/synergy-2026-05-27.md`](agent-findings/synergy-2026-05-27.md) | Synergy findings — 2026-05-27 | 2026-05-27 | 2026-05-27 |
-| [`aidocs/data/12-timescaledb-performance-analysis.md`](data/12-timescaledb-performance-analysis.md) | TimescaleDB Timeseries Integration — Performance Analysis & Mitigations | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/69-timeseries-upstream-migration.md`](data/69-timeseries-upstream-migration.md) | Timeseries Schema — Migration from Upstream | 2026-05-23 | 2026-05-26 |
-| [`aidocs/data/88-thumbnail-spi.md`](data/88-thumbnail-spi.md) | TH1 — File Thumbnail SPI | 2026-05-23 | 2026-05-23 |
-| [`aidocs/input/input_raw.md`](input/input_raw.md) | Set up configuration | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/22-admin-cli-draft.md`](ops/22-admin-cli-draft.md) | Admin CLI — Candidate-Function Draft | 2026-05-23 | 2026-05-27 |
-| [`aidocs/ops/27-convenience-clients-design.md`](ops/27-convenience-clients-design.md) | Convenience Clients — `shepard-py` and `shepard-ts` (P16) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/28-paradigms-and-clients-synthesis.md`](ops/28-paradigms-and-clients-synthesis.md) | 28. Paradigms-and-Clients Synthesis — The Integrated Proposal | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/33-frontend-workflow-analysis.md`](ops/33-frontend-workflow-analysis.md) | 33 — Frontend / UI Workflow Analysis + Suggestions | 2026-05-23 | 2026-05-26 |
-| [`aidocs/ops/86-ui-changelog.md`](ops/86-ui-changelog.md) | 86 — UI Change Log | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/11-implementation-plan.md`](platform/11-implementation-plan.md) | Implementation Plan — shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/19-architecture-feedback.md`](platform/19-architecture-feedback.md) | 19 — Critical Architectural Feedback | 2026-05-23 | 2026-05-26 |
-| [`aidocs/platform/20-epic-roadmap.md`](platform/20-epic-roadmap.md) | Epic Roadmap — shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/23-api-critique.md`](platform/23-api-critique.md) | API Critique — Usability, Redundancies, Paradigms, Client Generation | 2026-05-23 | 2026-05-26 |
-| [`aidocs/platform/26-crud-consistency.md`](platform/26-crud-consistency.md) | 26. REST API CRUD Consistency Inventory | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/29-p10-implementation-design.md`](platform/29-p10-implementation-design.md) | P10 — `POST /sql/timeseries` Implementation Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/32-long-running-process-pattern.md`](platform/32-long-running-process-pattern.md) | Long-Running Process Pattern — Async Jobs | 2026-05-23 | 2026-05-28 |
-| [`aidocs/platform/A3c-namespace-migration.md`](platform/A3c-namespace-migration.md) | A3c: infrastructure-vs-feature toggle namespace split | 2026-05-23 | 2026-05-23 |
-| [`aidocs/reference/v5-openapi-summary.md`](reference/v5-openapi-summary.md) | v5 source — OpenAPI 5.4.0 summary (legacy-compat ground truth) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/semantics/13-search-improvements.md`](semantics/13-search-improvements.md) | Search — Improvements & Unification Proposal | 2026-05-23 | 2026-05-26 |
-| [`aidocs/strategy/70-competitor-landscape-and-feature-ideas.md`](strategy/70-competitor-landscape-and-feature-ideas.md) | aidocs/70 — Competitor landscape & feature ideas for shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/71-fork-adoption-as-upstream.md`](strategy/71-fork-adoption-as-upstream.md) | aidocs/71 — Fork adoption as upstream: feasibility, verification, and cost-benefit | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/73-dlr-stakeholder.md`](strategy/73-dlr-stakeholder.md) | aidocs/73 — shepard: Stakeholder brief for DLR | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/74-dlr-bt-stakeholder.md`](strategy/74-dlr-bt-stakeholder.md) | aidocs/74 — shepard: Stakeholder brief for DLR-BT (Stuttgart) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/82-zlp-augsburg-stakeholder.md`](strategy/82-zlp-augsburg-stakeholder.md) | aidocs/82 — shepard: Stakeholder brief for DLR ZLP Augsburg | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/86-shepard-predecessor-systems.md`](strategy/86-shepard-predecessor-systems.md) | Predecessor systems at DLR ZLP Augsburg — continuity of field before Shepard | 2026-05-23 | 2026-05-26 |
-| [`aidocs/strategy/95-damast-space-transport-data-management.md`](strategy/95-damast-space-transport-data-management.md) | DaMaST — Data Management for Space Transport | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/96-hokitep-zlp-extension-and-joint-usecase.md`](strategy/96-hokitep-zlp-extension-and-joint-usecase.md) | HoKiTeP — ZLP extension and joint use-case orchestration | 2026-05-23 | 2026-05-23 |
-| [`aidocs/workflows/31-rocrate-export-optimisation.md`](workflows/31-rocrate-export-optimisation.md) | 31 — RO-Crate Export Optimisation | 2026-05-23 | 2026-05-23 |
+| [`aidocs/agent-findings/dispatcher-runs/2026-05-29-20.md`](agent-findings/dispatcher-runs/2026-05-29-20.md) | Dispatcher run — 2026-05-29 20:xx UTC | 2026-05-29 | 2026-05-29 |
+| [`aidocs/agent-findings/mffd-afp-spatial-analysis-cases.md`](agent-findings/mffd-afp-spatial-analysis-cases.md) | MFFD AFP Spatial Data — Analysis Cases | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/mffd-wiki-analysis-findings.md`](agent-findings/mffd-wiki-analysis-findings.md) | MFFD Confluence Wiki Analysis — Findings | 2026-05-28 | 2026-05-29 |
+| [`aidocs/agent-findings/mffd-wiki-reading-guide.md`](agent-findings/mffd-wiki-reading-guide.md) | MFFD Confluence Wiki — Complete Systematic Review | — | 2026-05-29 |
+| [`aidocs/agent-findings/synergy-2026-05-23-ai-accountability.md`](agent-findings/synergy-2026-05-23-ai-accountability.md) | S-08 — AI accountability dashboard: MCP × Permission audit log × F(AI)²R | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/synergy-2026-05-23-channel-as-individual.md`](agent-findings/synergy-2026-05-23-channel-as-individual.md) | S-01 — Channel-as-individual: HSDS HDF5 × AAS TimeSeriesData × sTC | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/synergy-2026-05-23-openlineage-fair2r.md`](agent-findings/synergy-2026-05-23-openlineage-fair2r.md) | S-02 — OpenLineage RunEvent × F(AI)²R × PROV-O: EASA evidence for free | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/synergy-2026-05-23-pidinst-three-exports.md`](agent-findings/synergy-2026-05-23-pidinst-three-exports.md) | S-05 — One PID, three exports: PIDINST × SOSA/SSN × AAS Nameplate | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/synergy-2026-05-23-roundtrip-wiki.md`](agent-findings/synergy-2026-05-23-roundtrip-wiki.md) | S-03 — Round-trip wiki: Confluence import × Wiki-writer × Snapshot chain | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/synergy-2026-05-23-shacl-driven-mcp.md`](agent-findings/synergy-2026-05-23-shacl-driven-mcp.md) | S-07 — SHACL × MCP tools × ShapesValidateRest: one validator, two surfaces | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/synergy-2026-05-23-snapshots-garage-gap.md`](agent-findings/synergy-2026-05-23-snapshots-garage-gap.md) | S-06 — Snapshots × Garage S3 (no versioning): Shepard absorbs the gap | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/synergy-2026-05-23-trace3d-video-sync.md`](agent-findings/synergy-2026-05-23-trace3d-video-sync.md) | S-04 — Trace3D × Video × DataBinding: synchronized 3D-trace + camera-PiP | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/synergy-2026-05-27.md`](agent-findings/synergy-2026-05-27.md) | Synergy findings — 2026-05-27 | 2026-05-27 | 2026-05-29 |
+| [`aidocs/data/12-timescaledb-performance-analysis.md`](data/12-timescaledb-performance-analysis.md) | TimescaleDB Timeseries Integration — Performance Analysis & Mitigations | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/69-timeseries-upstream-migration.md`](data/69-timeseries-upstream-migration.md) | Timeseries Schema — Migration from Upstream | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/88-thumbnail-spi.md`](data/88-thumbnail-spi.md) | TH1 — File Thumbnail SPI | 2026-05-23 | 2026-05-29 |
+| [`aidocs/input/input_raw.md`](input/input_raw.md) | Set up configuration | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/22-admin-cli-draft.md`](ops/22-admin-cli-draft.md) | Admin CLI — Candidate-Function Draft | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/27-convenience-clients-design.md`](ops/27-convenience-clients-design.md) | Convenience Clients — `shepard-py` and `shepard-ts` (P16) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/28-paradigms-and-clients-synthesis.md`](ops/28-paradigms-and-clients-synthesis.md) | 28. Paradigms-and-Clients Synthesis — The Integrated Proposal | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/33-frontend-workflow-analysis.md`](ops/33-frontend-workflow-analysis.md) | 33 — Frontend / UI Workflow Analysis + Suggestions | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/86-ui-changelog.md`](ops/86-ui-changelog.md) | 86 — UI Change Log | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/11-implementation-plan.md`](platform/11-implementation-plan.md) | Implementation Plan — shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/19-architecture-feedback.md`](platform/19-architecture-feedback.md) | 19 — Critical Architectural Feedback | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/20-epic-roadmap.md`](platform/20-epic-roadmap.md) | Epic Roadmap — shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/23-api-critique.md`](platform/23-api-critique.md) | API Critique — Usability, Redundancies, Paradigms, Client Generation | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/26-crud-consistency.md`](platform/26-crud-consistency.md) | 26. REST API CRUD Consistency Inventory | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/29-p10-implementation-design.md`](platform/29-p10-implementation-design.md) | P10 — `POST /sql/timeseries` Implementation Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/32-long-running-process-pattern.md`](platform/32-long-running-process-pattern.md) | Long-Running Process Pattern — Async Jobs | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/A3c-namespace-migration.md`](platform/A3c-namespace-migration.md) | A3c: infrastructure-vs-feature toggle namespace split | 2026-05-23 | 2026-05-29 |
+| [`aidocs/reference/v5-openapi-summary.md`](reference/v5-openapi-summary.md) | v5 source — OpenAPI 5.4.0 summary (legacy-compat ground truth) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/semantics/13-search-improvements.md`](semantics/13-search-improvements.md) | Search — Improvements & Unification Proposal | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/70-competitor-landscape-and-feature-ideas.md`](strategy/70-competitor-landscape-and-feature-ideas.md) | aidocs/70 — Competitor landscape & feature ideas for shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/71-fork-adoption-as-upstream.md`](strategy/71-fork-adoption-as-upstream.md) | aidocs/71 — Fork adoption as upstream: feasibility, verification, and cost-benefit | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/73-dlr-stakeholder.md`](strategy/73-dlr-stakeholder.md) | aidocs/73 — shepard: Stakeholder brief for DLR | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/74-dlr-bt-stakeholder.md`](strategy/74-dlr-bt-stakeholder.md) | aidocs/74 — shepard: Stakeholder brief for DLR-BT (Stuttgart) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/82-zlp-augsburg-stakeholder.md`](strategy/82-zlp-augsburg-stakeholder.md) | aidocs/82 — shepard: Stakeholder brief for DLR ZLP Augsburg | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/86-shepard-predecessor-systems.md`](strategy/86-shepard-predecessor-systems.md) | Predecessor systems at DLR ZLP Augsburg — continuity of field before Shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/95-damast-space-transport-data-management.md`](strategy/95-damast-space-transport-data-management.md) | DaMaST — Data Management for Space Transport | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/96-hokitep-zlp-extension-and-joint-usecase.md`](strategy/96-hokitep-zlp-extension-and-joint-usecase.md) | HoKiTeP — ZLP extension and joint use-case orchestration | 2026-05-23 | 2026-05-29 |
+| [`aidocs/workflows/31-rocrate-export-optimisation.md`](workflows/31-rocrate-export-optimisation.md) | 31 — RO-Crate Export Optimisation | 2026-05-23 | 2026-05-29 |
 
-## concept (25)
+## concept (26)
 
 | doc | title | last-stage-change | last-touched |
 |---|---|---|---|
-| [`aidocs/agent-findings/mffd-welding-ts-analysis-cases.md`](agent-findings/mffd-welding-ts-analysis-cases.md) | MFFD CRW Welding Time-Series — Analysis Case Definitions | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/v5-metadata-enrichment-2026-05-23.md`](agent-findings/v5-metadata-enrichment-2026-05-23.md) | V5-METADATA-SURVEY — Metadata enrichment opportunities from v5 OpenAPI surface | 2026-05-26 | 2026-05-26 |
-| [`aidocs/data/05-db-inventory.md`](data/05-db-inventory.md) | Shepard DB Schema Inventory | 2026-05-26 | 2026-05-26 |
-| [`aidocs/data/45-gridfs-to-s3-evaluation.md`](data/45-gridfs-to-s3-evaluation.md) | GridFS → S3 — Evaluation | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/46-gridfs-to-s3-migration-runbook.md`](data/46-gridfs-to-s3-migration-runbook.md) | GridFS → S3 (Garage) Migration — Operator Runbook | 2026-05-26 | 2026-05-26 |
-| [`aidocs/data/50-experiment-orchestration.md`](data/50-experiment-orchestration.md) | Experiment Orchestration — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/53-file-reference-rename-video-content.md`](data/53-file-reference-rename-video-content.md) | FileReference Rename + Video Payload Kind — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/r4-novacrate-evaluation.md`](data/r4-novacrate-evaluation.md) | R4 — NovaCrate evaluation for RO-Crate metadata editing | 2026-05-26 | 2026-05-26 |
-| [`aidocs/frontend/02-css-layout-conventions.md`](frontend/02-css-layout-conventions.md) | Frontend CSS layout conventions | 2026-05-27 | 2026-05-27 |
-| [`aidocs/integrations/110-file-format-parser-plugin.md`](integrations/110-file-format-parser-plugin.md) | 110 — File-format parser plugin SPI | 2026-05-26 | 2026-05-28 |
-| [`aidocs/integrations/52-aas-backend-integration.md`](integrations/52-aas-backend-integration.md) | AAS Backend Integration — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/60-shepard-edge.md`](integrations/60-shepard-edge.md) | shepard Edge — Concept Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/61-shepard-mount-as-network-drive.md`](integrations/61-shepard-mount-as-network-drive.md) | shepard Mount as a Network Drive — Concept Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/49-in-app-user-docs.md`](ops/49-in-app-user-docs.md) | In-App User Docs — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/57-openapi-client-generator-evaluation.md`](ops/57-openapi-client-generator-evaluation.md) | OpenAPI Client Generator Evaluation — `/v2/` Codegen | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/58-ui-and-graph-ergonomics.md`](ops/58-ui-and-graph-ergonomics.md) | UI & Graph Ergonomics — Design Cluster | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/p22-sse-proxy-compat-findings.md`](ops/p22-sse-proxy-compat-findings.md) | P22 — SSE proxy-compatibility findings | 2026-05-26 | 2026-05-26 |
-| [`aidocs/ops/vis-s2-garage-omezarr-storage-policy.md`](ops/vis-s2-garage-omezarr-storage-policy.md) | VIS-S2 — Garage S3 + OME-Zarr storage-policy operator doc | 2026-05-26 | 2026-05-26 |
-| [`aidocs/platform/56-v2-api-simplification-output-profiles-mcp.md`](platform/56-v2-api-simplification-output-profiles-mcp.md) | `/v2/` API Simplification — Flat Paths, Output Profiles, MCP-Friendly OpenAPI | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/API3-container-safe-delete-design.md`](platform/API3-container-safe-delete-design.md) | API3 — Safe-Delete Design for Container Endpoints | 2026-05-26 | 2026-05-26 |
-| [`aidocs/semantics/48-internal-semantic-repository-via-neosemantics.md`](semantics/48-internal-semantic-repository-via-neosemantics.md) | Internal Semantic Repository via Neosemantics — Design | 2026-05-23 | 2026-05-26 |
-| [`aidocs/strategy/190-thesis-idea-timeline.md`](strategy/190-thesis-idea-timeline.md) | Thesis Idea Timeline | 2026-05-26 | 2026-05-26 |
-| [`aidocs/workflows/40-spw-stc-integration-design.md`](workflows/40-spw-stc-integration-design.md) | shepard-process-wizard + shepard-timeseries-collector integration design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/workflows/54-templates-as-first-class-entity.md`](workflows/54-templates-as-first-class-entity.md) | Templates as a First-Class Entity — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/workflows/55-provenance-and-activity-overhaul.md`](workflows/55-provenance-and-activity-overhaul.md) | Provenance and Activity Overhaul — Design | 2026-05-23 | 2026-05-26 |
+| [`aidocs/agent-findings/mffd-welding-ts-analysis-cases.md`](agent-findings/mffd-welding-ts-analysis-cases.md) | MFFD CRW Welding Time-Series — Analysis Case Definitions | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/v5-metadata-enrichment-2026-05-23.md`](agent-findings/v5-metadata-enrichment-2026-05-23.md) | V5-METADATA-SURVEY — Metadata enrichment opportunities from v5 OpenAPI surface | 2026-05-26 | 2026-05-29 |
+| [`aidocs/data/05-db-inventory.md`](data/05-db-inventory.md) | Shepard DB Schema Inventory | 2026-05-26 | 2026-05-29 |
+| [`aidocs/data/45-gridfs-to-s3-evaluation.md`](data/45-gridfs-to-s3-evaluation.md) | GridFS → S3 — Evaluation | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/46-gridfs-to-s3-migration-runbook.md`](data/46-gridfs-to-s3-migration-runbook.md) | GridFS → S3 (Garage) Migration — Operator Runbook | 2026-05-26 | 2026-05-29 |
+| [`aidocs/data/50-experiment-orchestration.md`](data/50-experiment-orchestration.md) | Experiment Orchestration — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/53-file-reference-rename-video-content.md`](data/53-file-reference-rename-video-content.md) | FileReference Rename + Video Payload Kind — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/r4-novacrate-evaluation.md`](data/r4-novacrate-evaluation.md) | R4 — NovaCrate evaluation for RO-Crate metadata editing | 2026-05-26 | 2026-05-29 |
+| [`aidocs/frontend/02-css-layout-conventions.md`](frontend/02-css-layout-conventions.md) | Frontend CSS layout conventions | 2026-05-27 | 2026-05-29 |
+| [`aidocs/integrations/110-file-format-parser-plugin.md`](integrations/110-file-format-parser-plugin.md) | 110 — File-format parser plugin SPI | 2026-05-26 | 2026-05-29 |
+| [`aidocs/integrations/52-aas-backend-integration.md`](integrations/52-aas-backend-integration.md) | AAS Backend Integration — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/60-shepard-edge.md`](integrations/60-shepard-edge.md) | shepard Edge — Concept Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/61-shepard-mount-as-network-drive.md`](integrations/61-shepard-mount-as-network-drive.md) | shepard Mount as a Network Drive — Concept Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/49-in-app-user-docs.md`](ops/49-in-app-user-docs.md) | In-App User Docs — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/57-openapi-client-generator-evaluation.md`](ops/57-openapi-client-generator-evaluation.md) | OpenAPI Client Generator Evaluation — `/v2/` Codegen | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/58-ui-and-graph-ergonomics.md`](ops/58-ui-and-graph-ergonomics.md) | UI & Graph Ergonomics — Design Cluster | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/89-pre-mutation-snapshots.md`](ops/89-pre-mutation-snapshots.md) | 89 — Pre-mutation snapshot contract | 2026-05-30 | — |
+| [`aidocs/ops/p22-sse-proxy-compat-findings.md`](ops/p22-sse-proxy-compat-findings.md) | P22 — SSE proxy-compatibility findings | 2026-05-26 | 2026-05-29 |
+| [`aidocs/ops/vis-s2-garage-omezarr-storage-policy.md`](ops/vis-s2-garage-omezarr-storage-policy.md) | VIS-S2 — Garage S3 + OME-Zarr storage-policy operator doc | 2026-05-26 | 2026-05-29 |
+| [`aidocs/platform/56-v2-api-simplification-output-profiles-mcp.md`](platform/56-v2-api-simplification-output-profiles-mcp.md) | `/v2/` API Simplification — Flat Paths, Output Profiles, MCP-Friendly OpenAPI | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/API3-container-safe-delete-design.md`](platform/API3-container-safe-delete-design.md) | API3 — Safe-Delete Design for Container Endpoints | 2026-05-26 | 2026-05-29 |
+| [`aidocs/semantics/48-internal-semantic-repository-via-neosemantics.md`](semantics/48-internal-semantic-repository-via-neosemantics.md) | Internal Semantic Repository via Neosemantics — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/190-thesis-idea-timeline.md`](strategy/190-thesis-idea-timeline.md) | Thesis Idea Timeline | 2026-05-26 | 2026-05-29 |
+| [`aidocs/workflows/40-spw-stc-integration-design.md`](workflows/40-spw-stc-integration-design.md) | shepard-process-wizard + shepard-timeseries-collector integration design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/workflows/54-templates-as-first-class-entity.md`](workflows/54-templates-as-first-class-entity.md) | Templates as a First-Class Entity — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/workflows/55-provenance-and-activity-overhaul.md`](workflows/55-provenance-and-activity-overhaul.md) | Provenance and Activity Overhaul — Design | 2026-05-23 | 2026-05-29 |
 
 ## idea (13)
 
 | doc | title | last-stage-change | last-touched |
 |---|---|---|---|
-| [`aidocs/98-thesis-perspective.md`](98-thesis-perspective.md) | 98 — Shepard as a thesis at a German university (perspective + viability) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/v5-metadata-enrichment-survey-2026-05-23.md`](agent-findings/v5-metadata-enrichment-survey-2026-05-23.md) | v5 OpenAPI — metadata enrichment survey for the MFFD importer (v15.10 candidates) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/109-mffd-scan-line-join-key.md`](data/109-mffd-scan-line-join-key.md) | 109 — MFFD scan-line join key across TPS stores | 2026-05-27 | 2026-05-27 |
-| [`aidocs/integrations/112-mfg-plugin-design.md`](integrations/112-mfg-plugin-design.md) | 112 — `shepard-plugin-mfg` design sketch | 2026-05-27 | 2026-05-27 |
+| [`aidocs/98-thesis-perspective.md`](98-thesis-perspective.md) | 98 — Shepard as a thesis at a German university (perspective + viability) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/v5-metadata-enrichment-survey-2026-05-23.md`](agent-findings/v5-metadata-enrichment-survey-2026-05-23.md) | v5 OpenAPI — metadata enrichment survey for the MFFD importer (v15.10 candidates) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/109-mffd-scan-line-join-key.md`](data/109-mffd-scan-line-join-key.md) | 109 — MFFD scan-line join key across TPS stores | 2026-05-27 | 2026-05-29 |
+| [`aidocs/integrations/112-mfg-plugin-design.md`](integrations/112-mfg-plugin-design.md) | 112 — `shepard-plugin-mfg` design sketch | 2026-05-27 | 2026-05-29 |
 | [`aidocs/integrations/116-btkvs-improved-schema.md`](integrations/116-btkvs-improved-schema.md) | 116 — BT-KVS docket improved schema | 2026-05-29 | 2026-05-29 |
-| [`aidocs/platform/106-requirements-traceability.md`](platform/106-requirements-traceability.md) | 106 — Requirements traceability — research direction | 2026-05-23 | 2026-05-23 |
+| [`aidocs/platform/106-requirements-traceability.md`](platform/106-requirements-traceability.md) | 106 — Requirements traceability — research direction | 2026-05-23 | 2026-05-29 |
 | [`aidocs/platform/110-permissions-redesign-decision.md`](platform/110-permissions-redesign-decision.md) | 110 — Permissions: redesign or extend in place? | 2026-05-29 | 2026-05-29 |
-| [`aidocs/platform/68-plugin-vs-core-overview.md`](platform/68-plugin-vs-core-overview.md) | 68 — Plugin-vs-core architecture overview | 2026-05-23 | 2026-05-23 |
-| [`aidocs/semantics/43-ai-opportunities.md`](semantics/43-ai-opportunities.md) | AI Opportunities — Traditional ML + LLM Integration | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/101-diva-project-context.md`](strategy/101-diva-project-context.md) | 101 — DIVA: Drone Integration via AAS (project context) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/75-dfg-eresearch-funding.md`](strategy/75-dfg-eresearch-funding.md) | aidocs/75 — DFG e-Research-Technologien: Antragsfähigkeit und Konzeptskizze | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/76-shepard-users-and-citations.md`](strategy/76-shepard-users-and-citations.md) | aidocs/76 — shepard: Known users, citations, and ecosystem | 2026-05-23 | 2026-05-23 |
-| [`aidocs/workflows/30-provenance-and-lineage-design.md`](workflows/30-provenance-and-lineage-design.md) | Provenance and Data Lineage — Design Exploration | 2026-05-23 | 2026-05-26 |
+| [`aidocs/platform/68-plugin-vs-core-overview.md`](platform/68-plugin-vs-core-overview.md) | 68 — Plugin-vs-core architecture overview | 2026-05-23 | 2026-05-29 |
+| [`aidocs/semantics/43-ai-opportunities.md`](semantics/43-ai-opportunities.md) | AI Opportunities — Traditional ML + LLM Integration | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/101-diva-project-context.md`](strategy/101-diva-project-context.md) | 101 — DIVA: Drone Integration via AAS (project context) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/75-dfg-eresearch-funding.md`](strategy/75-dfg-eresearch-funding.md) | aidocs/75 — DFG e-Research-Technologien: Antragsfähigkeit und Konzeptskizze | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/76-shepard-users-and-citations.md`](strategy/76-shepard-users-and-citations.md) | aidocs/76 — shepard: Known users, citations, and ecosystem | 2026-05-23 | 2026-05-29 |
+| [`aidocs/workflows/30-provenance-and-lineage-design.md`](workflows/30-provenance-and-lineage-design.md) | Provenance and Data Lineage — Design Exploration | 2026-05-23 | 2026-05-29 |
 
 ## feature-defined (108)
 
 | doc | title | last-stage-change | last-touched |
 |---|---|---|---|
-| [`aidocs/43-reverse-engineered-requirements.md`](43-reverse-engineered-requirements.md) | 43 — Reverse-engineered requirements (to be challenged) | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/185-v5-survey-bundle.md`](agent-findings/185-v5-survey-bundle.md) | v5 Survey Bundle (v15.10) | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/aas-edc-reuse-survey-2026-05-23.md`](agent-findings/aas-edc-reuse-survey-2026-05-23.md) | AAS + EDC reuse survey for `shepard-plugin-aas` + `shepard-plugin-edc` | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/backend-jandex-hang-investigation-2026-05-28.md`](agent-findings/backend-jandex-hang-investigation-2026-05-28.md) | Backend rebuild — Quarkus/Jandex infinite-loop investigation (2026-05-28) | 2026-05-28 | 2026-05-28 |
+| [`aidocs/43-reverse-engineered-requirements.md`](43-reverse-engineered-requirements.md) | 43 — Reverse-engineered requirements (to be challenged) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/185-v5-survey-bundle.md`](agent-findings/185-v5-survey-bundle.md) | v5 Survey Bundle (v15.10) | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/aas-edc-reuse-survey-2026-05-23.md`](agent-findings/aas-edc-reuse-survey-2026-05-23.md) | AAS + EDC reuse survey for `shepard-plugin-aas` + `shepard-plugin-edc` | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/backend-jandex-hang-investigation-2026-05-28.md`](agent-findings/backend-jandex-hang-investigation-2026-05-28.md) | Backend rebuild — Quarkus/Jandex infinite-loop investigation (2026-05-28) | 2026-05-28 | 2026-05-29 |
 | [`aidocs/agent-findings/btkvs-docket-showcase-2026-05-29.md`](agent-findings/btkvs-docket-showcase-2026-05-29.md) | BT-KVS docket showcase — C/C and C/SiC fabrication tracking | 2026-05-29 | 2026-05-29 |
-| [`aidocs/agent-findings/bug-148-do-perms-seeded-2026-05-24.md`](agent-findings/bug-148-do-perms-seeded-2026-05-24.md) | BUG-148 — DataObject Permissions seeding: WORKS AS DESIGNED | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/file-storage-routing-audit-2026-05-24.md`](agent-findings/file-storage-routing-audit-2026-05-24.md) | File-storage routing audit — Garage vs Mongo GridFS, 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/garage-and-docker-stack-audit-2026-05-24.md`](agent-findings/garage-and-docker-stack-audit-2026-05-24.md) | Garage S3 + Docker stack audit — 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/gh-lean-cost-consult-2026-05-23.md`](agent-findings/gh-lean-cost-consult-2026-05-23.md) | GH lean-extension cost consult — 2026-05-23 | 2026-05-23 | 2026-05-26 |
+| [`aidocs/agent-findings/bug-148-do-perms-seeded-2026-05-24.md`](agent-findings/bug-148-do-perms-seeded-2026-05-24.md) | BUG-148 — DataObject Permissions seeding: WORKS AS DESIGNED | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/file-storage-routing-audit-2026-05-24.md`](agent-findings/file-storage-routing-audit-2026-05-24.md) | File-storage routing audit — Garage vs Mongo GridFS, 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/garage-and-docker-stack-audit-2026-05-24.md`](agent-findings/garage-and-docker-stack-audit-2026-05-24.md) | Garage S3 + Docker stack audit — 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/gh-lean-cost-consult-2026-05-23.md`](agent-findings/gh-lean-cost-consult-2026-05-23.md) | GH lean-extension cost consult — 2026-05-23 | 2026-05-23 | 2026-05-29 |
 | [`aidocs/agent-findings/jandex-hang-fix-2026-05-29.md`](agent-findings/jandex-hang-fix-2026-05-29.md) | Jandex hang — root cause + fix (2026-05-29) | 2026-05-29 | 2026-05-29 |
-| [`aidocs/agent-findings/jandex-hang-trigger-investigation-2026-05-28.md`](agent-findings/jandex-hang-trigger-investigation-2026-05-28.md) | Jandex hang — trigger-class hunt (2026-05-28) | 2026-05-28 | 2026-05-28 |
-| [`aidocs/agent-findings/mffd-shared-container-scale-check.md`](agent-findings/mffd-shared-container-scale-check.md) | MFFD shared-container scale check — 2026-05-26 | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/mffd-v16-ui-screenshots-2026-05-23/README.md`](agent-findings/mffd-v16-ui-screenshots-2026-05-23/README.md) | MFFD v16 UI screenshots — first live look at the digital-thread tree | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/mongodb-substrate-audit-2026-05-24.md`](agent-findings/mongodb-substrate-audit-2026-05-24.md) | MongoDB substrate audit — 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/no-ui-gap-survey-2026-05-24.md`](agent-findings/no-ui-gap-survey-2026-05-24.md) | No-UI gap survey + placeholder roll-out — 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/persona-digital-native-gh-pm-2026-05-23.md`](agent-findings/persona-digital-native-gh-pm-2026-05-23.md) | Persona: Digital Native Researcher — GH-PM audit (2026-05-23) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/plugin-design-audit-2026-05-24.md`](agent-findings/plugin-design-audit-2026-05-24.md) | Plugin design audit — Spatial + Tables + HDF5, 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/postgres-pgbouncer-substrate-audit-2026-05-24.md`](agent-findings/postgres-pgbouncer-substrate-audit-2026-05-24.md) | Postgres + PgBouncer substrate audit — 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/rdm-004-provenance-empty-fix-2026-05-24.md`](agent-findings/rdm-004-provenance-empty-fix-2026-05-24.md) | RDM-2026-05-24-004 — Provenance panel empty: root-cause + Bucket D fix | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/rdm-scrutinizer-2026-05-24.md`](agent-findings/rdm-scrutinizer-2026-05-24.md) | RDM Scrutinizer — FAIR + DMP + Publication Readiness, 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/research-network-orcid-anchor-2026-05-23.md`](agent-findings/research-network-orcid-anchor-2026-05-23.md) | Findings — ORCID anchor + general platform sweep for Florian Krebs (DLR ZLP Augsburg) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/synthesis-architecture-report-2026-05-24.md`](agent-findings/synthesis-architecture-report-2026-05-24.md) | Synthesis architecture report — 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/tib-hannover-outreach-2026-05-23.md`](agent-findings/tib-hannover-outreach-2026-05-23.md) | TIB Hannover outreach — Step 1 ("Used by" entry) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/ts-design-audit-2026-05-24.md`](agent-findings/ts-design-audit-2026-05-24.md) | TimescaleDB design audit — 2026-05-24 | 2026-05-24 | 2026-05-24 |
+| [`aidocs/agent-findings/jandex-hang-trigger-investigation-2026-05-28.md`](agent-findings/jandex-hang-trigger-investigation-2026-05-28.md) | Jandex hang — trigger-class hunt (2026-05-28) | 2026-05-28 | 2026-05-29 |
+| [`aidocs/agent-findings/mffd-shared-container-scale-check.md`](agent-findings/mffd-shared-container-scale-check.md) | MFFD shared-container scale check — 2026-05-26 | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/mffd-v16-ui-screenshots-2026-05-23/README.md`](agent-findings/mffd-v16-ui-screenshots-2026-05-23/README.md) | MFFD v16 UI screenshots — first live look at the digital-thread tree | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/mongodb-substrate-audit-2026-05-24.md`](agent-findings/mongodb-substrate-audit-2026-05-24.md) | MongoDB substrate audit — 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/no-ui-gap-survey-2026-05-24.md`](agent-findings/no-ui-gap-survey-2026-05-24.md) | No-UI gap survey + placeholder roll-out — 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-digital-native-gh-pm-2026-05-23.md`](agent-findings/persona-digital-native-gh-pm-2026-05-23.md) | Persona: Digital Native Researcher — GH-PM audit (2026-05-23) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/plugin-design-audit-2026-05-24.md`](agent-findings/plugin-design-audit-2026-05-24.md) | Plugin design audit — Spatial + Tables + HDF5, 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/postgres-pgbouncer-substrate-audit-2026-05-24.md`](agent-findings/postgres-pgbouncer-substrate-audit-2026-05-24.md) | Postgres + PgBouncer substrate audit — 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/rdm-004-provenance-empty-fix-2026-05-24.md`](agent-findings/rdm-004-provenance-empty-fix-2026-05-24.md) | RDM-2026-05-24-004 — Provenance panel empty: root-cause + Bucket D fix | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/rdm-scrutinizer-2026-05-24.md`](agent-findings/rdm-scrutinizer-2026-05-24.md) | RDM Scrutinizer — FAIR + DMP + Publication Readiness, 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/research-network-orcid-anchor-2026-05-23.md`](agent-findings/research-network-orcid-anchor-2026-05-23.md) | Findings — ORCID anchor + general platform sweep for Florian Krebs (DLR ZLP Augsburg) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/synthesis-architecture-report-2026-05-24.md`](agent-findings/synthesis-architecture-report-2026-05-24.md) | Synthesis architecture report — 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/tib-hannover-outreach-2026-05-23.md`](agent-findings/tib-hannover-outreach-2026-05-23.md) | TIB Hannover outreach — Step 1 ("Used by" entry) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/ts-design-audit-2026-05-24.md`](agent-findings/ts-design-audit-2026-05-24.md) | TimescaleDB design audit — 2026-05-24 | 2026-05-24 | 2026-05-29 |
 | [`aidocs/agent-findings/ts-ingest-222gb-importer-audit-2026-05-29.md`](agent-findings/ts-ingest-222gb-importer-audit-2026-05-29.md) | TS ingest 222 GB — v15 importer audit (CHOKE-01 + CHOKE-02) | 2026-05-29 | 2026-05-29 |
-| [`aidocs/agent-findings/ui-018-019-hypothesis-recheck-2026-05-24.md`](agent-findings/ui-018-019-hypothesis-recheck-2026-05-24.md) | UI Hypothesis Re-check 2026-05-24 — UI-018 + UI-019 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ux-scrutinizer-workflows-2026-05-24.md`](agent-findings/ux-scrutinizer-workflows-2026-05-24.md) | UX Scrutinizer — Workflow + Click Minimisation, 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/video-s3-chunked-encoding-2026-05-28.md`](agent-findings/video-s3-chunked-encoding-2026-05-28.md) | Video upload via S3FileStorage → Garage — chunked-encoding signature mismatch | 2026-05-28 | 2026-05-28 |
-| [`aidocs/data/107-cite-nanotom-shepard-substrate.md`](data/107-cite-nanotom-shepard-substrate.md) | aidocs/107 — CITE + Nanotom as shepard data-management substrate | 2026-05-24 | 2026-05-26 |
-| [`aidocs/data/108-mffd-dump-ingestion-plan.md`](data/108-mffd-dump-ingestion-plan.md) | MFFD Dump Ingestion Plan | 2026-05-26 | 2026-05-26 |
-| [`aidocs/data/35-hdf5-hsds-implementation-design.md`](data/35-hdf5-hsds-implementation-design.md) | HDF5 / HSDS Implementation Design (E7 → A5 series) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/46-payload-versioning-design.md`](data/46-payload-versioning-design.md) | Payload Versioning — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/78-cad-geometry-annotator.md`](data/78-cad-geometry-annotator.md) | aidocs/78 — 3D Geometry & FEM Annotator (`shepard-plugin-cad`) | 2026-05-23 | 2026-05-28 |
-| [`aidocs/data/79-cpacs-annotator.md`](data/79-cpacs-annotator.md) | aidocs/79 — CPACS Annotator (shepard-plugin-cpacs) | 2026-05-23 | 2026-05-28 |
-| [`aidocs/data/81-spatial-data-binding.md`](data/81-spatial-data-binding.md) | aidocs/81 — Spatial Data Binding: Linking Geometry to Measurements | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/82-spatial-perf-evaluation.md`](data/82-spatial-perf-evaluation.md) | Spatial-data performance evaluation (PostGIS reassessment) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/83-pointcloud-and-live-overlay.md`](data/83-pointcloud-and-live-overlay.md) | aidocs/83 — Point Cloud Integration and Live Overlay Modalities | 2026-05-26 | 2026-05-26 |
-| [`aidocs/data/84-live-digital-twin.md`](data/84-live-digital-twin.md) | aidocs/84 — Live Digital Twin: Moving Objects, Production Cell Scene, and State Streaming | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/85-coordinate-frame-tree.md`](data/85-coordinate-frame-tree.md) | aidocs/85 — Coordinate Frame Tree (CST1) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/86-scene-drive-and-replay.md`](data/86-scene-drive-and-replay.md) | aidocs/86 — Scene Drive, Data Linking, and Replay (DR1 series) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/89-stale-channel-admin-design.md`](data/89-stale-channel-admin-design.md) | 89 — Stale timeseries channel admin tool (ADMIN-STALE-CH) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/90-spatial-as-temporal-sweep.md`](data/90-spatial-as-temporal-sweep.md) | aidocs/90 — Spatial as temporal sweep (v6 SSOT) | 2026-05-24 | 2026-05-28 |
+| [`aidocs/agent-findings/ui-018-019-hypothesis-recheck-2026-05-24.md`](agent-findings/ui-018-019-hypothesis-recheck-2026-05-24.md) | UI Hypothesis Re-check 2026-05-24 — UI-018 + UI-019 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ux-scrutinizer-workflows-2026-05-24.md`](agent-findings/ux-scrutinizer-workflows-2026-05-24.md) | UX Scrutinizer — Workflow + Click Minimisation, 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/video-s3-chunked-encoding-2026-05-28.md`](agent-findings/video-s3-chunked-encoding-2026-05-28.md) | Video upload via S3FileStorage → Garage — chunked-encoding signature mismatch | 2026-05-28 | 2026-05-29 |
+| [`aidocs/data/107-cite-nanotom-shepard-substrate.md`](data/107-cite-nanotom-shepard-substrate.md) | aidocs/107 — CITE + Nanotom as shepard data-management substrate | 2026-05-24 | 2026-05-29 |
+| [`aidocs/data/108-mffd-dump-ingestion-plan.md`](data/108-mffd-dump-ingestion-plan.md) | MFFD Dump Ingestion Plan | 2026-05-26 | 2026-05-29 |
+| [`aidocs/data/35-hdf5-hsds-implementation-design.md`](data/35-hdf5-hsds-implementation-design.md) | HDF5 / HSDS Implementation Design (E7 → A5 series) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/46-payload-versioning-design.md`](data/46-payload-versioning-design.md) | Payload Versioning — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/78-cad-geometry-annotator.md`](data/78-cad-geometry-annotator.md) | aidocs/78 — 3D Geometry & FEM Annotator (`shepard-plugin-cad`) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/79-cpacs-annotator.md`](data/79-cpacs-annotator.md) | aidocs/79 — CPACS Annotator (shepard-plugin-cpacs) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/81-spatial-data-binding.md`](data/81-spatial-data-binding.md) | aidocs/81 — Spatial Data Binding: Linking Geometry to Measurements | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/82-spatial-perf-evaluation.md`](data/82-spatial-perf-evaluation.md) | Spatial-data performance evaluation (PostGIS reassessment) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/83-pointcloud-and-live-overlay.md`](data/83-pointcloud-and-live-overlay.md) | aidocs/83 — Point Cloud Integration and Live Overlay Modalities | 2026-05-26 | 2026-05-29 |
+| [`aidocs/data/84-live-digital-twin.md`](data/84-live-digital-twin.md) | aidocs/84 — Live Digital Twin: Moving Objects, Production Cell Scene, and State Streaming | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/85-coordinate-frame-tree.md`](data/85-coordinate-frame-tree.md) | aidocs/85 — Coordinate Frame Tree (CST1) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/86-scene-drive-and-replay.md`](data/86-scene-drive-and-replay.md) | aidocs/86 — Scene Drive, Data Linking, and Replay (DR1 series) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/89-stale-channel-admin-design.md`](data/89-stale-channel-admin-design.md) | 89 — Stale timeseries channel admin tool (ADMIN-STALE-CH) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/90-spatial-as-temporal-sweep.md`](data/90-spatial-as-temporal-sweep.md) | aidocs/90 — Spatial as temporal sweep (v6 SSOT) | 2026-05-24 | 2026-05-29 |
 | [`aidocs/data/PERM-INHERIT-MATRIX.md`](data/PERM-INHERIT-MATRIX.md) | PERM-INHERIT-MATRIX — entity → permission source | 2026-05-29 | 2026-05-29 |
-| [`aidocs/frontend/01-user-research-findings-2024.md`](frontend/01-user-research-findings-2024.md) | User research findings — 2024-06/07 interview round | 2026-05-23 | 2026-05-23 |
-| [`aidocs/frontend/100-cross-instance-prov-ui.md`](frontend/100-cross-instance-prov-ui.md) | 100 — Cross-instance provenance: client-side rendering design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/111-tpl17-distributed-ledger-anchoring.md`](integrations/111-tpl17-distributed-ledger-anchoring.md) | TPL17 — Distributed Ledger Anchoring for Tamper Evidence | 2026-05-26 | 2026-05-28 |
-| [`aidocs/integrations/113-urdf-viewer.md`](integrations/113-urdf-viewer.md) | 113 — URDF web viewer + animator (URDF-WEBVIEW-1) | 2026-05-28 | 2026-05-28 |
-| [`aidocs/integrations/114-process-monitoring-parser-plugin.md`](integrations/114-process-monitoring-parser-plugin.md) | 114 — Process-monitoring parser plugin family | 2026-05-28 | 2026-05-28 |
-| [`aidocs/integrations/115-otvis-tier2-frame-extraction.md`](integrations/115-otvis-tier2-frame-extraction.md) | 115 — OTvis tier-2 design | 2026-05-28 | 2026-05-28 |
+| [`aidocs/frontend/01-user-research-findings-2024.md`](frontend/01-user-research-findings-2024.md) | User research findings — 2024-06/07 interview round | 2026-05-23 | 2026-05-29 |
+| [`aidocs/frontend/100-cross-instance-prov-ui.md`](frontend/100-cross-instance-prov-ui.md) | 100 — Cross-instance provenance: client-side rendering design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/111-tpl17-distributed-ledger-anchoring.md`](integrations/111-tpl17-distributed-ledger-anchoring.md) | TPL17 — Distributed Ledger Anchoring for Tamper Evidence | 2026-05-26 | 2026-05-29 |
+| [`aidocs/integrations/113-urdf-viewer.md`](integrations/113-urdf-viewer.md) | 113 — URDF web viewer + animator (URDF-WEBVIEW-1) | 2026-05-28 | 2026-05-29 |
+| [`aidocs/integrations/114-process-monitoring-parser-plugin.md`](integrations/114-process-monitoring-parser-plugin.md) | 114 — Process-monitoring parser plugin family | 2026-05-28 | 2026-05-29 |
+| [`aidocs/integrations/115-otvis-tier2-frame-extraction.md`](integrations/115-otvis-tier2-frame-extraction.md) | 115 — OTvis tier-2 design | 2026-05-28 | 2026-05-29 |
 | [`aidocs/integrations/117-krl-interpreter.md`](integrations/117-krl-interpreter.md) | 117 — KRL interpreter (KRL-INTERPRETER-01) | 2026-05-29 | 2026-05-29 |
-| [`aidocs/integrations/66-hmc-kip-integration.md`](integrations/66-hmc-kip-integration.md) | 66 — HMC Kernel Information Profile integration | 2026-05-23 | 2026-05-28 |
-| [`aidocs/integrations/67-unhide-publish-plugin.md`](integrations/67-unhide-publish-plugin.md) | 67 — Unhide publish plugin (Helmholtz Knowledge Graph integration) | 2026-05-23 | 2026-05-26 |
-| [`aidocs/integrations/70-home-showcase-mqtt-design.md`](integrations/70-home-showcase-mqtt-design.md) | home-showcase — MQTT → shepard collector + demo (HOME1) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/72-invenio-publishing-plugin.md`](integrations/72-invenio-publishing-plugin.md) | aidocs/72 — InvenioRDM publishing plugin (`shepard-plugin-invenio`) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/77-databus-moss-federation.md`](integrations/77-databus-moss-federation.md) | aidocs/77 — Databus + MOSS federation layer for shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/80-rce-integration.md`](integrations/80-rce-integration.md) | aidocs/80 — RCE Integration: Data Distribution with Provenance Tracking (`shepard-plugin-rce`) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/81-jupyterhub-integration.md`](integrations/81-jupyterhub-integration.md) | 81 — JupyterHub Integration | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/82-confluence-import.md`](integrations/82-confluence-import.md) | 82 — Confluence Data Center Space Export → Shepard Import | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/83-rebar-airflow-integration.md`](integrations/83-rebar-airflow-integration.md) | 83 — ReBAR / Airflow Integration | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/84-process-orchestrator-plugin.md`](integrations/84-process-orchestrator-plugin.md) | 84 — shepard-plugin-process-orchestrator | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/92-mffd-real-data-import-strategy.md`](integrations/92-mffd-real-data-import-strategy.md) | 92 — MFFD real-data import strategy | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/95-shepard-plugin-importer-patterns-from-v15.md`](integrations/95-shepard-plugin-importer-patterns-from-v15.md) | 95 — shepard-plugin-importer: patterns from v15.x MFFD field experience | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/96-metrology-spatial-analyzer.md`](integrations/96-metrology-spatial-analyzer.md) | 96 — Metrology integration: Spatial Analyzer + Leica trackers as a Shepard payload kind | 2026-05-23 | 2026-05-23 |
-| [`aidocs/integrations/97-shepard-plugin-ai-design.md`](integrations/97-shepard-plugin-ai-design.md) | 97 — `shepard-plugin-ai` v6 SSOT — local-first AI capability | 2026-05-24 | 2026-05-26 |
+| [`aidocs/integrations/66-hmc-kip-integration.md`](integrations/66-hmc-kip-integration.md) | 66 — HMC Kernel Information Profile integration | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/67-unhide-publish-plugin.md`](integrations/67-unhide-publish-plugin.md) | 67 — Unhide publish plugin (Helmholtz Knowledge Graph integration) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/70-home-showcase-mqtt-design.md`](integrations/70-home-showcase-mqtt-design.md) | home-showcase — MQTT → shepard collector + demo (HOME1) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/72-invenio-publishing-plugin.md`](integrations/72-invenio-publishing-plugin.md) | aidocs/72 — InvenioRDM publishing plugin (`shepard-plugin-invenio`) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/77-databus-moss-federation.md`](integrations/77-databus-moss-federation.md) | aidocs/77 — Databus + MOSS federation layer for shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/80-rce-integration.md`](integrations/80-rce-integration.md) | aidocs/80 — RCE Integration: Data Distribution with Provenance Tracking (`shepard-plugin-rce`) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/81-jupyterhub-integration.md`](integrations/81-jupyterhub-integration.md) | 81 — JupyterHub Integration | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/82-confluence-import.md`](integrations/82-confluence-import.md) | 82 — Confluence Data Center Space Export → Shepard Import | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/83-rebar-airflow-integration.md`](integrations/83-rebar-airflow-integration.md) | 83 — ReBAR / Airflow Integration | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/84-process-orchestrator-plugin.md`](integrations/84-process-orchestrator-plugin.md) | 84 — shepard-plugin-process-orchestrator | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/92-mffd-real-data-import-strategy.md`](integrations/92-mffd-real-data-import-strategy.md) | 92 — MFFD real-data import strategy | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/95-shepard-plugin-importer-patterns-from-v15.md`](integrations/95-shepard-plugin-importer-patterns-from-v15.md) | 95 — shepard-plugin-importer: patterns from v15.x MFFD field experience | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/96-metrology-spatial-analyzer.md`](integrations/96-metrology-spatial-analyzer.md) | 96 — Metrology integration: Spatial Analyzer + Leica trackers as a Shepard payload kind | 2026-05-23 | 2026-05-29 |
+| [`aidocs/integrations/97-shepard-plugin-ai-design.md`](integrations/97-shepard-plugin-ai-design.md) | 97 — `shepard-plugin-ai` v6 SSOT — local-first AI capability | 2026-05-24 | 2026-05-29 |
 | [`aidocs/ops/88-helm-deployment.md`](ops/88-helm-deployment.md) | 88 — Helm chart for Kubernetes deployment | 2026-05-29 | 2026-05-29 |
-| [`aidocs/platform/103-v1-compat-plugin-extraction.md`](platform/103-v1-compat-plugin-extraction.md) | `shepard-plugin-v1-compat` — design for extracting the | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/103a-v1-compat-marker-plugin.md`](platform/103a-v1-compat-marker-plugin.md) | `shepard-plugin-v1-compat` — **Phase 1 marker plugin** design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/109-tpl6-network-shaped-data-organisation.md`](platform/109-tpl6-network-shaped-data-organisation.md) | 109 — TPL6: Network-shaped data organisation | 2026-05-26 | 2026-05-26 |
+| [`aidocs/platform/103-v1-compat-plugin-extraction.md`](platform/103-v1-compat-plugin-extraction.md) | `shepard-plugin-v1-compat` — design for extracting the | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/103a-v1-compat-marker-plugin.md`](platform/103a-v1-compat-marker-plugin.md) | `shepard-plugin-v1-compat` — **Phase 1 marker plugin** design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/109-tpl6-network-shaped-data-organisation.md`](platform/109-tpl6-network-shaped-data-organisation.md) | 109 — TPL6: Network-shaped data organisation | 2026-05-26 | 2026-05-29 |
 | [`aidocs/platform/24-permission-system-review.md`](platform/24-permission-system-review.md) | 24 — Permission-System Review | 2026-05-29 | 2026-05-29 |
-| [`aidocs/platform/30-mcp-plugin-design.md`](platform/30-mcp-plugin-design.md) | 30 — shepard-plugin-mcp: Full-Parity MCP Endpoint | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/51-instance-admin-role.md`](platform/51-instance-admin-role.md) | Instance-Admin Role — Design (A0 + C3 + F8) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/63-architecture-decision-log.md`](platform/63-architecture-decision-log.md) | 63 — Architecture Decision Log | 2026-05-23 | 2026-05-28 |
-| [`aidocs/platform/69-runtime-plugin-cdi.md`](platform/69-runtime-plugin-cdi.md) | 69 — Runtime plugin CDI integration (deferred PM1b3) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/71-collection-watches-design.md`](platform/71-collection-watches-design.md) | Collection `:watches` Container — Design (WATCH1) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/83-tpl1-tpl2-shapes-templates-views.md`](platform/83-tpl1-tpl2-shapes-templates-views.md) | TPL1+TPL2: Shapes as Templates + Views — M1 milestone tracker | 2026-05-26 | 2026-05-26 |
-| [`aidocs/platform/88-quarkus-mcp-server-migration.md`](platform/88-quarkus-mcp-server-migration.md) | 88 — Native Quarkus MCP Server: Replacing the Python Sidecar | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/89-tpl9-fair2r-ai-provenance.md`](platform/89-tpl9-fair2r-ai-provenance.md) | TPL9 — f(ai)²r AI provenance capture (PROV-O extension for AI transparency) | 2026-05-26 | 2026-05-26 |
-| [`aidocs/platform/91-appid-uri-scheme.md`](platform/91-appid-uri-scheme.md) | 91 — appId URI Scheme: HTTPS Persistent Identifiers | 2026-05-23 | 2026-05-23 |
-| [`aidocs/semantics/100-consistent-semantic-annotation-design.md`](semantics/100-consistent-semantic-annotation-design.md) | 100 — Consistent semantic annotation surface (UI-first + MCP CRUD) | 2026-05-24 | 2026-05-26 |
-| [`aidocs/semantics/101-canonical-iris.md`](semantics/101-canonical-iris.md) | 101 — Canonical IRI namespaces for Shepard semantic documents | 2026-05-27 | 2026-05-27 |
-| [`aidocs/semantics/65-admin-configurable-ontology-preseed.md`](semantics/65-admin-configurable-ontology-preseed.md) | 65 — Admin-configurable ontology pre-seeding (with custom-bundle support) | 2026-05-23 | 2026-05-28 |
-| [`aidocs/semantics/94-metadata4ing-integration-design.md`](semantics/94-metadata4ing-integration-design.md) | 94 — Deepening metadata4ing (m4i) integration into Shepard's semantic graph | 2026-05-23 | 2026-05-28 |
-| [`aidocs/semantics/96-upper-ontology-alignment.md`](semantics/96-upper-ontology-alignment.md) | 96 — Upper-ontology alignment (BFO 2020 + IOF Core + IAO + PROV-O) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/semantics/97-tpl3-upper-ontology-bootstrap.md`](semantics/97-tpl3-upper-ontology-bootstrap.md) | 97 — TPL3 — Upper-ontology bootstrap migration + starter kit | 2026-05-26 | 2026-05-26 |
-| [`aidocs/semantics/fair4ml-fair4ai-fai2r-2026-05-23.md`](semantics/fair4ml-fair4ai-fai2r-2026-05-23.md) | FAIR4ML × FAIR for AI × f(ai)²r — comparative survey + alignment plan | 2026-05-23 | 2026-05-26 |
-| [`aidocs/strategy/100-shepard-bt-zlp-rollout-plan.md`](strategy/100-shepard-bt-zlp-rollout-plan.md) | Shepard rollout plan — BT / ZLP Augsburg cells | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/102-institute-youtube-profile.md`](strategy/102-institute-youtube-profile.md) | 102 — DLR Institute of Structures and Design: YouTube channel as vision + use-case source | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/102-thesis-timeline-of-ideas.md`](strategy/102-thesis-timeline-of-ideas.md) | Timeline of ideas across Shepard's intellectual trajectory | 2026-05-23 | 2026-05-27 |
-| [`aidocs/strategy/103-research-network.md`](strategy/103-research-network.md) | Shepard research network — DLR eLib + external-peer reconstruction | 2026-05-26 | 2026-05-26 |
-| [`aidocs/strategy/104-author-research-profile.md`](strategy/104-author-research-profile.md) | Author research profile — Florian Krebs, DLR ZLP Augsburg | 2026-05-23 | 2026-05-26 |
-| [`aidocs/strategy/105-postgres-multitenant-decision.md`](strategy/105-postgres-multitenant-decision.md) | aidocs/105 — POSTGRES-MULTITENANT decision: one PG, N schemas, ACCEPTED | 2026-05-24 | 2026-05-24 |
-| [`aidocs/strategy/106-shepard-industrial-ai-role.md`](strategy/106-shepard-industrial-ai-role.md) | 106 — Shepard's Role in the Industrial-AI Value Chain | 2026-05-24 | 2026-05-26 |
-| [`aidocs/strategy/87-dlr-zlp-positioning.md`](strategy/87-dlr-zlp-positioning.md) | DLR ZLP Augsburg — institutional positioning and the substrate Shepard serves | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/88-nfdi4ing-alignment.md`](strategy/88-nfdi4ing-alignment.md) | 88 — NFDI4Ing alignment: positioning Shepard inside the German engineering RDM federation | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/89-genai-methodology-and-reflexivity.md`](strategy/89-genai-methodology-and-reflexivity.md) | Generative AI as research method — Krebs's stated position and this project's observed practice | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/90-hmc-phase-2-positioning.md`](strategy/90-hmc-phase-2-positioning.md) | 90 — HMC Phase 2 positioning: Shepard's pre-committed work-packages at DLR ZLP | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/91-forinfpro-semantically-driven-analytics.md`](strategy/91-forinfpro-semantically-driven-analytics.md) | ForInfPro and the semantically-driven analytics use case | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/92-aerospace-x-regulatory-context.md`](strategy/92-aerospace-x-regulatory-context.md) | 92 — Aerospace-X and the aerospace regulatory context | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/93-management-context-and-compliance.md`](strategy/93-management-context-and-compliance.md) | Shepard inside the DLR management context — institutional stack, governance frame, compliance gates | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/94-federation-and-dataspaces.md`](strategy/94-federation-and-dataspaces.md) | 94 — Federation and dataspaces: where Shepard sits in Manufacturing-X / Aerospace-X / Catena-X | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/ai-fork-production-readiness-2026-05-23.md`](strategy/ai-fork-production-readiness-2026-05-23.md) | Is the AI-collaborative `noheton/shepard` fork production-ready? | 2026-05-23 | 2026-05-23 |
-| [`aidocs/strategy/requirements-alignment-damast-ux-mffd-2026-05-23.md`](strategy/requirements-alignment-damast-ux-mffd-2026-05-23.md) | Requirements alignment — DaMaST workshop × UX 5-phase journey × MFFD-focused gap analysis | 2026-05-23 | 2026-05-28 |
-| [`aidocs/sustainability/00-energy-estimation-log.md`](sustainability/00-energy-estimation-log.md) | 00 — Energy + CO₂ estimation log per commit | 2026-05-23 | 2026-05-26 |
-| [`aidocs/sustainability/01-methodology.md`](sustainability/01-methodology.md) | 01 — Energy / CO₂ estimation methodology | 2026-05-23 | 2026-05-27 |
-| [`aidocs/ux/73-personal-landing-page.md`](ux/73-personal-landing-page.md) | 73 — Personal Landing Page | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ux/74-auto-refresh-stale-session.md`](ux/74-auto-refresh-stale-session.md) | 74 — Auto-Refresh on Stale Session | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ux/76-uplot-timeseries-chart.md`](ux/76-uplot-timeseries-chart.md) | 76 — uPlot Timeseries Chart | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ux/78-containerless-basic-mode.md`](ux/78-containerless-basic-mode.md) | 78 — Container-hiding Basic Mode | 2026-05-23 | 2026-05-23 |
+| [`aidocs/platform/30-mcp-plugin-design.md`](platform/30-mcp-plugin-design.md) | 30 — shepard-plugin-mcp: Full-Parity MCP Endpoint | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/51-instance-admin-role.md`](platform/51-instance-admin-role.md) | Instance-Admin Role — Design (A0 + C3 + F8) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/63-architecture-decision-log.md`](platform/63-architecture-decision-log.md) | 63 — Architecture Decision Log | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/69-runtime-plugin-cdi.md`](platform/69-runtime-plugin-cdi.md) | 69 — Runtime plugin CDI integration (deferred PM1b3) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/71-collection-watches-design.md`](platform/71-collection-watches-design.md) | Collection `:watches` Container — Design (WATCH1) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/83-tpl1-tpl2-shapes-templates-views.md`](platform/83-tpl1-tpl2-shapes-templates-views.md) | TPL1+TPL2: Shapes as Templates + Views — M1 milestone tracker | 2026-05-26 | 2026-05-29 |
+| [`aidocs/platform/88-quarkus-mcp-server-migration.md`](platform/88-quarkus-mcp-server-migration.md) | 88 — Native Quarkus MCP Server: Replacing the Python Sidecar | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/89-tpl9-fair2r-ai-provenance.md`](platform/89-tpl9-fair2r-ai-provenance.md) | TPL9 — f(ai)²r AI provenance capture (PROV-O extension for AI transparency) | 2026-05-26 | 2026-05-29 |
+| [`aidocs/platform/91-appid-uri-scheme.md`](platform/91-appid-uri-scheme.md) | 91 — appId URI Scheme: HTTPS Persistent Identifiers | 2026-05-23 | 2026-05-29 |
+| [`aidocs/semantics/100-consistent-semantic-annotation-design.md`](semantics/100-consistent-semantic-annotation-design.md) | 100 — Consistent semantic annotation surface (UI-first + MCP CRUD) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/semantics/101-canonical-iris.md`](semantics/101-canonical-iris.md) | 101 — Canonical IRI namespaces for Shepard semantic documents | 2026-05-27 | 2026-05-29 |
+| [`aidocs/semantics/65-admin-configurable-ontology-preseed.md`](semantics/65-admin-configurable-ontology-preseed.md) | 65 — Admin-configurable ontology pre-seeding (with custom-bundle support) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/semantics/94-metadata4ing-integration-design.md`](semantics/94-metadata4ing-integration-design.md) | 94 — Deepening metadata4ing (m4i) integration into Shepard's semantic graph | 2026-05-23 | 2026-05-29 |
+| [`aidocs/semantics/96-upper-ontology-alignment.md`](semantics/96-upper-ontology-alignment.md) | 96 — Upper-ontology alignment (BFO 2020 + IOF Core + IAO + PROV-O) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/semantics/97-tpl3-upper-ontology-bootstrap.md`](semantics/97-tpl3-upper-ontology-bootstrap.md) | 97 — TPL3 — Upper-ontology bootstrap migration + starter kit | 2026-05-26 | 2026-05-29 |
+| [`aidocs/semantics/fair4ml-fair4ai-fai2r-2026-05-23.md`](semantics/fair4ml-fair4ai-fai2r-2026-05-23.md) | FAIR4ML × FAIR for AI × f(ai)²r — comparative survey + alignment plan | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/100-shepard-bt-zlp-rollout-plan.md`](strategy/100-shepard-bt-zlp-rollout-plan.md) | Shepard rollout plan — BT / ZLP Augsburg cells | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/102-institute-youtube-profile.md`](strategy/102-institute-youtube-profile.md) | 102 — DLR Institute of Structures and Design: YouTube channel as vision + use-case source | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/102-thesis-timeline-of-ideas.md`](strategy/102-thesis-timeline-of-ideas.md) | Timeline of ideas across Shepard's intellectual trajectory | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/103-research-network.md`](strategy/103-research-network.md) | Shepard research network — DLR eLib + external-peer reconstruction | 2026-05-26 | 2026-05-29 |
+| [`aidocs/strategy/104-author-research-profile.md`](strategy/104-author-research-profile.md) | Author research profile — Florian Krebs, DLR ZLP Augsburg | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/105-postgres-multitenant-decision.md`](strategy/105-postgres-multitenant-decision.md) | aidocs/105 — POSTGRES-MULTITENANT decision: one PG, N schemas, ACCEPTED | 2026-05-24 | 2026-05-29 |
+| [`aidocs/strategy/106-shepard-industrial-ai-role.md`](strategy/106-shepard-industrial-ai-role.md) | 106 — Shepard's Role in the Industrial-AI Value Chain | 2026-05-24 | 2026-05-29 |
+| [`aidocs/strategy/87-dlr-zlp-positioning.md`](strategy/87-dlr-zlp-positioning.md) | DLR ZLP Augsburg — institutional positioning and the substrate Shepard serves | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/88-nfdi4ing-alignment.md`](strategy/88-nfdi4ing-alignment.md) | 88 — NFDI4Ing alignment: positioning Shepard inside the German engineering RDM federation | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/89-genai-methodology-and-reflexivity.md`](strategy/89-genai-methodology-and-reflexivity.md) | Generative AI as research method — Krebs's stated position and this project's observed practice | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/90-hmc-phase-2-positioning.md`](strategy/90-hmc-phase-2-positioning.md) | 90 — HMC Phase 2 positioning: Shepard's pre-committed work-packages at DLR ZLP | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/91-forinfpro-semantically-driven-analytics.md`](strategy/91-forinfpro-semantically-driven-analytics.md) | ForInfPro and the semantically-driven analytics use case | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/92-aerospace-x-regulatory-context.md`](strategy/92-aerospace-x-regulatory-context.md) | 92 — Aerospace-X and the aerospace regulatory context | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/93-management-context-and-compliance.md`](strategy/93-management-context-and-compliance.md) | Shepard inside the DLR management context — institutional stack, governance frame, compliance gates | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/94-federation-and-dataspaces.md`](strategy/94-federation-and-dataspaces.md) | 94 — Federation and dataspaces: where Shepard sits in Manufacturing-X / Aerospace-X / Catena-X | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/ai-fork-production-readiness-2026-05-23.md`](strategy/ai-fork-production-readiness-2026-05-23.md) | Is the AI-collaborative `noheton/shepard` fork production-ready? | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/requirements-alignment-damast-ux-mffd-2026-05-23.md`](strategy/requirements-alignment-damast-ux-mffd-2026-05-23.md) | Requirements alignment — DaMaST workshop × UX 5-phase journey × MFFD-focused gap analysis | 2026-05-23 | 2026-05-29 |
+| [`aidocs/sustainability/00-energy-estimation-log.md`](sustainability/00-energy-estimation-log.md) | 00 — Energy + CO₂ estimation log per commit | 2026-05-23 | 2026-05-29 |
+| [`aidocs/sustainability/01-methodology.md`](sustainability/01-methodology.md) | 01 — Energy / CO₂ estimation methodology | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ux/73-personal-landing-page.md`](ux/73-personal-landing-page.md) | 73 — Personal Landing Page | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ux/74-auto-refresh-stale-session.md`](ux/74-auto-refresh-stale-session.md) | 74 — Auto-Refresh on Stale Session | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ux/76-uplot-timeseries-chart.md`](ux/76-uplot-timeseries-chart.md) | 76 — uPlot Timeseries Chart | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ux/78-containerless-basic-mode.md`](ux/78-containerless-basic-mode.md) | 78 — Container-hiding Basic Mode | 2026-05-23 | 2026-05-29 |
 
 ## audited-by-personas (74)
 
 | doc | title | last-stage-change | last-touched |
 |---|---|---|---|
-| [`aidocs/agent-findings/161-aidocs-ssot-audit.md`](agent-findings/161-aidocs-ssot-audit.md) | 161 — aidocs SSOT consolidation sweep | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/ai-ontology-mapping-survey-2026-05-23.md`](agent-findings/ai-ontology-mapping-survey-2026-05-23.md) | AI-assisted ontology mapping — research survey + adoption recommendation | 2026-05-23 | 2026-05-27 |
-| [`aidocs/agent-findings/aidocs-consolidation-survey.md`](agent-findings/aidocs-consolidation-survey.md) | aidocs consolidation survey — single source of truth enforcement | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/analytics-ai.md`](agent-findings/analytics-ai.md) | Applied ML & Data Science — Shepard Platform Findings | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/api-annoyances.md`](agent-findings/api-annoyances.md) | API annoyances — running log | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/api-scrutinizer-v14-import.md`](agent-findings/api-scrutinizer-v14-import.md) | API Scrutinizer — v14 → v15 import-script review | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/api-scrutinizer.md`](agent-findings/api-scrutinizer.md) | API Scrutinizer — Shepard /v2/ Findings | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/backend-logs-sift-2026-05-24.md`](agent-findings/backend-logs-sift-2026-05-24.md) | Backend logs sift — 2026-05-24 ~06:00 CEST | 2026-05-24 | 2026-05-26 |
-| [`aidocs/agent-findings/competitive-reassessment-2026-05-24.md`](agent-findings/competitive-reassessment-2026-05-24.md) | Competitive reassessment — post-V6-trinity verdict shift (2026-05-24) | 2026-05-24 | 2026-05-26 |
-| [`aidocs/agent-findings/data-ontologist-prov-o-v15.md`](agent-findings/data-ontologist-prov-o-v15.md) | PROV-O fragment design for v15 MFFD batch import | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/data-ontologist.md`](agent-findings/data-ontologist.md) | Data Ontologist — Discovery Findings | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/db-schema-recommendations.md`](agent-findings/db-schema-recommendations.md) | DB Schema Recommendations — Live Shepard Instance Audit | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/dlr-bt-simulation-cluster-toso-2026-05-24.md`](agent-findings/dlr-bt-simulation-cluster-toso-2026-05-24.md) | DLR-BT simulation cluster — "unsere Simulanten" | 2026-05-24 | 2026-05-26 |
-| [`aidocs/agent-findings/dlr-ontology-catalog.md`](agent-findings/dlr-ontology-catalog.md) | DLR Ontology & Model Initiative Catalogue | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/docs-pages-refresh.md`](agent-findings/docs-pages-refresh.md) | GH Pages docs refresh — pre-push survey + fix log | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/easa-ai-regulatory-positioning.md`](agent-findings/easa-ai-regulatory-positioning.md) | EASA AI Regulatory Positioning for Shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/easa-data-management-learning-assurance.md`](agent-findings/easa-data-management-learning-assurance.md) | EASA Data Management + Learning Assurance — deep dive (Shepard scope) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/ecosystem-advocate.md`](agent-findings/ecosystem-advocate.md) | Ecosystem Advocate — Findings | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/ecosystem-tools.md`](agent-findings/ecosystem-tools.md) | Ecosystem Tools — Findings | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/elib-bt-project-sweep-2026-05-24.md`](agent-findings/elib-bt-project-sweep-2026-05-24.md) | eLib BT-project sweep + 5 user-flagged papers — Braunschweig / Stuttgart / Augsburg deep-dive | 2026-05-24 | 2026-05-26 |
-| [`aidocs/agent-findings/eu-machinery-regulation-2023-1230.md`](agent-findings/eu-machinery-regulation-2023-1230.md) | EU Machinery Regulation 2023/1230 — Shepard implications | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/garage-activation-runbook.md`](agent-findings/garage-activation-runbook.md) | Garage activation runbook — findings & gotchas | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/gh-lean-traceability-consult-2026-05-23.md`](agent-findings/gh-lean-traceability-consult-2026-05-23.md) | gh-lean-traceability-consult — 2026-05-23 | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/manufacturing-quality.md`](agent-findings/manufacturing-quality.md) | Manufacturing Quality Readiness Assessment | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/mffd-cleanup-2026-05-22.md`](agent-findings/mffd-cleanup-2026-05-22.md) | MFFD-Dropbox (collection 515365) cleanup — 2026-05-22 | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/mffd-process-chain-gap-analysis.md`](agent-findings/mffd-process-chain-gap-analysis.md) | MFFD Synthetic Seed — Process Chain Gap Analysis | 2026-05-26 | 2026-05-27 |
-| [`aidocs/agent-findings/ogm-hydration-audit-2026-05-24.md`](agent-findings/ogm-hydration-audit-2026-05-24.md) | OGM-HYDRATION-AUDIT — v2 DAO sweep (2026-05-24) | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ogm-hydration-service-layer-2026-05-27.md`](agent-findings/ogm-hydration-service-layer-2026-05-27.md) | OGM-HYDRATE-2026-05-24-004 — Service-layer composite-call hydration audit (2026-05-27) | 2026-05-27 | 2026-05-27 |
-| [`aidocs/agent-findings/persona-api-scrutinizer-gh-pm-2026-05-23.md`](agent-findings/persona-api-scrutinizer-gh-pm-2026-05-23.md) | Persona — API Scrutinizer (Minimalist) — GH-PM adoption review | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/persona-audit-logstore-2026-05-23.md`](agent-findings/persona-audit-logstore-2026-05-23.md) | Persona audit — log-store-sidecar design (`aidocs/integrations/94`) | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/persona-audit-ontology-mapping-2026-05-23.md`](agent-findings/persona-audit-ontology-mapping-2026-05-23.md) | Persona audit — AI-assisted ontology mapping survey (round 1) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-audit-promptlog-2026-05-23.md`](agent-findings/persona-audit-promptlog-2026-05-23.md) | Persona audit — PromptLog design (aidocs/semantics/99) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-audit-views-as-shapes-2026-05-23.md`](agent-findings/persona-audit-views-as-shapes-2026-05-23.md) | Persona audit — views-as-shapes design (docs 95 + 98) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-digital-native-2026-05-24.md`](agent-findings/persona-digital-native-2026-05-24.md) | Persona: Digital Native Researcher — re-walk on live (2026-05-24) | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/persona-manufacturing-quality-2026-05-24.md`](agent-findings/persona-manufacturing-quality-2026-05-24.md) | Persona audit — Industrial Manufacturing & Quality Engineer (live, 2026-05-24) | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/persona-rdm-gh-pm-2026-05-23.md`](agent-findings/persona-rdm-gh-pm-2026-05-23.md) | Persona review — Research Data Manager / FAIR Steward | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-reluctant-senior-2026-05-24.md`](agent-findings/persona-reluctant-senior-2026-05-24.md) | Reluctant Senior Researcher — re-walk on live, 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/persona-reluctant-senior-gh-pm-2026-05-23.md`](agent-findings/persona-reluctant-senior-gh-pm-2026-05-23.md) | Reluctant Senior Researcher — audit of `aidocs/strategy/85` | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/persona-review-ai-opportunities.md`](agent-findings/persona-review-ai-opportunities.md) | Persona Review — Analytics & AI Opportunities Specialist | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-review-api-scrutinizer.md`](agent-findings/persona-review-api-scrutinizer.md) | API Scrutinizer — review of the `/v2/views` + view-shapes proposal | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-review-digital-native.md`](agent-findings/persona-review-digital-native.md) | Persona Review: Digital Native Researcher (2026-05-22) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-review-ime-aqe.md`](agent-findings/persona-review-ime-aqe.md) | Persona review — Industrial Manufacturing & Quality Engineer (IME/AQE) on the SHACL trio | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-review-ontologist.md`](agent-findings/persona-review-ontologist.md) | Persona review — Data & Process Ontologist on the SHACL trio | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-review-rdm.md`](agent-findings/persona-review-rdm.md) | Persona review — Research Data Manager (FAIR Steward) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-review-reluctant-senior.md`](agent-findings/persona-review-reluctant-senior.md) | Reluctant Senior Researcher — review of the MFFD shapes / views / SPI proposals | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/persona-strategy-aligner-gh-pm-2026-05-23.md`](agent-findings/persona-strategy-aligner-gh-pm-2026-05-23.md) | Persona — Strategy Aligner & Executive Advisor on GH-PM adoption (2026-05-23) | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/repo-task-sweep-2026-05-23.md`](agent-findings/repo-task-sweep-2026-05-23.md) | Repo task sweep — 2026-05-23 | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/research-data-manager.md`](agent-findings/research-data-manager.md) | Shepard FAIR Compliance Evaluation | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/shacl-changeover-non-ts.md`](agent-findings/shacl-changeover-non-ts.md) | SHACL changeover (non-TS scope) — implementation log | 2026-05-23 | 2026-05-26 |
-| [`aidocs/agent-findings/sidecars-spi-extension.md`](agent-findings/sidecars-spi-extension.md) | PM1f — `PluginManifest.sidecars()` SPI extension + file-s3 Garage declaration | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/strategy-advisor.md`](agent-findings/strategy-advisor.md) | Shepard — Strategic Advisor Findings | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/test-cleanup-2026-05-22.md`](agent-findings/test-cleanup-2026-05-22.md) | Backend test cleanup — 2026-05-22 | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/trace3d-spike.md`](agent-findings/trace3d-spike.md) | Trace3D view — spike: library shortlist + view-shape input contract | 2026-05-23 | 2026-05-23 |
+| [`aidocs/agent-findings/161-aidocs-ssot-audit.md`](agent-findings/161-aidocs-ssot-audit.md) | 161 — aidocs SSOT consolidation sweep | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/ai-ontology-mapping-survey-2026-05-23.md`](agent-findings/ai-ontology-mapping-survey-2026-05-23.md) | AI-assisted ontology mapping — research survey + adoption recommendation | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/aidocs-consolidation-survey.md`](agent-findings/aidocs-consolidation-survey.md) | aidocs consolidation survey — single source of truth enforcement | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/analytics-ai.md`](agent-findings/analytics-ai.md) | Applied ML & Data Science — Shepard Platform Findings | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/api-annoyances.md`](agent-findings/api-annoyances.md) | API annoyances — running log | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/api-scrutinizer-v14-import.md`](agent-findings/api-scrutinizer-v14-import.md) | API Scrutinizer — v14 → v15 import-script review | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/api-scrutinizer.md`](agent-findings/api-scrutinizer.md) | API Scrutinizer — Shepard /v2/ Findings | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/backend-logs-sift-2026-05-24.md`](agent-findings/backend-logs-sift-2026-05-24.md) | Backend logs sift — 2026-05-24 ~06:00 CEST | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/competitive-reassessment-2026-05-24.md`](agent-findings/competitive-reassessment-2026-05-24.md) | Competitive reassessment — post-V6-trinity verdict shift (2026-05-24) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/data-ontologist-prov-o-v15.md`](agent-findings/data-ontologist-prov-o-v15.md) | PROV-O fragment design for v15 MFFD batch import | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/data-ontologist.md`](agent-findings/data-ontologist.md) | Data Ontologist — Discovery Findings | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/db-schema-recommendations.md`](agent-findings/db-schema-recommendations.md) | DB Schema Recommendations — Live Shepard Instance Audit | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/dlr-bt-simulation-cluster-toso-2026-05-24.md`](agent-findings/dlr-bt-simulation-cluster-toso-2026-05-24.md) | DLR-BT simulation cluster — "unsere Simulanten" | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/dlr-ontology-catalog.md`](agent-findings/dlr-ontology-catalog.md) | DLR Ontology & Model Initiative Catalogue | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/docs-pages-refresh.md`](agent-findings/docs-pages-refresh.md) | GH Pages docs refresh — pre-push survey + fix log | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/easa-ai-regulatory-positioning.md`](agent-findings/easa-ai-regulatory-positioning.md) | EASA AI Regulatory Positioning for Shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/easa-data-management-learning-assurance.md`](agent-findings/easa-data-management-learning-assurance.md) | EASA Data Management + Learning Assurance — deep dive (Shepard scope) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/ecosystem-advocate.md`](agent-findings/ecosystem-advocate.md) | Ecosystem Advocate — Findings | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/ecosystem-tools.md`](agent-findings/ecosystem-tools.md) | Ecosystem Tools — Findings | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/elib-bt-project-sweep-2026-05-24.md`](agent-findings/elib-bt-project-sweep-2026-05-24.md) | eLib BT-project sweep + 5 user-flagged papers — Braunschweig / Stuttgart / Augsburg deep-dive | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/eu-machinery-regulation-2023-1230.md`](agent-findings/eu-machinery-regulation-2023-1230.md) | EU Machinery Regulation 2023/1230 — Shepard implications | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/garage-activation-runbook.md`](agent-findings/garage-activation-runbook.md) | Garage activation runbook — findings & gotchas | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/gh-lean-traceability-consult-2026-05-23.md`](agent-findings/gh-lean-traceability-consult-2026-05-23.md) | gh-lean-traceability-consult — 2026-05-23 | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/manufacturing-quality.md`](agent-findings/manufacturing-quality.md) | Manufacturing Quality Readiness Assessment | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/mffd-cleanup-2026-05-22.md`](agent-findings/mffd-cleanup-2026-05-22.md) | MFFD-Dropbox (collection 515365) cleanup — 2026-05-22 | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/mffd-process-chain-gap-analysis.md`](agent-findings/mffd-process-chain-gap-analysis.md) | MFFD Synthetic Seed — Process Chain Gap Analysis | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/ogm-hydration-audit-2026-05-24.md`](agent-findings/ogm-hydration-audit-2026-05-24.md) | OGM-HYDRATION-AUDIT — v2 DAO sweep (2026-05-24) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ogm-hydration-service-layer-2026-05-27.md`](agent-findings/ogm-hydration-service-layer-2026-05-27.md) | OGM-HYDRATE-2026-05-24-004 — Service-layer composite-call hydration audit (2026-05-27) | 2026-05-27 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-api-scrutinizer-gh-pm-2026-05-23.md`](agent-findings/persona-api-scrutinizer-gh-pm-2026-05-23.md) | Persona — API Scrutinizer (Minimalist) — GH-PM adoption review | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-audit-logstore-2026-05-23.md`](agent-findings/persona-audit-logstore-2026-05-23.md) | Persona audit — log-store-sidecar design (`aidocs/integrations/94`) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-audit-ontology-mapping-2026-05-23.md`](agent-findings/persona-audit-ontology-mapping-2026-05-23.md) | Persona audit — AI-assisted ontology mapping survey (round 1) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-audit-promptlog-2026-05-23.md`](agent-findings/persona-audit-promptlog-2026-05-23.md) | Persona audit — PromptLog design (aidocs/semantics/99) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-audit-views-as-shapes-2026-05-23.md`](agent-findings/persona-audit-views-as-shapes-2026-05-23.md) | Persona audit — views-as-shapes design (docs 95 + 98) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-digital-native-2026-05-24.md`](agent-findings/persona-digital-native-2026-05-24.md) | Persona: Digital Native Researcher — re-walk on live (2026-05-24) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-manufacturing-quality-2026-05-24.md`](agent-findings/persona-manufacturing-quality-2026-05-24.md) | Persona audit — Industrial Manufacturing & Quality Engineer (live, 2026-05-24) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-rdm-gh-pm-2026-05-23.md`](agent-findings/persona-rdm-gh-pm-2026-05-23.md) | Persona review — Research Data Manager / FAIR Steward | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-reluctant-senior-2026-05-24.md`](agent-findings/persona-reluctant-senior-2026-05-24.md) | Reluctant Senior Researcher — re-walk on live, 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-reluctant-senior-gh-pm-2026-05-23.md`](agent-findings/persona-reluctant-senior-gh-pm-2026-05-23.md) | Reluctant Senior Researcher — audit of `aidocs/strategy/85` | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-review-ai-opportunities.md`](agent-findings/persona-review-ai-opportunities.md) | Persona Review — Analytics & AI Opportunities Specialist | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-review-api-scrutinizer.md`](agent-findings/persona-review-api-scrutinizer.md) | API Scrutinizer — review of the `/v2/views` + view-shapes proposal | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-review-digital-native.md`](agent-findings/persona-review-digital-native.md) | Persona Review: Digital Native Researcher (2026-05-22) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-review-ime-aqe.md`](agent-findings/persona-review-ime-aqe.md) | Persona review — Industrial Manufacturing & Quality Engineer (IME/AQE) on the SHACL trio | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-review-ontologist.md`](agent-findings/persona-review-ontologist.md) | Persona review — Data & Process Ontologist on the SHACL trio | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-review-rdm.md`](agent-findings/persona-review-rdm.md) | Persona review — Research Data Manager (FAIR Steward) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-review-reluctant-senior.md`](agent-findings/persona-review-reluctant-senior.md) | Reluctant Senior Researcher — review of the MFFD shapes / views / SPI proposals | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-strategy-aligner-gh-pm-2026-05-23.md`](agent-findings/persona-strategy-aligner-gh-pm-2026-05-23.md) | Persona — Strategy Aligner & Executive Advisor on GH-PM adoption (2026-05-23) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/repo-task-sweep-2026-05-23.md`](agent-findings/repo-task-sweep-2026-05-23.md) | Repo task sweep — 2026-05-23 | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/research-data-manager.md`](agent-findings/research-data-manager.md) | Shepard FAIR Compliance Evaluation | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/shacl-changeover-non-ts.md`](agent-findings/shacl-changeover-non-ts.md) | SHACL changeover (non-TS scope) — implementation log | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/sidecars-spi-extension.md`](agent-findings/sidecars-spi-extension.md) | PM1f — `PluginManifest.sidecars()` SPI extension + file-s3 Garage declaration | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/strategy-advisor.md`](agent-findings/strategy-advisor.md) | Shepard — Strategic Advisor Findings | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/test-cleanup-2026-05-22.md`](agent-findings/test-cleanup-2026-05-22.md) | Backend test cleanup — 2026-05-22 | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/trace3d-spike.md`](agent-findings/trace3d-spike.md) | Trace3D view — spike: library shortlist + view-shape input contract | 2026-05-23 | 2026-05-29 |
 | [`aidocs/agent-findings/ui-annoyances.md`](agent-findings/ui-annoyances.md) | UI annoyances — running log | 2026-05-23 | 2026-05-29 |
-| [`aidocs/agent-findings/ui-scrutinizer-2026-05-24.md`](agent-findings/ui-scrutinizer-2026-05-24.md) | UI Scrutinizer — live-shepard systematic walk, 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ux-auditor.md`](agent-findings/ux-auditor.md) | UX Auditor — Discovery Report | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/ux-progress-indicators-sweep.md`](agent-findings/ux-progress-indicators-sweep.md) | UX progress indicators — Playwright-driven sweep (task #136) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/ux-survey-collections-containers-2026-05-24.md`](agent-findings/ux-survey-collections-containers-2026-05-24.md) | UX survey — collections + containers pages (barely-usable triage) | 2026-05-24 | 2026-05-24 |
+| [`aidocs/agent-findings/ui-scrutinizer-2026-05-24.md`](agent-findings/ui-scrutinizer-2026-05-24.md) | UI Scrutinizer — live-shepard systematic walk, 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ux-auditor.md`](agent-findings/ux-auditor.md) | UX Auditor — Discovery Report | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/ux-progress-indicators-sweep.md`](agent-findings/ux-progress-indicators-sweep.md) | UX progress indicators — Playwright-driven sweep (task #136) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/ux-survey-collections-containers-2026-05-24.md`](agent-findings/ux-survey-collections-containers-2026-05-24.md) | UX survey — collections + containers pages (barely-usable triage) | 2026-05-24 | 2026-05-29 |
 | [`aidocs/agent-findings/ux-walk-2026-05-29.md`](agent-findings/ux-walk-2026-05-29.md) | UX Walk 2026-05-29 — Live 4K regression sweep | 2026-05-29 | 2026-05-29 |
-| [`aidocs/agent-findings/v15-import-implementation.md`](agent-findings/v15-import-implementation.md) | v15 MFFD-import — implementation report | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/v15-review-data-ontologist.md`](agent-findings/v15-review-data-ontologist.md) | v15 review — Data & Process Ontologist lens | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/v15-review-ime-aqe.md`](agent-findings/v15-review-ime-aqe.md) | v15 review — IME + AQE lens | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/v15-review-rdm.md`](agent-findings/v15-review-rdm.md) | v15 import review — RDM / FAIR Data Steward lens | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/v15-review-reluctant-senior.md`](agent-findings/v15-review-reluctant-senior.md) | v15 import — review from the reluctant senior researcher | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/v15.1-implementation.md`](agent-findings/v15.1-implementation.md) | v15.1 MFFD-import — implementation report | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/v15.2-implementation.md`](agent-findings/v15.2-implementation.md) | v15.2 — Smart warmup phase (IMPORT-W1/W2/W3) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/vis-plugin-survey-addendum-cad-fem.md`](agent-findings/vis-plugin-survey-addendum-cad-fem.md) | Visualization plugin survey — addendum: CAD + FEM | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/vis-plugin-survey.md`](agent-findings/vis-plugin-survey.md) | Visualization plugin survey | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/worktree-consolidation-triage-2026-05-23.md`](agent-findings/worktree-consolidation-triage-2026-05-23.md) | Worktree Consolidation Triage — 2026-05-23 | 2026-05-23 | 2026-05-26 |
-| [`aidocs/ai-policy/147-oecd-ai-alignment.md`](ai-policy/147-oecd-ai-alignment.md) | Shepard AI design × authoritative policy alignment — 9-source × 4-band matrix | 2026-05-26 | 2026-05-26 |
-| [`aidocs/integrations/94-log-store-sidecar-design.md`](integrations/94-log-store-sidecar-design.md) | 94 — Log-store-with-shape sidecar design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/semantics/95-shacl-templates-and-individuals.md`](semantics/95-shacl-templates-and-individuals.md) | 95 — SHACL templates, named individuals, and ontology-driven UI | 2026-05-23 | 2026-05-27 |
-| [`aidocs/semantics/98-shapes-views-and-process-model.md`](semantics/98-shapes-views-and-process-model.md) | 98 — Shapes, views, and the MFFD process model | 2026-05-23 | 2026-05-27 |
-| [`aidocs/semantics/99-promptlog-design.md`](semantics/99-promptlog-design.md) | 99 — PromptLog: prompts as first-class Shepard artefacts | 2026-05-23 | 2026-05-28 |
+| [`aidocs/agent-findings/v15-import-implementation.md`](agent-findings/v15-import-implementation.md) | v15 MFFD-import — implementation report | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/v15-review-data-ontologist.md`](agent-findings/v15-review-data-ontologist.md) | v15 review — Data & Process Ontologist lens | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/v15-review-ime-aqe.md`](agent-findings/v15-review-ime-aqe.md) | v15 review — IME + AQE lens | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/v15-review-rdm.md`](agent-findings/v15-review-rdm.md) | v15 import review — RDM / FAIR Data Steward lens | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/v15-review-reluctant-senior.md`](agent-findings/v15-review-reluctant-senior.md) | v15 import — review from the reluctant senior researcher | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/v15.1-implementation.md`](agent-findings/v15.1-implementation.md) | v15.1 MFFD-import — implementation report | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/v15.2-implementation.md`](agent-findings/v15.2-implementation.md) | v15.2 — Smart warmup phase (IMPORT-W1/W2/W3) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/vis-plugin-survey-addendum-cad-fem.md`](agent-findings/vis-plugin-survey-addendum-cad-fem.md) | Visualization plugin survey — addendum: CAD + FEM | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/vis-plugin-survey.md`](agent-findings/vis-plugin-survey.md) | Visualization plugin survey | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/worktree-consolidation-triage-2026-05-23.md`](agent-findings/worktree-consolidation-triage-2026-05-23.md) | Worktree Consolidation Triage — 2026-05-23 | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ai-policy/147-oecd-ai-alignment.md`](ai-policy/147-oecd-ai-alignment.md) | Shepard AI design × authoritative policy alignment — 9-source × 4-band matrix | 2026-05-26 | 2026-05-29 |
+| [`aidocs/integrations/94-log-store-sidecar-design.md`](integrations/94-log-store-sidecar-design.md) | 94 — Log-store-with-shape sidecar design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/semantics/95-shacl-templates-and-individuals.md`](semantics/95-shacl-templates-and-individuals.md) | 95 — SHACL templates, named individuals, and ontology-driven UI | 2026-05-23 | 2026-05-29 |
+| [`aidocs/semantics/98-shapes-views-and-process-model.md`](semantics/98-shapes-views-and-process-model.md) | 98 — Shapes, views, and the MFFD process model | 2026-05-23 | 2026-05-29 |
+| [`aidocs/semantics/99-promptlog-design.md`](semantics/99-promptlog-design.md) | 99 — PromptLog: prompts as first-class Shepard artefacts | 2026-05-23 | 2026-05-29 |
 
 ## feedback-implemented (2)
 
 | doc | title | last-stage-change | last-touched |
 |---|---|---|---|
-| [`aidocs/agent-findings/q7-fileref-parser-bug-2026-05-28.md`](agent-findings/q7-fileref-parser-bug-2026-05-28.md) | Q7 / task #145 — fileRef parser bug (BUG-FILEREF-TRUNCATION) | 2026-05-28 | 2026-05-28 |
-| [`aidocs/agent-findings/rdm-002-orcid-input-2026-05-24.md`](agent-findings/rdm-002-orcid-input-2026-05-24.md) | RDM-002 — ORCID input on `/me/profile` (FAIR R1) | 2026-05-24 | 2026-05-24 |
+| [`aidocs/agent-findings/q7-fileref-parser-bug-2026-05-28.md`](agent-findings/q7-fileref-parser-bug-2026-05-28.md) | Q7 / task #145 — fileRef parser bug (BUG-FILEREF-TRUNCATION) | 2026-05-28 | 2026-05-29 |
+| [`aidocs/agent-findings/rdm-002-orcid-input-2026-05-24.md`](agent-findings/rdm-002-orcid-input-2026-05-24.md) | RDM-002 — ORCID input on `/me/profile` (FAIR R1) | 2026-05-24 | 2026-05-29 |
 
 ## tests-implemented (4)
 
 | doc | title | last-stage-change | last-touched |
 |---|---|---|---|
-| [`aidocs/agent-findings/bug-lj-v1-coll-id-fix-2026-05-24.md`](agent-findings/bug-lj-v1-coll-id-fix-2026-05-24.md) | BUG-LJ-V1-COLL-ID — fix report | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/prov-resolver-fix-2026-05-24.md`](agent-findings/prov-resolver-fix-2026-05-24.md) | PROV-RESOLVER-PATHWALK + PROV-V1-NUMERIC-LOOKUP — fix report | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ui-003-004-section-landing-fix-2026-05-24.md`](agent-findings/ui-003-004-section-landing-fix-2026-05-24.md) | UI-2026-05-24-003 + UI-2026-05-24-004 fix — section index landings + Unauthorized view | 2026-05-24 | 2026-05-24 |
-| [`aidocs/integrations/93-mffd-import-v15-requirements.md`](integrations/93-mffd-import-v15-requirements.md) | 93 — MFFD real-data import (v15) requirements | 2026-05-23 | 2026-05-23 |
+| [`aidocs/agent-findings/bug-lj-v1-coll-id-fix-2026-05-24.md`](agent-findings/bug-lj-v1-coll-id-fix-2026-05-24.md) | BUG-LJ-V1-COLL-ID — fix report | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/prov-resolver-fix-2026-05-24.md`](agent-findings/prov-resolver-fix-2026-05-24.md) | PROV-RESOLVER-PATHWALK + PROV-V1-NUMERIC-LOOKUP — fix report | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ui-003-004-section-landing-fix-2026-05-24.md`](agent-findings/ui-003-004-section-landing-fix-2026-05-24.md) | UI-2026-05-24-003 + UI-2026-05-24-004 fix — section index landings + Unauthorized view | 2026-05-24 | 2026-05-29 |
+| [`aidocs/integrations/93-mffd-import-v15-requirements.md`](integrations/93-mffd-import-v15-requirements.md) | 93 — MFFD real-data import (v15) requirements | 2026-05-23 | 2026-05-29 |
 
-## deployed (70)
+## deployed (71)
 
 | doc | title | last-stage-change | last-touched |
 |---|---|---|---|
-| [`aidocs/00-doc-stages.md`](00-doc-stages.md) | 00 — Doc lifecycle stages (taxonomy SSOT) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/00-index.md`](00-index.md) | aidocs — Index | 2026-05-23 | 2026-05-26 |
-| [`aidocs/100-ui-annoyances.md`](100-ui-annoyances.md) | 100 — Shepard UI annoyances (live captured) | 2026-05-23 | 2026-05-23 |
+| [`aidocs/00-doc-stages.md`](00-doc-stages.md) | 00 — Doc lifecycle stages (taxonomy SSOT) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/00-index.md`](00-index.md) | aidocs — Index | 2026-05-23 | 2026-05-29 |
+| [`aidocs/100-ui-annoyances.md`](100-ui-annoyances.md) | 100 — Shepard UI annoyances (live captured) | 2026-05-23 | 2026-05-29 |
 | [`aidocs/16-dispatcher-backlog.md`](16-dispatcher-backlog.md) | 16 — Dispatcher Backlog | 2026-05-23 | 2026-05-29 |
 | [`aidocs/34-upstream-upgrade-path.md`](34-upstream-upgrade-path.md) | Upstream upgrade path — `dlr-shepard/shepard 5.2.0` → `noheton/shepard main` | 2026-05-23 | 2026-05-29 |
-| [`aidocs/40-ecosystem.md`](40-ecosystem.md) | 40 — Shepard ecosystem | 2026-05-23 | 2026-05-28 |
-| [`aidocs/41-synergy-sweep.md`](41-synergy-sweep.md) | 41 — Synergy sweep: collapse-where-generalisation-helps | 2026-05-23 | 2026-05-23 |
+| [`aidocs/40-ecosystem.md`](40-ecosystem.md) | 40 — Shepard ecosystem | 2026-05-23 | 2026-05-29 |
+| [`aidocs/41-synergy-sweep.md`](41-synergy-sweep.md) | 41 — Synergy sweep: collapse-where-generalisation-helps | 2026-05-23 | 2026-05-29 |
 | [`aidocs/42-vision.md`](42-vision.md) | shepard — Vision (for researchers) | 2026-05-23 | 2026-05-29 |
 | [`aidocs/44-fork-vs-upstream-feature-matrix.md`](44-fork-vs-upstream-feature-matrix.md) | Fork vs Upstream — Feature Matrix | 2026-05-23 | 2026-05-29 |
-| [`aidocs/97-shepard-pipelines.md`](97-shepard-pipelines.md) | 97 — Shepard-pipelines: modern REBAR, Shepard-native | 2026-05-23 | 2026-05-23 |
-| [`aidocs/99-api-annoyances.md`](99-api-annoyances.md) | 99 — Shepard API annoyances (structural clunkiness) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/audience-frontmatter-retrofit-2026-05-23.md`](agent-findings/audience-frontmatter-retrofit-2026-05-23.md) | Audience-persona front-matter retrofit (DOCS-3A9) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/db-baseline-post-mffd.md`](agent-findings/db-baseline-post-mffd.md) | DB Baseline: post-MFFD ingest (2026-05-26) | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/db-opt2-hot-path-analysis.md`](agent-findings/db-opt2-hot-path-analysis.md) | DB-OPT2: Hot-path index analysis | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/db-opt3-timescaledb-tuning.md`](agent-findings/db-opt3-timescaledb-tuning.md) | DB-OPT3 — TimescaleDB Chunk + Compression Analysis | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/doc-alignment-2026-05-28.md`](agent-findings/doc-alignment-2026-05-28.md) | Doc Alignment — 2026-05-28 | 2026-05-28 | 2026-05-28 |
-| [`aidocs/agent-findings/fair8-fuji-alignment-2026-05-27.md`](agent-findings/fair8-fuji-alignment-2026-05-27.md) | FAIR8 — F-UJI Alignment Findings (2026-05-27) | 2026-05-27 | 2026-05-27 |
-| [`aidocs/agent-findings/feature-synergy-hunt-2026-05-26.md`](agent-findings/feature-synergy-hunt-2026-05-26.md) | Feature & Synergy Hunt — 2026-05-26 | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/gh-pm-adoption-synthesis-2026-05-23.md`](agent-findings/gh-pm-adoption-synthesis-2026-05-23.md) | Synthesis — GH-PM (policy doc 85) adoption decisions | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/gh-pm-backfill-plan-2026-05-23.md`](agent-findings/gh-pm-backfill-plan-2026-05-23.md) | GH-PM5 backfill — plan + execution log (2026-05-23) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/lic1-shipped-2026-05-24.md`](agent-findings/lic1-shipped-2026-05-24.md) | LIC1 shipped — license + accessRights end-to-end (2026-05-24) | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/mcp-validation-2026-05-26.md`](agent-findings/mcp-validation-2026-05-26.md) | MCP End-to-End Validation — 2026-05-26 | 2026-05-26 | 2026-05-26 |
-| [`aidocs/agent-findings/mffd-import-slowness-diagnose-2026-05-23.md`](agent-findings/mffd-import-slowness-diagnose-2026-05-23.md) | MFFD cube3 import slowness — diagnostic | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/neo4j-n10s-design-audit-2026-05-24.md`](agent-findings/neo4j-n10s-design-audit-2026-05-24.md) | Neo4j + n10s substrate audit — 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ops-cleanup-2026-05-24.md`](agent-findings/ops-cleanup-2026-05-24.md) | ops-cleanup-2026-05-24 — un-ignore neo4j migrations + worktree env bootstrap | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ops-hygiene-bundle-2026-05-24.md`](agent-findings/ops-hygiene-bundle-2026-05-24.md) | OPS hygiene bundle — 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ops-migration-healthcheck-2026-05-24.md`](agent-findings/ops-migration-healthcheck-2026-05-24.md) | ops-migration-healthcheck-2026-05-24 — readiness gate on Neo4j migration-chain integrity | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/persona-audit-admin-stale-ch-2026-05-23.md`](agent-findings/persona-audit-admin-stale-ch-2026-05-23.md) | Persona audit — ADMIN-STALE-CH (Stale timeseries channel admin tool) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/plugin-docs-gap-audit-2026-05-23.md`](agent-findings/plugin-docs-gap-audit-2026-05-23.md) | Plugin documentation gap audit — 2026-05-23 | 2026-05-23 | 2026-05-23 |
-| [`aidocs/agent-findings/principle-candidates.md`](agent-findings/principle-candidates.md) | Implicit Design Principles — Candidate Discovery | 2026-05-28 | 2026-05-28 |
-| [`aidocs/agent-findings/rdm-001-cite-this-dataset-2026-05-24.md`](agent-findings/rdm-001-cite-this-dataset-2026-05-24.md) | RDM-001 — "Cite this dataset" card on Collection landing (2026-05-24) | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/rdm-005-metadata-completeness-2026-05-24.md`](agent-findings/rdm-005-metadata-completeness-2026-05-24.md) | RDM-005 — Metadata Completeness Score widget (live) | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/sema-v6-preseed-status.md`](agent-findings/sema-v6-preseed-status.md) | SEMA-V6 Preseed Status (2026-05-26) | 2026-05-26 | 2026-05-26 |
+| [`aidocs/97-shepard-pipelines.md`](97-shepard-pipelines.md) | 97 — Shepard-pipelines: modern REBAR, Shepard-native | 2026-05-23 | 2026-05-29 |
+| [`aidocs/99-api-annoyances.md`](99-api-annoyances.md) | 99 — Shepard API annoyances (structural clunkiness) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/audience-frontmatter-retrofit-2026-05-23.md`](agent-findings/audience-frontmatter-retrofit-2026-05-23.md) | Audience-persona front-matter retrofit (DOCS-3A9) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/db-baseline-post-mffd.md`](agent-findings/db-baseline-post-mffd.md) | DB Baseline: post-MFFD ingest (2026-05-26) | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/db-opt2-hot-path-analysis.md`](agent-findings/db-opt2-hot-path-analysis.md) | DB-OPT2: Hot-path index analysis | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/db-opt3-timescaledb-tuning.md`](agent-findings/db-opt3-timescaledb-tuning.md) | DB-OPT3 — TimescaleDB Chunk + Compression Analysis | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/dispatcher-runs/2026-05-29-21.md`](agent-findings/dispatcher-runs/2026-05-29-21.md) | Dispatcher run 2026-05-29-21 | 2026-05-29 | 2026-05-29 |
+| [`aidocs/agent-findings/doc-alignment-2026-05-28.md`](agent-findings/doc-alignment-2026-05-28.md) | Doc Alignment — 2026-05-28 | 2026-05-28 | 2026-05-29 |
+| [`aidocs/agent-findings/fair8-fuji-alignment-2026-05-27.md`](agent-findings/fair8-fuji-alignment-2026-05-27.md) | FAIR8 — F-UJI Alignment Findings (2026-05-27) | 2026-05-27 | 2026-05-29 |
+| [`aidocs/agent-findings/feature-synergy-hunt-2026-05-26.md`](agent-findings/feature-synergy-hunt-2026-05-26.md) | Feature & Synergy Hunt — 2026-05-26 | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/gh-pm-adoption-synthesis-2026-05-23.md`](agent-findings/gh-pm-adoption-synthesis-2026-05-23.md) | Synthesis — GH-PM (policy doc 85) adoption decisions | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/gh-pm-backfill-plan-2026-05-23.md`](agent-findings/gh-pm-backfill-plan-2026-05-23.md) | GH-PM5 backfill — plan + execution log (2026-05-23) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/lic1-shipped-2026-05-24.md`](agent-findings/lic1-shipped-2026-05-24.md) | LIC1 shipped — license + accessRights end-to-end (2026-05-24) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/mcp-validation-2026-05-26.md`](agent-findings/mcp-validation-2026-05-26.md) | MCP End-to-End Validation — 2026-05-26 | 2026-05-26 | 2026-05-29 |
+| [`aidocs/agent-findings/mffd-import-slowness-diagnose-2026-05-23.md`](agent-findings/mffd-import-slowness-diagnose-2026-05-23.md) | MFFD cube3 import slowness — diagnostic | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/neo4j-n10s-design-audit-2026-05-24.md`](agent-findings/neo4j-n10s-design-audit-2026-05-24.md) | Neo4j + n10s substrate audit — 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ops-cleanup-2026-05-24.md`](agent-findings/ops-cleanup-2026-05-24.md) | ops-cleanup-2026-05-24 — un-ignore neo4j migrations + worktree env bootstrap | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ops-hygiene-bundle-2026-05-24.md`](agent-findings/ops-hygiene-bundle-2026-05-24.md) | OPS hygiene bundle — 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ops-migration-healthcheck-2026-05-24.md`](agent-findings/ops-migration-healthcheck-2026-05-24.md) | ops-migration-healthcheck-2026-05-24 — readiness gate on Neo4j migration-chain integrity | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/persona-audit-admin-stale-ch-2026-05-23.md`](agent-findings/persona-audit-admin-stale-ch-2026-05-23.md) | Persona audit — ADMIN-STALE-CH (Stale timeseries channel admin tool) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/plugin-docs-gap-audit-2026-05-23.md`](agent-findings/plugin-docs-gap-audit-2026-05-23.md) | Plugin documentation gap audit — 2026-05-23 | 2026-05-23 | 2026-05-29 |
+| [`aidocs/agent-findings/principle-candidates.md`](agent-findings/principle-candidates.md) | Implicit Design Principles — Candidate Discovery | 2026-05-28 | 2026-05-29 |
+| [`aidocs/agent-findings/rdm-001-cite-this-dataset-2026-05-24.md`](agent-findings/rdm-001-cite-this-dataset-2026-05-24.md) | RDM-001 — "Cite this dataset" card on Collection landing (2026-05-24) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/rdm-005-metadata-completeness-2026-05-24.md`](agent-findings/rdm-005-metadata-completeness-2026-05-24.md) | RDM-005 — Metadata Completeness Score widget (live) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/sema-v6-preseed-status.md`](agent-findings/sema-v6-preseed-status.md) | SEMA-V6 Preseed Status (2026-05-26) | 2026-05-26 | 2026-05-29 |
 | [`aidocs/agent-findings/ts-axis-verify-2026-05-29.md`](agent-findings/ts-axis-verify-2026-05-29.md) | TS-AXIS-VERIFY — MFFD spatial-roles annotations verified live (2026-05-29) | 2026-05-29 | 2026-05-29 |
-| [`aidocs/agent-findings/ui-002-header-search-fix-2026-05-24.md`](agent-findings/ui-002-header-search-fix-2026-05-24.md) | UI-002 — Header-search dropdown fix (2026-05-24) | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ui-005-watches-me-silenced-2026-05-24.md`](agent-findings/ui-005-watches-me-silenced-2026-05-24.md) | UI-005 — silence `/watches/me` 404 spam on collection landing | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ui-006-007-009-015-home-polish-2026-05-24.md`](agent-findings/ui-006-007-009-015-home-polish-2026-05-24.md) | Home + file-row polish pass — UI-006/007/009/015 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ui-011-collections-list-fix-2026-05-24.md`](agent-findings/ui-011-collections-list-fix-2026-05-24.md) | UI-011 — Collections list page column enrichment | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ui-011e-do-count-fix-2026-05-24.md`](agent-findings/ui-011e-do-count-fix-2026-05-24.md) | UI-011e — `# DOs` column shows 0 everywhere on `/collections` — fix | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ui-013-help-search-anchors-2026-05-24.md`](agent-findings/ui-013-help-search-anchors-2026-05-24.md) | UI-2026-05-24-013 — in-page help search + per-heading anchors (CLOSED) | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ui-016-017-polish-2026-05-24.md`](agent-findings/ui-016-017-polish-2026-05-24.md) | UI-016 + UI-017 cosmetic polish — 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ui-020-labjournal-bulk-fix-2026-05-24.md`](agent-findings/ui-020-labjournal-bulk-fix-2026-05-24.md) | UI-020 — Lab-journal bulk fetch closes per-DataObject N+1 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ui-021-sd-list-fix-2026-05-24.md`](agent-findings/ui-021-sd-list-fix-2026-05-24.md) | UI-021 — `/containers/structureddata` "shows 0 rows" — close as WAI/misreport | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ux-pattern-d-count-badges-2026-05-24.md`](agent-findings/ux-pattern-d-count-badges-2026-05-24.md) | UX Pattern D — count badges on DataObject reference panels | 2026-05-24 | 2026-05-24 |
-| [`aidocs/agent-findings/ux-polish-bundle-2026-05-24.md`](agent-findings/ux-polish-bundle-2026-05-24.md) | UX polish bundle — 2026-05-24 | 2026-05-24 | 2026-05-24 |
-| [`aidocs/case-study-2026-05-19.md`](case-study-2026-05-19.md) | Case Study: One Month of AI-Assisted Fork Development | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/00-model-inventory.md`](data/00-model-inventory.md) | 00 — Model inventory (SSOT) | 2026-05-23 | 2026-05-27 |
-| [`aidocs/data/37-lab-journal-and-jupyter-design.md`](data/37-lab-journal-and-jupyter-design.md) | Lab Journal Reassessment + Jupyter Feasibility — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/41-snapshots-design.md`](data/41-snapshots-design.md) | Snapshots — Design (versioning, reloaded) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/data/68-timeseries-data-model-tuning.md`](data/68-timeseries-data-model-tuning.md) | TimescaleDB Data Model Tuning — Recommendations | 2026-05-23 | 2026-05-23 |
-| [`aidocs/handover-2026-05-19.md`](handover-2026-05-19.md) | Shepard Fork — Handover Document | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/59-performance-testing-and-tuning.md`](ops/59-performance-testing-and-tuning.md) | Performance testing + auto-tuning — design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/75-api-integration-test-suite.md`](ops/75-api-integration-test-suite.md) | API-Level Integration Test Suite — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/77-k6-performance-metrics.md`](ops/77-k6-performance-metrics.md) | k6 Per-Endpoint SLO Matrix + `/v2/` Coverage | 2026-05-23 | 2026-05-27 |
-| [`aidocs/ops/85-ui-overhaul-design.md`](ops/85-ui-overhaul-design.md) | 85 — UI Overhaul: Critique, Opportunities, and Roadmap | 2026-05-23 | 2026-05-23 |
-| [`aidocs/ops/87-collection-container-duality.md`](ops/87-collection-container-duality.md) | 87 — Collection / Container Duality: Design Discussion | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/25-neo4j-id-migration-design.md`](platform/25-neo4j-id-migration-design.md) | Neo4j ID Migration — Design (L2) | 2026-05-23 | 2026-05-26 |
-| [`aidocs/platform/47-dev-experience-and-plugin-system.md`](platform/47-dev-experience-and-plugin-system.md) | Dev Experience + Storage-Backend Plugin System — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/platform/85-openapi-llm-readable.md`](platform/85-openapi-llm-readable.md) | OpenAPI documentation standard — LLM-readable | 2026-05-23 | 2026-05-23 |
+| [`aidocs/agent-findings/ui-002-header-search-fix-2026-05-24.md`](agent-findings/ui-002-header-search-fix-2026-05-24.md) | UI-002 — Header-search dropdown fix (2026-05-24) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ui-005-watches-me-silenced-2026-05-24.md`](agent-findings/ui-005-watches-me-silenced-2026-05-24.md) | UI-005 — silence `/watches/me` 404 spam on collection landing | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ui-006-007-009-015-home-polish-2026-05-24.md`](agent-findings/ui-006-007-009-015-home-polish-2026-05-24.md) | Home + file-row polish pass — UI-006/007/009/015 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ui-011-collections-list-fix-2026-05-24.md`](agent-findings/ui-011-collections-list-fix-2026-05-24.md) | UI-011 — Collections list page column enrichment | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ui-011e-do-count-fix-2026-05-24.md`](agent-findings/ui-011e-do-count-fix-2026-05-24.md) | UI-011e — `# DOs` column shows 0 everywhere on `/collections` — fix | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ui-013-help-search-anchors-2026-05-24.md`](agent-findings/ui-013-help-search-anchors-2026-05-24.md) | UI-2026-05-24-013 — in-page help search + per-heading anchors (CLOSED) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ui-016-017-polish-2026-05-24.md`](agent-findings/ui-016-017-polish-2026-05-24.md) | UI-016 + UI-017 cosmetic polish — 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ui-020-labjournal-bulk-fix-2026-05-24.md`](agent-findings/ui-020-labjournal-bulk-fix-2026-05-24.md) | UI-020 — Lab-journal bulk fetch closes per-DataObject N+1 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ui-021-sd-list-fix-2026-05-24.md`](agent-findings/ui-021-sd-list-fix-2026-05-24.md) | UI-021 — `/containers/structureddata` "shows 0 rows" — close as WAI/misreport | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ux-pattern-d-count-badges-2026-05-24.md`](agent-findings/ux-pattern-d-count-badges-2026-05-24.md) | UX Pattern D — count badges on DataObject reference panels | 2026-05-24 | 2026-05-29 |
+| [`aidocs/agent-findings/ux-polish-bundle-2026-05-24.md`](agent-findings/ux-polish-bundle-2026-05-24.md) | UX polish bundle — 2026-05-24 | 2026-05-24 | 2026-05-29 |
+| [`aidocs/case-study-2026-05-19.md`](case-study-2026-05-19.md) | Case Study: One Month of AI-Assisted Fork Development | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/00-model-inventory.md`](data/00-model-inventory.md) | 00 — Model inventory (SSOT) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/37-lab-journal-and-jupyter-design.md`](data/37-lab-journal-and-jupyter-design.md) | Lab Journal Reassessment + Jupyter Feasibility — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/41-snapshots-design.md`](data/41-snapshots-design.md) | Snapshots — Design (versioning, reloaded) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/data/68-timeseries-data-model-tuning.md`](data/68-timeseries-data-model-tuning.md) | TimescaleDB Data Model Tuning — Recommendations | 2026-05-23 | 2026-05-29 |
+| [`aidocs/handover-2026-05-19.md`](handover-2026-05-19.md) | Shepard Fork — Handover Document | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/59-performance-testing-and-tuning.md`](ops/59-performance-testing-and-tuning.md) | Performance testing + auto-tuning — design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/75-api-integration-test-suite.md`](ops/75-api-integration-test-suite.md) | API-Level Integration Test Suite — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/77-k6-performance-metrics.md`](ops/77-k6-performance-metrics.md) | k6 Per-Endpoint SLO Matrix + `/v2/` Coverage | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/85-ui-overhaul-design.md`](ops/85-ui-overhaul-design.md) | 85 — UI Overhaul: Critique, Opportunities, and Roadmap | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ops/87-collection-container-duality.md`](ops/87-collection-container-duality.md) | 87 — Collection / Container Duality: Design Discussion | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/25-neo4j-id-migration-design.md`](platform/25-neo4j-id-migration-design.md) | Neo4j ID Migration — Design (L2) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/47-dev-experience-and-plugin-system.md`](platform/47-dev-experience-and-plugin-system.md) | Dev Experience + Storage-Backend Plugin System — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/platform/85-openapi-llm-readable.md`](platform/85-openapi-llm-readable.md) | OpenAPI documentation standard — LLM-readable | 2026-05-23 | 2026-05-29 |
 | [`aidocs/platform/87-timeseries-appid-migration.md`](platform/87-timeseries-appid-migration.md) | 87 — Timeseries appId Migration (TS-ID) | 2026-05-23 | 2026-05-29 |
-| [`aidocs/plugins/69-aas-plugin-extraction-design.md`](plugins/69-aas-plugin-extraction-design.md) | AAS → plugin extraction — Design (AAS1-plugin) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/reading-list.md`](reading-list.md) | Reading list | 2026-05-23 | 2026-05-23 |
-| [`aidocs/roadmap.md`](roadmap.md) | Shepard Fork — Roadmap | 2026-05-23 | 2026-05-28 |
-| [`aidocs/strategy/83-github-features-leverage.md`](strategy/83-github-features-leverage.md) | GitHub features — what shepard uses, deliberately skips, and why | 2026-05-23 | 2026-05-26 |
-| [`aidocs/strategy/85-github-project-management-policies.md`](strategy/85-github-project-management-policies.md) | 85 — GitHub project-management policies (traceability SSOT) | 2026-05-23 | 2026-05-27 |
-| [`aidocs/ux/82-basic-vs-advanced-mode-matrix.md`](ux/82-basic-vs-advanced-mode-matrix.md) | 82 — Basic vs Advanced Mode Feature Matrix | 2026-05-23 | 2026-05-23 |
-| [`aidocs/workflows/36-user-profile-and-settings-design.md`](workflows/36-user-profile-and-settings-design.md) | User Profile & Settings — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/workflows/38-git-integration-design.md`](workflows/38-git-integration-design.md) | Git Integration — Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/workflows/39-templates-design.md`](workflows/39-templates-design.md) | Templates — Implementation Design | 2026-05-23 | 2026-05-23 |
-| [`aidocs/workflows/64-provenance-architecture.md`](workflows/64-provenance-architecture.md) | 64 — Provenance architecture (what's shipped + where it's going) | 2026-05-23 | 2026-05-28 |
+| [`aidocs/plugins/69-aas-plugin-extraction-design.md`](plugins/69-aas-plugin-extraction-design.md) | AAS → plugin extraction — Design (AAS1-plugin) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/reading-list.md`](reading-list.md) | Reading list | 2026-05-23 | 2026-05-29 |
+| [`aidocs/roadmap.md`](roadmap.md) | Shepard Fork — Roadmap | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/83-github-features-leverage.md`](strategy/83-github-features-leverage.md) | GitHub features — what shepard uses, deliberately skips, and why | 2026-05-23 | 2026-05-29 |
+| [`aidocs/strategy/85-github-project-management-policies.md`](strategy/85-github-project-management-policies.md) | 85 — GitHub project-management policies (traceability SSOT) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/ux/82-basic-vs-advanced-mode-matrix.md`](ux/82-basic-vs-advanced-mode-matrix.md) | 82 — Basic vs Advanced Mode Feature Matrix | 2026-05-23 | 2026-05-29 |
+| [`aidocs/workflows/36-user-profile-and-settings-design.md`](workflows/36-user-profile-and-settings-design.md) | User Profile & Settings — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/workflows/38-git-integration-design.md`](workflows/38-git-integration-design.md) | Git Integration — Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/workflows/39-templates-design.md`](workflows/39-templates-design.md) | Templates — Implementation Design | 2026-05-23 | 2026-05-29 |
+| [`aidocs/workflows/64-provenance-architecture.md`](workflows/64-provenance-architecture.md) | 64 — Provenance architecture (what's shipped + where it's going) | 2026-05-23 | 2026-05-29 |
 
 ## decommissioned (49)
 
 | doc | title | last-stage-change | last-touched |
 |---|---|---|---|
-| [`aidocs/archive/01-repo-overview.md`](archive/01-repo-overview.md) | Repo Overview — shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/02-cluster-map.md`](archive/02-cluster-map.md) | Cluster Map — shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/03-issues-status.md`](archive/03-issues-status.md) | Issues Status — shepard (GitLab open items) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/04-reconciliation.md`](archive/04-reconciliation.md) | Reconciliation — GitHub mirror vs GitLab authoritative | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/05-dependency-report.md`](archive/05-dependency-report.md) | Dependency Report — shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/06-code-quality.md`](archive/06-code-quality.md) | Code Quality — shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/07-security-issues.md`](archive/07-security-issues.md) | Security Issues — shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/08-first-issues.md`](archive/08-first-issues.md) | First Issues — shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/09-ready-to-close.md`](archive/09-ready-to-close.md) | Ready to Close on GitHub — shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/10-cleanup-plan.md`](archive/10-cleanup-plan.md) | Cleanup Plan — shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/15-phase-0-status.md`](archive/15-phase-0-status.md) | Phase 0 — Housekeeping Status | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/17-startup-wait-audit.md`](archive/17-startup-wait-audit.md) | 17 — Startup Wait / Retry Audit | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/18-pagination-inventory.md`](archive/18-pagination-inventory.md) | Pagination — Inventory & Sized Rollout Plan | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/21-user-interest-gauge.md`](archive/21-user-interest-gauge.md) | User / Scientific Interest Gauge — HDF5, Tabular Storage, KG Interfaces | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/ai-in-science-policy-alignment.md`](archive/agent-findings-sessions-2026-05/ai-in-science-policy-alignment.md) | AI-in-Science policy alignment — does Shepard's AI design match the prevailing authoritative consensus? | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/analytics-ai-debate.md`](archive/agent-findings-sessions-2026-05/analytics-ai-debate.md) | Analytics & AI Opportunities Specialist — Phase 2 Debate | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/analytics-ai-proposals.md`](archive/agent-findings-sessions-2026-05/analytics-ai-proposals.md) | AI & Analytics Feature Proposals | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/api-scrutinizer-debate.md`](archive/agent-findings-sessions-2026-05/api-scrutinizer-debate.md) | API Scrutinizer — Phase 2 Debate | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/api-scrutinizer-proposals.md`](archive/agent-findings-sessions-2026-05/api-scrutinizer-proposals.md) | API Scrutinizer — Concrete Improvement Proposals | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/data-ontologist-debate.md`](archive/agent-findings-sessions-2026-05/data-ontologist-debate.md) | Data & Process Ontologist — Debate Output | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/data-ontologist-proposals.md`](archive/agent-findings-sessions-2026-05/data-ontologist-proposals.md) | Data Ontologist — Feature Proposals | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/database-antipatterns-audit.md`](archive/agent-findings-sessions-2026-05/database-antipatterns-audit.md) | Database anti-pattern audit — Neo4j + Postgres/Hibernate + MongoDB/GridFS + PostGIS + Garage S3 | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/database-schema-research-multi-db.md`](archive/agent-findings-sessions-2026-05/database-schema-research-multi-db.md) | Database schema research — multi-substrate sweep (Neo4j + Postgres + MongoDB + PostGIS + Garage) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/easa-ai-compliance.md`](archive/agent-findings-sessions-2026-05/easa-ai-compliance.md) | EASA AI Concept Paper Issue 2 — Compliance Gap Analysis | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/ecosystem-advocate-debate.md`](archive/agent-findings-sessions-2026-05/ecosystem-advocate-debate.md) | Ecosystem Advocate Debate | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/ecosystem-advocate-proposals.md`](archive/agent-findings-sessions-2026-05/ecosystem-advocate-proposals.md) | Ecosystem Advocate — Feature Proposals | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/industrial-robotics-ontology-audit.md`](archive/agent-findings-sessions-2026-05/industrial-robotics-ontology-audit.md) | Industrial Robotics + ZLP-Domain Ontology Audit (Shepard scope) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/manufacturing-quality-debate.md`](archive/agent-findings-sessions-2026-05/manufacturing-quality-debate.md) | Manufacturing & Quality Engineering — Cross-Agent Debate | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/manufacturing-quality-proposals.md`](archive/agent-findings-sessions-2026-05/manufacturing-quality-proposals.md) | Manufacturing & Quality Engineering — Feature Proposals | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/mffd-paper-198366.md`](archive/agent-findings-sessions-2026-05/mffd-paper-198366.md) | MFFD Paper 198366 — Comprehensive Extraction | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/performance-baseline-2026-05-21.md`](archive/agent-findings-sessions-2026-05/performance-baseline-2026-05-21.md) | Shepard performance baseline — 2026-05-21 | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/persona-debate-round.md`](archive/agent-findings-sessions-2026-05/persona-debate-round.md) | Persona Debate Round — Reluctant Senior vs. Digital Native | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/persona-digital-native.md`](archive/agent-findings-sessions-2026-05/persona-digital-native.md) | Persona: Digital Native Researcher — Findings | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/persona-reluctant-senior.md`](archive/agent-findings-sessions-2026-05/persona-reluctant-senior.md) | Reluctant Senior Researcher — Persona Findings | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/plugin-registry-trust.md`](archive/agent-findings-sessions-2026-05/plugin-registry-trust.md) | Plugin Registry Trust Mechanisms — Convenience-First Survey | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/quarkus-ecosystem.md`](archive/agent-findings-sessions-2026-05/quarkus-ecosystem.md) | Quarkus Extension Ecosystem — Opportunities for Shepard | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/quarkus-mcp-kadi-gaps.md`](archive/agent-findings-sessions-2026-05/quarkus-mcp-kadi-gaps.md) | Quarkus MCP, Kadi4Mat, and RDM Ecosystem Gaps — Findings | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/research-data-manager-debate.md`](archive/agent-findings-sessions-2026-05/research-data-manager-debate.md) | Research Data Manager — Cross-Agent Debate | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/research-data-manager-proposals.md`](archive/agent-findings-sessions-2026-05/research-data-manager-proposals.md) | Proposal 1: KIP1e — License Field on All Entities (Core, foundational) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/strategy-advisor-debate.md`](archive/agent-findings-sessions-2026-05/strategy-advisor-debate.md) | Strategy Advisor — Cross-Agent Debate | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/strategy-advisor-proposals.md`](archive/agent-findings-sessions-2026-05/strategy-advisor-proposals.md) | Strategy Advisor — Feature Proposals | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/timescaledb-schema-research.md`](archive/agent-findings-sessions-2026-05/timescaledb-schema-research.md) | TimescaleDB schema research — is the schema the MFFD ingest bottleneck? | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/ux-auditor-debate.md`](archive/agent-findings-sessions-2026-05/ux-auditor-debate.md) | UX Auditor Debate — Core Tech & UX Lens | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/ux-auditor-proposals.md`](archive/agent-findings-sessions-2026-05/ux-auditor-proposals.md) | UX Auditor — Feature Proposals | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings-sessions-2026-05/v1-compat-live-validation.md`](archive/agent-findings-sessions-2026-05/v1-compat-live-validation.md) | V1COMPAT.0 Phase 1 — live validation findings | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/agent-findings/predecessor-history-correction-2026-05-23.md`](archive/agent-findings/predecessor-history-correction-2026-05-23.md) | Predecessor history — standing correction | 2026-05-23 | 2026-05-26 |
-| [`aidocs/archive/platform/68-v2-baseline-v1-compat-layer.md`](archive/platform/68-v2-baseline-v1-compat-layer.md) | V2 baseline + `/shepard/api/` as compat layer — Design (V2BASE) | 2026-05-23 | 2026-05-23 |
-| [`aidocs/archive/platform/86-ai-plugin-design.md`](archive/platform/86-ai-plugin-design.md) | `shepard-plugin-ai` — AI Platform Design (superseded) | 2026-05-24 | 2026-05-26 |
-| [`aidocs/archive/semantics/14-semantic-improvements.md`](archive/semantics/14-semantic-improvements.md) | Semantic Annotations — Improvements & Knowledge-Graph Path (DECOMMISSIONED) | 2026-05-24 | 2026-05-26 |
+| [`aidocs/archive/01-repo-overview.md`](archive/01-repo-overview.md) | Repo Overview — shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/02-cluster-map.md`](archive/02-cluster-map.md) | Cluster Map — shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/03-issues-status.md`](archive/03-issues-status.md) | Issues Status — shepard (GitLab open items) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/04-reconciliation.md`](archive/04-reconciliation.md) | Reconciliation — GitHub mirror vs GitLab authoritative | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/05-dependency-report.md`](archive/05-dependency-report.md) | Dependency Report — shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/06-code-quality.md`](archive/06-code-quality.md) | Code Quality — shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/07-security-issues.md`](archive/07-security-issues.md) | Security Issues — shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/08-first-issues.md`](archive/08-first-issues.md) | First Issues — shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/09-ready-to-close.md`](archive/09-ready-to-close.md) | Ready to Close on GitHub — shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/10-cleanup-plan.md`](archive/10-cleanup-plan.md) | Cleanup Plan — shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/15-phase-0-status.md`](archive/15-phase-0-status.md) | Phase 0 — Housekeeping Status | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/17-startup-wait-audit.md`](archive/17-startup-wait-audit.md) | 17 — Startup Wait / Retry Audit | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/18-pagination-inventory.md`](archive/18-pagination-inventory.md) | Pagination — Inventory & Sized Rollout Plan | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/21-user-interest-gauge.md`](archive/21-user-interest-gauge.md) | User / Scientific Interest Gauge — HDF5, Tabular Storage, KG Interfaces | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/ai-in-science-policy-alignment.md`](archive/agent-findings-sessions-2026-05/ai-in-science-policy-alignment.md) | AI-in-Science policy alignment — does Shepard's AI design match the prevailing authoritative consensus? | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/analytics-ai-debate.md`](archive/agent-findings-sessions-2026-05/analytics-ai-debate.md) | Analytics & AI Opportunities Specialist — Phase 2 Debate | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/analytics-ai-proposals.md`](archive/agent-findings-sessions-2026-05/analytics-ai-proposals.md) | AI & Analytics Feature Proposals | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/api-scrutinizer-debate.md`](archive/agent-findings-sessions-2026-05/api-scrutinizer-debate.md) | API Scrutinizer — Phase 2 Debate | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/api-scrutinizer-proposals.md`](archive/agent-findings-sessions-2026-05/api-scrutinizer-proposals.md) | API Scrutinizer — Concrete Improvement Proposals | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/data-ontologist-debate.md`](archive/agent-findings-sessions-2026-05/data-ontologist-debate.md) | Data & Process Ontologist — Debate Output | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/data-ontologist-proposals.md`](archive/agent-findings-sessions-2026-05/data-ontologist-proposals.md) | Data Ontologist — Feature Proposals | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/database-antipatterns-audit.md`](archive/agent-findings-sessions-2026-05/database-antipatterns-audit.md) | Database anti-pattern audit — Neo4j + Postgres/Hibernate + MongoDB/GridFS + PostGIS + Garage S3 | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/database-schema-research-multi-db.md`](archive/agent-findings-sessions-2026-05/database-schema-research-multi-db.md) | Database schema research — multi-substrate sweep (Neo4j + Postgres + MongoDB + PostGIS + Garage) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/easa-ai-compliance.md`](archive/agent-findings-sessions-2026-05/easa-ai-compliance.md) | EASA AI Concept Paper Issue 2 — Compliance Gap Analysis | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/ecosystem-advocate-debate.md`](archive/agent-findings-sessions-2026-05/ecosystem-advocate-debate.md) | Ecosystem Advocate Debate | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/ecosystem-advocate-proposals.md`](archive/agent-findings-sessions-2026-05/ecosystem-advocate-proposals.md) | Ecosystem Advocate — Feature Proposals | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/industrial-robotics-ontology-audit.md`](archive/agent-findings-sessions-2026-05/industrial-robotics-ontology-audit.md) | Industrial Robotics + ZLP-Domain Ontology Audit (Shepard scope) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/manufacturing-quality-debate.md`](archive/agent-findings-sessions-2026-05/manufacturing-quality-debate.md) | Manufacturing & Quality Engineering — Cross-Agent Debate | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/manufacturing-quality-proposals.md`](archive/agent-findings-sessions-2026-05/manufacturing-quality-proposals.md) | Manufacturing & Quality Engineering — Feature Proposals | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/mffd-paper-198366.md`](archive/agent-findings-sessions-2026-05/mffd-paper-198366.md) | MFFD Paper 198366 — Comprehensive Extraction | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/performance-baseline-2026-05-21.md`](archive/agent-findings-sessions-2026-05/performance-baseline-2026-05-21.md) | Shepard performance baseline — 2026-05-21 | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/persona-debate-round.md`](archive/agent-findings-sessions-2026-05/persona-debate-round.md) | Persona Debate Round — Reluctant Senior vs. Digital Native | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/persona-digital-native.md`](archive/agent-findings-sessions-2026-05/persona-digital-native.md) | Persona: Digital Native Researcher — Findings | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/persona-reluctant-senior.md`](archive/agent-findings-sessions-2026-05/persona-reluctant-senior.md) | Reluctant Senior Researcher — Persona Findings | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/plugin-registry-trust.md`](archive/agent-findings-sessions-2026-05/plugin-registry-trust.md) | Plugin Registry Trust Mechanisms — Convenience-First Survey | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/quarkus-ecosystem.md`](archive/agent-findings-sessions-2026-05/quarkus-ecosystem.md) | Quarkus Extension Ecosystem — Opportunities for Shepard | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/quarkus-mcp-kadi-gaps.md`](archive/agent-findings-sessions-2026-05/quarkus-mcp-kadi-gaps.md) | Quarkus MCP, Kadi4Mat, and RDM Ecosystem Gaps — Findings | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/research-data-manager-debate.md`](archive/agent-findings-sessions-2026-05/research-data-manager-debate.md) | Research Data Manager — Cross-Agent Debate | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/research-data-manager-proposals.md`](archive/agent-findings-sessions-2026-05/research-data-manager-proposals.md) | Proposal 1: KIP1e — License Field on All Entities (Core, foundational) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/strategy-advisor-debate.md`](archive/agent-findings-sessions-2026-05/strategy-advisor-debate.md) | Strategy Advisor — Cross-Agent Debate | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/strategy-advisor-proposals.md`](archive/agent-findings-sessions-2026-05/strategy-advisor-proposals.md) | Strategy Advisor — Feature Proposals | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/timescaledb-schema-research.md`](archive/agent-findings-sessions-2026-05/timescaledb-schema-research.md) | TimescaleDB schema research — is the schema the MFFD ingest bottleneck? | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/ux-auditor-debate.md`](archive/agent-findings-sessions-2026-05/ux-auditor-debate.md) | UX Auditor Debate — Core Tech & UX Lens | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/ux-auditor-proposals.md`](archive/agent-findings-sessions-2026-05/ux-auditor-proposals.md) | UX Auditor — Feature Proposals | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings-sessions-2026-05/v1-compat-live-validation.md`](archive/agent-findings-sessions-2026-05/v1-compat-live-validation.md) | V1COMPAT.0 Phase 1 — live validation findings | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/agent-findings/predecessor-history-correction-2026-05-23.md`](archive/agent-findings/predecessor-history-correction-2026-05-23.md) | Predecessor history — standing correction | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/platform/68-v2-baseline-v1-compat-layer.md`](archive/platform/68-v2-baseline-v1-compat-layer.md) | V2 baseline + `/shepard/api/` as compat layer — Design (V2BASE) | 2026-05-23 | 2026-05-29 |
+| [`aidocs/archive/platform/86-ai-plugin-design.md`](archive/platform/86-ai-plugin-design.md) | `shepard-plugin-ai` — AI Platform Design (superseded) | 2026-05-24 | 2026-05-29 |
+| [`aidocs/archive/semantics/14-semantic-improvements.md`](archive/semantics/14-semantic-improvements.md) | Semantic Annotations — Improvements & Knowledge-Graph Path (DECOMMISSIONED) | 2026-05-24 | 2026-05-29 |

--- a/aidocs/ops/89-pre-mutation-snapshots.md
+++ b/aidocs/ops/89-pre-mutation-snapshots.md
@@ -1,0 +1,487 @@
+---
+stage: concept
+last-stage-change: 2026-05-30
+---
+
+# 89 — Pre-mutation snapshot contract
+
+**Status.** Concept. Design doc only; no implementation shipped yet.
+**Audience.** Backend contributors, instance admins, CI gate authors.
+**Relates to.** `aidocs/16 §PRE-MUT-SNAP` (backlog),
+`aidocs/data/41-snapshots-design.md` (snapshot architecture),
+`project_snapshot_boundaries.md` (memory: snapshots are human-gated
+boundaries), `feedback_referenced_data_infinite_retention.md`
+(kill-switch: referenced data is never a deletion candidate).
+
+---
+
+## 1. Motivation
+
+On 2026-05-23, during the MFFD TS-tapelaying-duplicate triage, an
+operator ran a spot-check before issuing a `DELETE` against three
+TimescaleDB containers (IDs 528098, 589657, 599903). The backend
+returned a 500 due to an unrelated decompression-limit issue
+(TSDB-DDL-1), so no data was lost. But the near-miss exposed a
+structural gap: the only safety net was an accidental backend error,
+not an intentional pre-mutation gate.
+
+The structural fix is to require a pre-mutation snapshot for every
+pathway that can destroy or irreversibly transform data. The snapshot
+is the last readable checkpoint before the change; if anything goes
+wrong after it, the operator has a restore path. Without it, "undo"
+means backups — slower, noisier, and scope-wider than needed.
+
+Two existing policies frame this contract:
+
+- **`project_snapshot_boundaries.md`** — "every larger transformation
+  gets a snapshot pair (before + after)." This doc operationalises
+  that rule for the specific class of mutations that modify persisted
+  data.
+- **`feedback_referenced_data_infinite_retention.md`** — "data that
+  has any live reference is never touched." This is the kill-switch
+  criterion: if a mutation pathway's scope analysis shows that every
+  candidate row has at least one live reference, the snapshot is still
+  taken (for audit), but the mutation itself is a no-op.
+
+The companion snapshot architecture is `aidocs/data/41`, which defines
+the logical snapshot model (entity revisions, `SnapshotEntry` map).
+This document is not a redesign of that model; it defines the **gate
+behaviour** — when a snapshot must be taken, what it must cover, and
+what happens when it fails.
+
+---
+
+## 2. Scope — mutation pathways that require a pre-mutation snapshot
+
+The following operation classes are in scope. Each one MUST take a
+pre-mutation snapshot of the affected scope before executing the
+first destructive operation.
+
+### 2.1 Orphan cleanup and purge operations
+
+- SM1 `purgeOrphans` — removes TimescaleDB rows, Mongo documents, and
+  Garage objects whose reference count has fallen to zero and whose
+  retention window has expired.
+- Manual orphan-wipe scripts under `examples/mffd-showcase/scripts/`
+  (e.g. the tapelaying-duplicate consolidation).
+- Any future `DELETE /v2/admin/storage/purge` endpoint (PRE-MUT-SNAP2
+  will add a REST surface for this).
+
+### 2.2 Schema and data migrations
+
+- Any Cypher migration file that mutates existing node properties or
+  deletes nodes / relationships (as opposed to purely additive `IF NOT
+  EXISTS` guards — those are exempt).
+- Any Flyway SQL migration that runs `UPDATE`, `DELETE`, or `ALTER
+  TABLE ... DROP COLUMN`.
+- The `MigrationsRunner` post-A1e propagation path — if a migration
+  fails, the snapshot taken before it ran is the rollback artefact.
+
+### 2.3 Storage rebalance and file-move operations
+
+- FS1e file-move (`POST /v2/admin/files/migrate`) — copies every
+  payload SHA from one FileStorage backend to another, then removes
+  the source objects.
+- Any future blob-rebalance or cross-bucket copy that removes source
+  objects after confirming the destination copy.
+
+### 2.4 Shepherded admin commands that touch data
+
+- `shepard-admin storage purge` — the CLI wrapper for SM1 purgeOrphans.
+- `shepard-admin storage migrate` — the CLI wrapper for FS1e.
+- Any future `shepard-admin <feature> reset` or `shepard-admin
+  <feature> wipe` variant.
+
+### 2.5 Out of scope (no pre-mutation snapshot required)
+
+- Purely additive writes (POST, create, append-only INSERT) — no
+  existing data is at risk.
+- Read-only operations (GET, SPARQL queries, export without delete).
+- Soft-delete status flips (DataObject status DRAFT → ARCHIVED) that
+  do not destroy payload bytes.
+- Provenance and secondary-write activity recording — these are
+  secondary effects; their own failure mode is handled by the
+  fire-and-forget rule (CLAUDE.md §"secondary writes are fire-and-forget").
+
+---
+
+## 3. Snapshot artefact shape
+
+### 3.1 The `:Snapshot` DataObject in `snapshots-system`
+
+Every pre-mutation snapshot is materialised as a `:Snapshot`
+DataObject inside a reserved collection named `snapshots-system`. The
+collection is created by a startup migration and is read-only for all
+roles except `instance-admin`. Normal users cannot write to, rename,
+or delete it.
+
+The `:Snapshot` DataObject carries the following fields in addition to
+the standard `appId + createdAt + createdBy`:
+
+```
+name:          string   — human-readable, e.g. "pre-purge-SM1-2026-05-30T14:22Z"
+description:   string   — machine-generated summary of the scope
+triggerKind:   enum     — one of: ADMIN_CLI | REST_ENDPOINT | MIGRATION | SCRIPT
+triggeredBy:   string   — userId or system principal (e.g. "shepard-migrations")
+scope:         JSON     — per-substrate scope descriptor (see §3.2)
+artefactHash:  string   — SHA-256 of the concatenated per-substrate artefact hashes
+retainUntil:   Instant  — createdAt + grace window (default 90 days)
+```
+
+PROV-O edges wired via `ActivityDAO.wireEdges()`:
+- `WAS_ASSOCIATED_WITH` → `:User` or system actor
+- `GENERATED` → the `:Snapshot` DataObject
+- `USED` → every entity whose `appId` appears in the scope descriptor
+
+The `artefactHash` field provides tamper-evidence at the snapshot
+boundary. The HMAC chain (`HmacChainService.stamp()`) extends this to
+the per-`:Activity` level.
+
+### 3.2 Scope descriptor (per-substrate)
+
+The `scope` field is a JSON object keyed by substrate name. Each value
+is a substrate-native description of what was captured.
+
+```json
+{
+  "timescaledb": {
+    "table": "timeseries_data_points",
+    "filter": "container_id IN (528098, 589657, 599903)",
+    "rowCount": 17843201,
+    "sizeBytes": 1073741824,
+    "snapshotTable": "snapshots.timeseries_data_points_20260530T142200Z",
+    "sha256": "a3f1..."
+  },
+  "neo4j": {
+    "rootAppIds": ["019...a", "019...b", "019...c"],
+    "nodeCount": 127,
+    "relationshipCount": 318,
+    "exportFile": "s3://snapshots/neo4j-20260530T142200Z.cypher.gz",
+    "sha256": "b7e2..."
+  },
+  "mongodb": {
+    "collections": ["timeseries_metadata"],
+    "filter": {"containerId": {"$in": [528098, 589657, 599903]}},
+    "documentCount": 42,
+    "snapshotCollection": "snapshots.timeseries_metadata_20260530T142200Z",
+    "sha256": "c9d4..."
+  },
+  "garage": {
+    "buckets": ["shepard-files"],
+    "objectKeys": ["sha256/a3f1...", "sha256/b7e2..."],
+    "objectCount": 7,
+    "sizeBytes": 204800,
+    "manifestFile": "s3://snapshots/garage-manifest-20260530T142200Z.json",
+    "sha256": "d5f6..."
+  }
+}
+```
+
+Substrates not covered by the mutation scope are omitted from the
+descriptor. A migration that only touches Neo4j will have a
+`neo4j`-only scope descriptor.
+
+### 3.3 Per-substrate snapshot primitives
+
+These are the implementation targets for PRE-MUT-SNAP2.
+
+**TimescaleDB.** Create a parallel table in a dedicated `snapshots`
+schema:
+
+```sql
+CREATE TABLE IF NOT EXISTS snapshots.<table>_<session>
+  AS SELECT * FROM <table> WHERE <scope_filter>;
+ALTER TABLE snapshots.<table>_<session> SET (autovacuum_enabled = false);
+```
+
+The session identifier is a UTC timestamp slug to avoid collisions.
+The snapshot table is read-only by construction (no triggers). After
+the grace window, `DROP TABLE snapshots.<table>_<session>` runs as
+part of the retention sweep.
+
+**Neo4j.** Use `apoc.export.cypher.query(cypher, filePath, config)`
+to write the subgraph defined by the scope to a Garage object:
+
+```cypher
+CALL apoc.export.cypher.query(
+  "MATCH (n) WHERE n.appId IN $appIds OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m",
+  $exportUri,
+  {format: 'plain', useOptimizations: {type: 'UNWIND_BATCH', unwindBatchSize: 100}}
+) YIELD nodes, relationships, properties
+```
+
+The `$exportUri` is a `s3://snapshots/neo4j-<session>.cypher.gz`
+path. The SHA-256 of the gzipped file is the `sha256` field.
+
+**MongoDB.** Use the `$out` aggregation stage to project into a
+snapshot collection:
+
+```javascript
+db.getCollection(coll).aggregate([
+  { $match: scopeFilter },
+  { $out: `snapshots.${coll}_${session}` }
+])
+```
+
+Snapshot collections are in the same MongoDB database to avoid a
+cross-database `$out` restriction.
+
+**Garage / S3.** For file payloads, the snapshot is a manifest JSON
+listing every object key + expected SHA-256, uploaded to
+`s3://snapshots/garage-manifest-<session>.json`. The actual objects
+are not copied (they are content-addressed by SHA-256 and are the
+primary source of truth). The manifest is the restore anchor: if a
+post-mutation operator needs to verify that the right objects are
+still in Garage, they compare the current bucket contents against the
+manifest. A full copy is only needed if objects were deleted as part
+of the mutation (e.g. FS1e after confirming destination copy).
+
+### 3.4 SnapshotResult contract
+
+Each substrate primitive returns a structured result:
+
+```java
+record SnapshotResult(
+    String substrate,       // "timescaledb" | "neo4j" | "mongodb" | "garage"
+    String scope,           // human-readable scope summary
+    long   rowCount,        // rows / nodes / documents / objects captured
+    long   sizeBytes,       // uncompressed size estimate
+    String artefactUri,     // where the snapshot artefact lives
+    String sha256,          // SHA-256 of the artefact
+    long   durationMs       // wall-clock time to take the snapshot
+)
+```
+
+The per-substrate results are aggregated by `SnapshotService` into the
+`scope` JSON and the combined `artefactHash`.
+
+---
+
+## 4. Retention policy
+
+### 4.1 Default grace window: 90 days
+
+Pre-mutation snapshots are retained for 90 days after creation. This
+covers the typical post-deployment observation window during which an
+operator might notice a data anomaly and need to restore from the
+pre-mutation state.
+
+The window is configurable at runtime via the `:SnapshotConfig`
+singleton:
+
+```
+GET  /v2/admin/snapshots/config
+PATCH /v2/admin/snapshots/config
+  body: { "graceWindowDays": 180 }
+```
+
+The deploy-time default is `shepard.v2.snapshots.grace-window-days=90`
+in `application.properties`. The runtime value from `:SnapshotConfig`
+takes precedence per the admin-configurable-at-runtime rule
+(CLAUDE.md §"Always: surface operator knobs in the admin config").
+
+Individual snapshots can be pinned indefinitely by setting their
+`retainUntil` to null:
+
+```
+PATCH /v2/snapshots/{appId}
+  body: { "retainUntil": null }
+```
+
+Pinned snapshots are exempt from the grace-window sweep. Only
+`instance-admin` can pin or unpin.
+
+### 4.2 Retention sweep
+
+A scheduled task (default: daily, 03:00 UTC) scans for snapshots
+where `retainUntil < now()` and issues the substrate-native drop
+operations in reverse-dependency order (Garage manifest → Mongo
+snapshot collections → TimescaleDB snapshot tables → Neo4j export
+files). The `:Snapshot` DataObject itself is soft-deleted after all
+artefacts are removed.
+
+The sweep is itself governed by the `--no-snapshot` escape hatch rule:
+the sweep DOES NOT take a snapshot before dropping old snapshots. Old
+snapshot artefacts are by definition already the final state of the
+data at the time they were taken; dropping them after the grace window
+is an intentional expiry, not a destructive mutation.
+
+### 4.3 `--no-snapshot` escape hatch
+
+Any mutation pathway can be invoked with `--no-snapshot` (CLI) or
+`?skipSnapshot=true` (REST admin endpoint, requires `instance-admin`).
+When this flag is present, the mutation proceeds without a pre-mutation
+snapshot and a `WARN` log entry is emitted:
+
+```
+WARN pre-mutation snapshot skipped by operator request;
+     mutation kind=SM1_PURGE scope=containers:[528098] user=fkrebs
+```
+
+The `--no-snapshot` flag is an operator-controlled bypass, not a
+silent default. Using it in a script without explicit documentation
+in the script's comment header is a code-review finding.
+
+---
+
+## 5. Failure behaviour — snapshot fails → abort the mutation
+
+If the pre-mutation snapshot fails for any substrate in the scope, the
+mutation MUST NOT proceed. This is not a best-effort secondary write;
+it is a hard gate.
+
+The failure behaviour is:
+
+1. `SnapshotService.takePreMutationSnapshot(scope)` throws
+   `SnapshotFailedException` if any substrate primitive fails.
+2. The calling mutation pathway catches `SnapshotFailedException`,
+   logs the error with full scope detail, and returns an error to
+   the caller (HTTP 500 with RFC 7807 body, or a non-zero exit code
+   from the CLI).
+3. No mutation operation (DELETE, UPDATE, DROP) is issued to any
+   substrate. The system remains in its pre-mutation state.
+4. The partially-created snapshot artefacts (if any substrates
+   succeeded before the failure) are cleaned up by a background
+   garbage-collect pass within 5 minutes.
+
+The rationale: a partial snapshot is worse than no snapshot, because
+it may give the operator false confidence that the scope is covered.
+The clean failure posture is "no snapshot, no mutation."
+
+### 5.1 Transient vs permanent failures
+
+`SnapshotService` distinguishes between transient failures (network
+timeout to Garage, temporary TimescaleDB lock contention) and
+permanent failures (insufficient disk space, APOC not installed). For
+transient failures, a single automatic retry is attempted after a 5-
+second back-off. If the retry also fails, the exception is propagated
+as in the main flow above.
+
+### 5.2 What "snapshot fails" looks like to an operator
+
+The operator sees a clear error from the CLI or REST response:
+
+```
+ERROR: Pre-mutation snapshot failed for scope containers:[528098, 589657, 599903].
+Substrate: timescaledb
+Reason: INSERT INTO snapshots.timeseries_data_points_... failed —
+  no space left on device (available: 2.1 GB, required estimate: 8.4 GB)
+Mutation aborted. No data has been modified.
+To bypass this gate (DANGEROUS): re-run with --no-snapshot and document why.
+```
+
+The error message always includes:
+- which substrate failed
+- the human-readable reason
+- explicit confirmation that no data was modified
+- the `--no-snapshot` escape hatch and a warning that it is dangerous
+
+---
+
+## 6. Cross-substrate restore order
+
+When restoring from a pre-mutation snapshot, substrates must be
+restored in the following order to preserve referential integrity:
+
+1. **Neo4j** — restore the subgraph first. Neo4j is the primary
+   identity and relationship substrate. References in TimescaleDB,
+   MongoDB, and Garage are keyed to Neo4j entity IDs or `appId`
+   values. Restoring Neo4j first means that subsequent substrate
+   restores can validate foreign-key consistency.
+
+2. **TimescaleDB** — restore the time-series data. TimescaleDB rows
+   reference `container_id` values that must exist in Neo4j (which
+   was just restored in step 1).
+
+3. **MongoDB** — restore the document collections. Mongo documents
+   reference `containerId` values in the same pattern as TimescaleDB.
+
+4. **Garage / S3** — verify or restore file objects. For mutations
+   that deleted source objects (e.g. FS1e), copy back from the
+   destination bucket or from tape. For mutations that did not delete
+   source objects, verify current object integrity against the
+   pre-mutation manifest.
+
+The restore order is documented in the operator runbook (PRE-MUT-SNAP4
+target: `docs/admin/runbooks/rollback-from-snapshot.md`).
+
+If a partial restore is detected (Neo4j restored but TimescaleDB
+restore failed), the system emits a `WARN` and leaves the instance in
+a known-partially-restored state rather than attempting a rollback of
+the already-applied Neo4j restore. The operator must complete the
+remaining substrates manually, following the runbook.
+
+---
+
+## 7. Implementation plan
+
+This section summarises the follow-on work items from `aidocs/16
+§PRE-MUT-SNAP`. The present doc (PRE-MUT-SNAP1) is the contract
+definition; the items below build the mechanism.
+
+| ID | Slice | Deliverable |
+|---|---|---|
+| **PRE-MUT-SNAP2** | Substrate primitives | `de.dlr.shepard.ops.SnapshotService` Java class implementing the per-substrate snapshot operations described in §3.3. REST surface: `POST /v2/admin/snapshots` (admin-gated, `instance-admin` role). |
+| **PRE-MUT-SNAP3** | Gate wiring | Wire `SnapshotService.takePreMutationSnapshot()` into every mutation pathway listed in §2: SM1 purgeOrphans, FS1e file-move, migration runner, `shepard-admin` data-mutating commands, and the MFFD showcase orphan-wipe scripts. Default: gate on. |
+| **PRE-MUT-SNAP4** | Rollback runbook | `docs/admin/runbooks/rollback-from-snapshot.md`. Single-page operator procedure per the `feedback_admin_runbooks_pattern.md` contract: numbered steps, host indicators, expected stdout, end-state verification. Includes the §6 restore order. |
+| **PRE-MUT-SNAP5** | Acceptance test | Apply the mechanism to the deferred MFFD-tapelaying consolidation (528098 keep, 589657 + 599903 delete). This is the end-to-end acceptance test: snapshot-first, then DELETE, then confirm the snapshot artefact is navigable via `GET /v2/snapshots/{appId}`. |
+
+PRE-MUT-SNAP2 is the unblocking dependency. PRE-MUT-SNAP3, PRE-MUT-SNAP4,
+and PRE-MUT-SNAP5 can proceed in parallel once PRE-MUT-SNAP2 ships.
+
+### 7.1 `:SnapshotConfig` singleton
+
+PRE-MUT-SNAP2 ships a `:SnapshotConfig` Neo4j singleton with the
+following runtime-mutable fields:
+
+```
+graceWindowDays:    int      (default 90)
+sweepScheduleCron:  string   (default "0 3 * * *")
+autoRetryOnTransientFailure: boolean (default true)
+retryBackoffSeconds: int     (default 5)
+```
+
+Seeded from `application.properties` keys in the
+`shepard.v2.snapshots.*` namespace. Admin REST surface:
+`GET/PATCH /v2/admin/snapshots/config`.
+
+### 7.2 `snapshots-system` collection bootstrap
+
+The `snapshots-system` collection is created by a Neo4j migration
+(`V(N+1)__Bootstrap_snapshots_system_collection.cypher`) on first
+startup. It is a singleton: the migration is idempotent
+(`MERGE ... ON CREATE SET ...`). The collection is marked with a
+`systemCollection: true` property; the UI and API gate all
+destructive operations behind `instance-admin`.
+
+The `snapshots` PostgreSQL/TimescaleDB schema is created by a Flyway
+migration (`V(N+1)__Create_snapshots_schema.sql`):
+
+```sql
+CREATE SCHEMA IF NOT EXISTS snapshots;
+REVOKE CREATE ON SCHEMA snapshots FROM PUBLIC;
+GRANT ALL ON SCHEMA snapshots TO shepard_admin;
+```
+
+---
+
+## 8. Cross-references
+
+- **`aidocs/data/41-snapshots-design.md`** — the snapshot entity model
+  (`:Snapshot`, `:SnapshotEntry`, `revision` field on
+  `VersionableEntity`). This doc depends on V2b being shipped before
+  PRE-MUT-SNAP2 can build on it.
+- **`aidocs/16 §PRE-MUT-SNAP`** — the backlog rows for the full
+  mechanism (PRE-MUT-SNAP1 through PRE-MUT-SNAP5).
+- **`aidocs/16 §TSDB-DDL-3`** — the specific first acceptance test:
+  the tapelaying-duplicate consolidation that should go through the
+  new path once PRE-MUT-SNAP1..4 are ready.
+- **`docs/admin/runbooks/orphan-retention-policy.md`** — the SM1
+  orphan-retention runbook; the purge pathway described there is one
+  of the gates PRE-MUT-SNAP3 will wire into.
+- **CLAUDE.md §"Always: surface operator knobs in the admin config"**
+  — the `:SnapshotConfig` singleton and admin REST surface pattern.
+- **CLAUDE.md §"Always: secondary writes are fire-and-forget"** — note
+  that the pre-mutation snapshot is NOT a secondary write; it is a hard
+  gate on the primary mutation. The snapshot service must NOT be
+  wrapped in a try/catch that continues on failure.


### PR DESCRIPTION
## Summary

- Adds `aidocs/ops/89-pre-mutation-snapshots.md` (`stage: concept`) defining the pre-mutation snapshot gate contract, satisfying the PRE-MUT-SNAP1 acceptance criterion from `aidocs/16-dispatcher-backlog.md`
- Defines (a) which mutation pathways require a snapshot (§2), (b) the snapshot artefact shape including per-substrate primitives and PROV-O edges (§3), (c) the 90-day default retention policy and runtime-configurable `:SnapshotConfig` knob (§4), (d) hard abort-on-failure semantics — snapshot fails → mutation does not proceed (§5)
- Also covers cross-substrate restore order (Neo4j → TimescaleDB → Mongo → Garage, §6) and the implementation roadmap pointing to PRE-MUT-SNAP2..5 (§7)
- Regenerates `aidocs/01-doc-stage-index.md` (395 docs total, +1)

## Motivation

Triggered by the 2026-05-23 MFFD TS-tapelaying-duplicate triage (containers 528098/589657/599903): the REST DELETE 500'd before any data was lost, but the only safety net was an accidental backend error, not an intentional gate. This doc operationalises the `project_snapshot_boundaries.md` rule ("every larger transformation gets a snapshot pair") for the specific class of mutations that destroy or irreversibly transform persisted data.

## Test plan

- [ ] Confirm `aidocs/ops/89-pre-mutation-snapshots.md` exists with valid YAML front-matter `stage: concept`
- [ ] Confirm `aidocs/01-doc-stage-index.md` includes the new doc
- [ ] No backend or frontend tests needed (pure documentation PR)
- [ ] Follow-on: PRE-MUT-SNAP2 (substrate primitives) will be the first implementation PR that must comply with the contract defined here

https://claude.ai/code/session_01Gmd5e4VvDXNpxDk343icH7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmd5e4VvDXNpxDk343icH7)_