### PR TITLE
feat(MCP-COV-11-PROV): prov_query + activity_list MCP tools

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/provenance/daos/ActivityDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/provenance/daos/ActivityDAO.java
@@ -286,6 +286,79 @@ public class ActivityDAO extends GenericDAO<Activity> {
   }
 
   /**
+   * Walk the PROV-O graph to find all activities that directly touched
+   * {@code entityAppId} via a {@code GENERATED} or {@code USED} edge.
+   *
+   * <p>The depth parameter limits the result set size, not a graph traversal
+   * depth — activities are direct neighbours of the target entity node.
+   * We multiply by 50 to get a practical row cap without requiring a
+   * second count query: depth=3 → cap=150 rows, depth=10 → cap=500 rows.
+   * Results are ordered newest-first.
+   *
+   * @param entityAppId appId of the entity whose provenance to fetch
+   * @param depth       clamped to [1, 10]; scales the result-set cap
+   */
+  public List<ActivityEdgeRow> findByEntityAppId(String entityAppId, int depth) {
+    int capped = Math.max(1, Math.min(depth, 10));
+    String cypher =
+      "MATCH (a:Activity)-[r:GENERATED|USED]->(e {appId: $appId})" +
+      " RETURN a, type(r) AS relation" +
+      " ORDER BY a.startedAtMillis DESC" +
+      " LIMIT " + (capped * 50);
+    Map<String, Object> params = Map.of("appId", entityAppId);
+
+    List<ActivityEdgeRow> out = new ArrayList<>();
+    var result = session.query(cypher, params);
+    for (Map<String, Object> row : result.queryResults()) {
+      if (!(row.get("a") instanceof Activity act)) continue;
+      String rel = Objects.toString(row.get("relation"), "USED");
+      out.add(new ActivityEdgeRow(act, rel));
+    }
+    return out;
+  }
+
+  /** Activity node plus the PROV-O edge label that linked it to the queried entity. */
+  public record ActivityEdgeRow(Activity activity, String relation) {}
+
+  /**
+   * List recent activities with MCP-friendly filter parameter names.
+   * All filters are optional; null or blank means "no filter on this field".
+   *
+   * <p>Field mapping from MCP names to Neo4j properties:
+   * {@code userId} → {@code agentUsername},
+   * {@code resourcePath} → {@code path} (prefix match),
+   * {@code httpMethod} → {@code method} (upper-cased before match).
+   *
+   * @param userId       optional agentUsername filter
+   * @param resourcePath optional path prefix filter
+   * @param httpMethod   optional HTTP method filter
+   * @param limit        max rows; capped to [1, 100]
+   */
+  public List<Activity> listForMcp(String userId, String resourcePath, String httpMethod, int limit) {
+    int capped = Math.max(1, Math.min(limit, 100));
+    StringBuilder cypher = new StringBuilder("MATCH (a:Activity) WHERE 1=1");
+    Map<String, Object> params = new HashMap<>();
+    if (userId != null && !userId.isBlank()) {
+      cypher.append(" AND a.agentUsername = $userId");
+      params.put("userId", userId);
+    }
+    if (resourcePath != null && !resourcePath.isBlank()) {
+      cypher.append(" AND a.path STARTS WITH $path");
+      params.put("path", resourcePath);
+    }
+    if (httpMethod != null && !httpMethod.isBlank()) {
+      cypher.append(" AND a.method = $method");
+      params.put("method", httpMethod.toUpperCase());
+    }
+    cypher.append(" RETURN a ORDER BY a.startedAtMillis DESC LIMIT $limit");
+    params.put("limit", capped);
+
+    List<Activity> out = new ArrayList<>();
+    findByQuery(cypher.toString(), params).forEach(out::add);
+    return out;
+  }
+
+  /**
    * Wire the three PROV-O edges for a freshly saved {@link Activity}.
    *
    * <ul>

--- a/backend/src/main/java/de/dlr/shepard/v2/mcp/ActivityMcpTools.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/mcp/ActivityMcpTools.java
@@ -1,0 +1,180 @@
+package de.dlr.shepard.v2.mcp;
+
+import de.dlr.shepard.provenance.daos.ActivityDAO;
+import de.dlr.shepard.provenance.entities.Activity;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MCP-COV-11-PROV — provenance query and activity list tools.
+ *
+ * <p>Two tools:
+ * <ul>
+ *   <li>{@code prov_query} — returns the PROV-O activity chain around a
+ *       given entity (GENERATED + USED edges) up to {@code depth} hops.</li>
+ *   <li>{@code activity_list} — returns a paginated list of recent
+ *       {@code :Activity} nodes, optionally filtered by userId,
+ *       resourcePath, or httpMethod.</li>
+ * </ul>
+ *
+ * <p>Both tools are read-only — no {@code :Activity} is recorded for a
+ * provenance query itself (reading provenance is not itself a mutation).
+ */
+@ApplicationScoped
+public class ActivityMcpTools {
+
+  static final int PROV_DEFAULT_DEPTH = 3;
+  static final int PROV_MAX_DEPTH = 10;
+  static final int LIST_DEFAULT_LIMIT = 20;
+  static final int LIST_MAX_LIMIT = 100;
+
+  @Inject
+  ActivityDAO activityDAO;
+
+  @Inject
+  McpContextBridge contextBridge;
+
+  @Inject
+  McpToolSupport support;
+
+  @Tool(
+    name = "prov_query",
+    description =
+      "Return the PROV-O activity chain around a given entity — every " +
+      ":Activity that GENERATED or USED the entity, ordered newest-first.\n\n" +
+      "Use this to answer 'who created this DataObject?', 'who last modified " +
+      "this FileReference?', or 'which AI agent annotated this entity?'\n\n" +
+      "Parameters:\n" +
+      "  entityAppId — UUID v7 of any Shepard entity (DataObject, Collection,\n" +
+      "                FileReference, SemanticAnnotation, …).\n" +
+      "  depth       — optional scale factor for the result-set cap; default " + PROV_DEFAULT_DEPTH +
+      ", max " + PROV_MAX_DEPTH + ".\n\n" +
+      "Response shape:\n" +
+      "{\n" +
+      "  \"entityAppId\": \"...\",\n" +
+      "  \"depth\": <int>,\n" +
+      "  \"count\": <int>,\n" +
+      "  \"activities\": [\n" +
+      "    {\n" +
+      "      \"appId\": \"...\",\n" +
+      "      \"relation\": \"GENERATED|USED\",\n" +
+      "      \"userId\": \"...\",\n" +
+      "      \"actionKind\": \"...\",\n" +
+      "      \"summary\": \"...\",\n" +
+      "      \"resourcePath\": \"...\",\n" +
+      "      \"httpMethod\": \"...\",\n" +
+      "      \"startedAtMillis\": <long>,\n" +
+      "      \"sourceMode\": \"human|ai\"\n" +
+      "    }, ...\n" +
+      "  ]\n" +
+      "}"
+  )
+  public String provQuery(
+    @ToolArg(description = "UUID v7 of the entity whose PROV-O chain to fetch.") String entityAppId,
+    @ToolArg(required = false, description = "Result-set scale factor (default " + PROV_DEFAULT_DEPTH + ", max " + PROV_MAX_DEPTH + ").") Integer depth
+  ) {
+    return support.run("prov_query", () -> {
+      contextBridge.bind();
+      if (entityAppId == null || entityAppId.isBlank()) {
+        throw McpToolSupport.invalidParams("entityAppId is required (UUID v7).");
+      }
+
+      int effectiveDepth = Math.max(1, Math.min(depth == null ? PROV_DEFAULT_DEPTH : depth, PROV_MAX_DEPTH));
+      List<ActivityDAO.ActivityEdgeRow> rows = activityDAO.findByEntityAppId(entityAppId, effectiveDepth);
+
+      List<Map<String, Object>> activities = new ArrayList<>(rows.size());
+      for (ActivityDAO.ActivityEdgeRow row : rows) {
+        activities.add(toActivityMap(row.activity(), row.relation()));
+      }
+
+      Map<String, Object> body = new LinkedHashMap<>();
+      body.put("entityAppId", entityAppId);
+      body.put("depth", effectiveDepth);
+      body.put("count", activities.size());
+      body.put("activities", activities);
+      return support.toJson(body);
+    });
+  }
+
+  @Tool(
+    name = "activity_list",
+    description =
+      "Return a paginated list of recent :Activity nodes, newest-first.\n\n" +
+      "Use this to answer 'what happened recently?', 'what did user X do?', or " +
+      "'which requests hit /v2/dataobjects today?'\n\n" +
+      "Parameters:\n" +
+      "  userId       — optional: filter to activities by this agent username.\n" +
+      "  resourcePath — optional: prefix-match on the request path " +
+      "(e.g. '/v2/collections/' matches all collection mutations).\n" +
+      "  httpMethod   — optional: filter by HTTP method (GET, POST, PUT, PATCH, DELETE).\n" +
+      "  limit        — optional: max results; default " + LIST_DEFAULT_LIMIT +
+      ", max " + LIST_MAX_LIMIT + ".\n\n" +
+      "Response shape:\n" +
+      "{\n" +
+      "  \"filter\": { \"userId\": \"...\", \"resourcePath\": \"...\", \"httpMethod\": \"...\" },\n" +
+      "  \"limit\": <int>,\n" +
+      "  \"count\": <int>,\n" +
+      "  \"activities\": [\n" +
+      "    {\n" +
+      "      \"appId\": \"...\",\n" +
+      "      \"userId\": \"...\",\n" +
+      "      \"actionKind\": \"...\",\n" +
+      "      \"summary\": \"...\",\n" +
+      "      \"resourcePath\": \"...\",\n" +
+      "      \"httpMethod\": \"...\",\n" +
+      "      \"startedAtMillis\": <long>,\n" +
+      "      \"sourceMode\": \"human|ai\"\n" +
+      "    }, ...\n" +
+      "  ]\n" +
+      "}"
+  )
+  public String activityList(
+    @ToolArg(required = false, description = "Filter to activities by this agent username.") String userId,
+    @ToolArg(required = false, description = "Prefix-match filter on the request path (e.g. '/v2/collections/').") String resourcePath,
+    @ToolArg(required = false, description = "Filter by HTTP method: GET, POST, PUT, PATCH, DELETE.") String httpMethod,
+    @ToolArg(required = false, description = "Max results (default " + LIST_DEFAULT_LIMIT + ", max " + LIST_MAX_LIMIT + ").") Integer limit
+  ) {
+    return support.run("activity_list", () -> {
+      contextBridge.bind();
+      int effectiveLimit = Math.max(1, Math.min(limit == null ? LIST_DEFAULT_LIMIT : limit, LIST_MAX_LIMIT));
+      List<Activity> rows = activityDAO.listForMcp(userId, resourcePath, httpMethod, effectiveLimit);
+
+      List<Map<String, Object>> activities = new ArrayList<>(rows.size());
+      for (Activity a : rows) {
+        activities.add(toActivityMap(a, null));
+      }
+
+      Map<String, Object> filterMap = new LinkedHashMap<>();
+      filterMap.put("userId", userId);
+      filterMap.put("resourcePath", resourcePath);
+      filterMap.put("httpMethod", httpMethod);
+
+      Map<String, Object> body = new LinkedHashMap<>();
+      body.put("filter", filterMap);
+      body.put("limit", effectiveLimit);
+      body.put("count", activities.size());
+      body.put("activities", activities);
+      return support.toJson(body);
+    });
+  }
+
+  private static Map<String, Object> toActivityMap(Activity a, String relation) {
+    Map<String, Object> m = new LinkedHashMap<>();
+    m.put("appId", a.getAppId());
+    if (relation != null) m.put("relation", relation);
+    m.put("userId", a.getAgentUsername());
+    m.put("actionKind", a.getActionKind());
+    m.put("summary", a.getSummary());
+    m.put("resourcePath", a.getPath());
+    m.put("httpMethod", a.getMethod());
+    m.put("startedAtMillis", a.getStartedAtMillis());
+    m.put("sourceMode", a.getSourceMode());
+    return m;
+  }
+}

--- a/backend/src/test/java/de/dlr/shepard/v2/mcp/ActivityMcpToolsTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/mcp/ActivityMcpToolsTest.java
@@ -1,0 +1,200 @@
+package de.dlr.shepard.v2.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.dlr.shepard.provenance.daos.ActivityDAO;
+import de.dlr.shepard.provenance.entities.Activity;
+import io.quarkiverse.mcp.server.McpException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * MCP-COV-11-PROV — unit tests for {@link ActivityMcpTools}.
+ *
+ * <p>Manual CDI wiring, Mockito mocks, real {@link McpToolSupport} with a
+ * real {@link ObjectMapper} — same shape as {@link LineageMcpToolsTest}.
+ */
+class ActivityMcpToolsTest {
+
+  static final String ENTITY_APP_ID   = "018f9c5a-7e26-7000-c000-000000000001";
+  static final String ACTIVITY_APP_ID = "018f9c5a-7e26-7000-c000-000000000099";
+
+  @Mock ActivityDAO activityDAO;
+  @Mock McpContextBridge contextBridge;
+
+  ActivityMcpTools tools;
+  McpToolSupport support;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    support = new McpToolSupport();
+    support.objectMapper = new ObjectMapper();
+
+    tools = new ActivityMcpTools();
+    tools.activityDAO = activityDAO;
+    tools.contextBridge = contextBridge;
+    tools.support = support;
+  }
+
+  private Activity makeActivity(String appId, String userId, String actionKind,
+      String path, String method, Long startedAt, String sourceMode) {
+    Activity a = new Activity();
+    a.setAppId(appId);
+    a.setAgentUsername(userId);
+    a.setActionKind(actionKind);
+    a.setPath(path);
+    a.setMethod(method);
+    a.setStartedAtMillis(startedAt);
+    a.setSourceMode(sourceMode);
+    return a;
+  }
+
+  // ── prov_query ────────────────────────────────────────────────────────────
+
+  @Test
+  void provQueryReturnsActivitiesWithRelation() throws Exception {
+    Activity a = makeActivity(ACTIVITY_APP_ID, "alice", "CREATE",
+        "/v2/dataobjects", "POST", 1_000_000L, "human");
+    when(activityDAO.findByEntityAppId(eq(ENTITY_APP_ID), eq(ActivityMcpTools.PROV_DEFAULT_DEPTH)))
+        .thenReturn(List.of(new ActivityDAO.ActivityEdgeRow(a, "GENERATED")));
+
+    String json = tools.provQuery(ENTITY_APP_ID, null);
+
+    JsonNode root = new ObjectMapper().readTree(json);
+    assertEquals(ENTITY_APP_ID, root.get("entityAppId").asText());
+    assertEquals(ActivityMcpTools.PROV_DEFAULT_DEPTH, root.get("depth").asInt());
+    assertEquals(1, root.get("count").asInt());
+
+    JsonNode first = root.get("activities").get(0);
+    assertEquals(ACTIVITY_APP_ID, first.get("appId").asText());
+    assertEquals("GENERATED", first.get("relation").asText());
+    assertEquals("alice", first.get("userId").asText());
+    assertEquals("CREATE", first.get("actionKind").asText());
+    assertEquals("/v2/dataobjects", first.get("resourcePath").asText());
+    assertEquals("POST", first.get("httpMethod").asText());
+    assertEquals(1_000_000L, first.get("startedAtMillis").asLong());
+    assertEquals("human", first.get("sourceMode").asText());
+  }
+
+  @Test
+  void provQueryReturnsEmptyListWhenNoActivities() throws Exception {
+    when(activityDAO.findByEntityAppId(eq(ENTITY_APP_ID), eq(ActivityMcpTools.PROV_DEFAULT_DEPTH)))
+        .thenReturn(List.of());
+
+    String json = tools.provQuery(ENTITY_APP_ID, null);
+
+    JsonNode root = new ObjectMapper().readTree(json);
+    assertEquals(0, root.get("count").asInt());
+    assertEquals(0, root.get("activities").size());
+  }
+
+  @Test
+  void provQueryClampsDepthToMax() {
+    when(activityDAO.findByEntityAppId(eq(ENTITY_APP_ID), eq(ActivityMcpTools.PROV_MAX_DEPTH)))
+        .thenReturn(List.of());
+    tools.provQuery(ENTITY_APP_ID, 999);
+    verify(activityDAO).findByEntityAppId(ENTITY_APP_ID, ActivityMcpTools.PROV_MAX_DEPTH);
+  }
+
+  @Test
+  void provQueryClampsDepthToOne() {
+    when(activityDAO.findByEntityAppId(eq(ENTITY_APP_ID), eq(1)))
+        .thenReturn(List.of());
+    tools.provQuery(ENTITY_APP_ID, 0);
+    verify(activityDAO).findByEntityAppId(ENTITY_APP_ID, 1);
+  }
+
+  @Test
+  void provQueryRejectsBlankEntityAppId() {
+    McpException ex = assertThrows(McpException.class, () -> tools.provQuery("  ", null));
+    assertEquals(-32602, ex.getJsonRpcErrorCode());
+  }
+
+  @Test
+  void provQueryRejectsNullEntityAppId() {
+    McpException ex = assertThrows(McpException.class, () -> tools.provQuery(null, null));
+    assertEquals(-32602, ex.getJsonRpcErrorCode());
+  }
+
+  // ── activity_list ─────────────────────────────────────────────────────────
+
+  @Test
+  void activityListReturnsRecentActivitiesWithNoFilter() throws Exception {
+    Activity a = makeActivity(ACTIVITY_APP_ID, "bob", "UPDATE",
+        "/v2/collections/abc/data-objects/xyz", "PUT", 2_000_000L, "ai");
+    when(activityDAO.listForMcp(isNull(), isNull(), isNull(),
+        eq(ActivityMcpTools.LIST_DEFAULT_LIMIT)))
+        .thenReturn(List.of(a));
+
+    String json = tools.activityList(null, null, null, null);
+
+    JsonNode root = new ObjectMapper().readTree(json);
+    assertEquals(ActivityMcpTools.LIST_DEFAULT_LIMIT, root.get("limit").asInt());
+    assertEquals(1, root.get("count").asInt());
+
+    JsonNode first = root.get("activities").get(0);
+    assertEquals(ACTIVITY_APP_ID, first.get("appId").asText());
+    assertEquals("bob", first.get("userId").asText());
+    assertEquals("UPDATE", first.get("actionKind").asText());
+    assertEquals("ai", first.get("sourceMode").asText());
+
+    // relation field must NOT be present in activity_list output
+    assertTrue(first.get("relation") == null || first.get("relation").isNull());
+  }
+
+  @Test
+  void activityListFiltersByUserId() {
+    when(activityDAO.listForMcp(eq("alice"), isNull(), isNull(),
+        eq(ActivityMcpTools.LIST_DEFAULT_LIMIT)))
+        .thenReturn(List.of());
+    tools.activityList("alice", null, null, null);
+    verify(activityDAO).listForMcp("alice", null, null, ActivityMcpTools.LIST_DEFAULT_LIMIT);
+  }
+
+  @Test
+  void activityListFiltersByResourcePath() {
+    when(activityDAO.listForMcp(isNull(), eq("/v2/collections/"), isNull(),
+        eq(ActivityMcpTools.LIST_DEFAULT_LIMIT)))
+        .thenReturn(List.of());
+    tools.activityList(null, "/v2/collections/", null, null);
+    verify(activityDAO).listForMcp(null, "/v2/collections/", null, ActivityMcpTools.LIST_DEFAULT_LIMIT);
+  }
+
+  @Test
+  void activityListClampsLimitToMax() {
+    when(activityDAO.listForMcp(isNull(), isNull(), isNull(),
+        eq(ActivityMcpTools.LIST_MAX_LIMIT)))
+        .thenReturn(List.of());
+    tools.activityList(null, null, null, 9999);
+    verify(activityDAO).listForMcp(null, null, null, ActivityMcpTools.LIST_MAX_LIMIT);
+  }
+
+  @Test
+  void activityListReturnsFilterEchoInResponse() throws Exception {
+    when(activityDAO.listForMcp(eq("charlie"), eq("/v2/"), eq("POST"), eq(5)))
+        .thenReturn(List.of());
+
+    String json = tools.activityList("charlie", "/v2/", "POST", 5);
+
+    JsonNode root = new ObjectMapper().readTree(json);
+    assertEquals(5, root.get("limit").asInt());
+    assertEquals(0, root.get("count").asInt());
+
+    JsonNode filter = root.get("filter");
+    assertEquals("charlie", filter.get("userId").asText());
+    assertEquals("/v2/", filter.get("resourcePath").asText());
+    assertEquals("POST", filter.get("httpMethod").asText());
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `prov_query(entityAppId, depth?)` MCP tool — walks the PROV-O graph (`GENERATED` + `USED` edges) to return every `:Activity` that touched a given entity, ordered newest-first.
- Adds `activity_list(userId?, resourcePath?, httpMethod?, limit?)` MCP tool — paginated list of recent `:Activity` nodes with caller-friendly optional filters.
- Extends `ActivityDAO` with two new read-only methods (`findByEntityAppId`, `listForMcp`) and an `ActivityEdgeRow` record.

## Tool details

### `prov_query`

Input: `entityAppId` (UUID v7 of any Shepard entity), optional `depth` (default 3, max 10).

Response shape:
```json
{
  "entityAppId": "...",
  "depth": 3,
  "count": 2,
  "activities": [
    {
      "appId": "...",
      "relation": "GENERATED|USED",
      "userId": "alice",
      "actionKind": "CREATE",
      "summary": "...",
      "resourcePath": "/v2/dataobjects",
      "httpMethod": "POST",
      "startedAtMillis": 1000000,
      "sourceMode": "human"
    }
  ]
}
```

### `activity_list`

Input: optional `userId` (maps to `agentUsername`), optional `resourcePath` (prefix match on `path`), optional `httpMethod` (uppercased before match), optional `limit` (default 20, max 100).

Response shape:
```json
{
  "filter": { "userId": "alice", "resourcePath": "/v2/", "httpMethod": "POST" },
  "limit": 20,
  "count": 1,
  "activities": [...]
}
```

## DAO changes

`ActivityDAO` additions (`backend/src/main/java/de/dlr/shepard/provenance/daos/ActivityDAO.java`):

- `findByEntityAppId(entityAppId, depth)` — Cypher `MATCH (a:Activity)-[r:GENERATED|USED]->(e {appId: $appId}) RETURN a, type(r) AS relation ORDER BY a.startedAtMillis DESC LIMIT depth*50`; result cap scales with depth.
- `listForMcp(userId, resourcePath, httpMethod, limit)` — builder-style Cypher; field mapping: `userId → agentUsername`, `resourcePath → path` (STARTS WITH), `httpMethod → method` (uppercased); limit capped to [1, 100].
- `ActivityEdgeRow` record — pairs an `Activity` with its PROV-O edge label (`GENERATED` or `USED`).

## Tests

11 new unit tests in `ActivityMcpToolsTest` — all pass (`mvn -Dtest=ActivityMcpToolsTest test` → 11/11):

- Happy path `prov_query`: correct fields including `relation`, `userId`, `resourcePath`, `startedAtMillis`
- Empty result when no activities found
- Depth clamped to max (10) and min (1) with DAO call verification
- Null and blank `entityAppId` → McpException -32602
- `activity_list` with no filter returns default limit
- `activity_list` filtered by `userId` — DAO called with correct args
- `activity_list` filtered by `resourcePath`
- Limit clamped to max (100)
- Filter echo in response body verified
- `relation` field absent from `activity_list` rows (only in `prov_query`)

Pre-existing test failures in the full `mvn verify` run are unrelated to this change (existing mock-setup issues in other suites).

https://claude.ai/code/session_015JcAvouxhwRYtUbAB2eCEz