### PR TITLE
feat(UI21-BACKEND-Q): server-side createdBy filter for container list

### DIFF
--- a/backend-client/src/models/ContainerSearchParams.ts
+++ b/backend-client/src/models/ContainerSearchParams.ts
@@ -21,23 +21,29 @@ import {
 } from './ContainerType';
 
 /**
- * 
+ *
  * @export
  * @interface ContainerSearchParams
  */
 export interface ContainerSearchParams {
     /**
-     * 
+     *
      * @type {string}
      * @memberof ContainerSearchParams
      */
     query: string;
     /**
-     * 
+     *
      * @type {ContainerType}
      * @memberof ContainerSearchParams
      */
     queryType: ContainerType;
+    /**
+     * Optional username filter; when set the server returns only containers created by this user.
+     * @type {string}
+     * @memberof ContainerSearchParams
+     */
+    createdBy?: string;
 }
 
 
@@ -60,9 +66,10 @@ export function ContainerSearchParamsFromJSONTyped(json: any, ignoreDiscriminato
         return json;
     }
     return {
-        
+
         'query': json['query'],
         'queryType': ContainerTypeFromJSON(json['queryType']),
+        'createdBy': json['createdBy'] == null ? undefined : json['createdBy'],
     };
 }
 
@@ -71,9 +78,10 @@ export function ContainerSearchParamsToJSON(value?: ContainerSearchParams | null
         return value;
     }
     return {
-        
+
         'query': value['query'],
         'queryType': ContainerTypeToJSON(value['queryType']),
+        'createdBy': value['createdBy'] == null ? undefined : value['createdBy'],
     };
 }
 

--- a/backend/src/main/java/de/dlr/shepard/common/search/io/ContainerSearchParams.java
+++ b/backend/src/main/java/de/dlr/shepard/common/search/io/ContainerSearchParams.java
@@ -16,8 +16,16 @@ public class ContainerSearchParams extends ASearchParams {
   @NotNull
   private ContainerType queryType;
 
+  private String createdBy;
+
   public ContainerSearchParams(String query, ContainerType queryType) {
     super(query);
     this.queryType = queryType;
+  }
+
+  public ContainerSearchParams(String query, ContainerType queryType, String createdBy) {
+    super(query);
+    this.queryType = queryType;
+    this.createdBy = createdBy;
   }
 }

--- a/backend/src/main/java/de/dlr/shepard/common/search/query/Neo4jQueryBuilder.java
+++ b/backend/src/main/java/de/dlr/shepard/common/search/query/Neo4jQueryBuilder.java
@@ -716,6 +716,16 @@ public class Neo4jQueryBuilder {
     SortingHelper sortOrder,
     String userName
   ) {
+    return containerSelectionQueryWithNeo4jId(JSONQuery, containerType, sortOrder, userName, null);
+  }
+
+  public static Neo4jQuery containerSelectionQueryWithNeo4jId(
+    String JSONQuery,
+    ContainerType containerType,
+    SortingHelper sortOrder,
+    String userName,
+    String createdBy
+  ) {
     ParamBinder binder = new ParamBinder();
     String ret = "MATCH (" + containerType.getTypeAlias() + ":" + containerType.getTypeName() + ")";
     ret = ret + " WHERE ";
@@ -724,6 +734,16 @@ public class Neo4jQueryBuilder {
     ret = ret + notDeletedPart(containerType.getTypeAlias());
     ret = ret + " AND ";
     ret = ret + CypherQueryHelper.getReadableByQuery(containerType.getTypeAlias(), userName);
+    if (createdBy != null && !createdBy.isBlank()) {
+      String createdByRef = binder.bind(createdBy.toLowerCase());
+      ret =
+        ret +
+        " AND (EXISTS {MATCH (" +
+        containerType.getTypeAlias() +
+        ") - [:created_by] -> (u) WHERE toLower(u.username) contains " +
+        createdByRef +
+        "})";
+    }
     if (sortOrder.hasOrderByAttribute()) {
       ret +=
         " " +

--- a/backend/src/main/java/de/dlr/shepard/common/search/services/ContainerSearchService.java
+++ b/backend/src/main/java/de/dlr/shepard/common/search/services/ContainerSearchService.java
@@ -39,7 +39,8 @@ public class ContainerSearchService {
       containerSearchParams.getQuery(),
       containerSearchParams.getQueryType(),
       sortOrder,
-      user.getUsername()
+      user.getUsername(),
+      containerSearchParams.getCreatedBy()
     );
     List<BasicContainerIO> resultList = findContainerList(neo4jSelectionQuery, containerSearchParams, pagination);
     Integer totalResultCount = searchDAO.getContainerTotalCount(

--- a/backend/src/test/java/de/dlr/shepard/common/search/services/ContainerSearchServiceTest.java
+++ b/backend/src/test/java/de/dlr/shepard/common/search/services/ContainerSearchServiceTest.java
@@ -146,4 +146,54 @@ public class ContainerSearchServiceTest {
     var actual = containerSearcher.search(searchBody, null, new SortingHelper(null, null));
     assertThat(actual.getResults()).containsExactly(new BasicContainerIO(sdRes1), new BasicContainerIO(sdRes2));
   }
+
+  @Test
+  public void searchContainerWithCreatedByFilterTest() {
+    String JSONquery = "{\"property\": \"name\", \"value\": \"MyName\", \"operator\": \"eq\"}";
+    String createdBy = "alice";
+    ContainerSearchParams params = new ContainerSearchParams(JSONquery, ContainerType.FILE, createdBy);
+    ContainerSearchBody searchBody = new ContainerSearchBody(params);
+    Neo4jQuery neo4jQueryWithCreatedBy = Neo4jQueryBuilder.containerSelectionQueryWithNeo4jId(
+      JSONquery,
+      ContainerType.FILE,
+      new SortingHelper(null, null),
+      user.getUsername(),
+      createdBy
+    );
+    assertThat(neo4jQueryWithCreatedBy.cypher()).contains("created_by");
+    FileContainer fileRes = new FileContainer(7L);
+    List<BasicContainer> fileResList = List.of(fileRes);
+    when(searchDAO.findContainers(neo4jQueryWithCreatedBy, null, Constants.FILECONTAINER_IN_QUERY)).thenReturn(
+      fileResList
+    );
+    when(userService.getCurrentUser()).thenReturn(user);
+
+    var actual = containerSearcher.search(searchBody, null, new SortingHelper(null, null));
+    assertThat(actual.getResults()).containsExactly(new BasicContainerIO(fileRes));
+    assertThat(actual.getSearchParams().getCreatedBy()).isEqualTo(createdBy);
+  }
+
+  @Test
+  public void searchContainerWithNullCreatedByIgnoresFilterTest() {
+    String JSONquery = "{\"property\": \"name\", \"value\": \"AnotherName\", \"operator\": \"eq\"}";
+    ContainerSearchParams params = new ContainerSearchParams(JSONquery, ContainerType.TIMESERIES);
+    ContainerSearchBody searchBody = new ContainerSearchBody(params);
+    Neo4jQuery neo4jQueryNoCreatedBy = Neo4jQueryBuilder.containerSelectionQueryWithNeo4jId(
+      JSONquery,
+      ContainerType.TIMESERIES,
+      new SortingHelper(null, null),
+      user.getUsername(),
+      null
+    );
+    assertThat(neo4jQueryNoCreatedBy.cypher()).doesNotContain("created_by");
+    TimeseriesContainer timeRes = new TimeseriesContainer(9L);
+    List<BasicContainer> timeResList = List.of(timeRes);
+    when(searchDAO.findContainers(neo4jQueryNoCreatedBy, null, Constants.TIMESERIESCONTAINER_IN_QUERY)).thenReturn(
+      timeResList
+    );
+    when(userService.getCurrentUser()).thenReturn(user);
+
+    var actual = containerSearcher.search(searchBody, null, new SortingHelper(null, null));
+    assertThat(actual.getResults()).containsExactly(new BasicContainerIO(timeRes));
+  }
 }

--- a/frontend/components/container/ContainerListPage.vue
+++ b/frontend/components/container/ContainerListPage.vue
@@ -115,24 +115,6 @@ function setGroupView(v: "flat" | "collection") {
   });
 }
 
-// ── Owner filter (h) — client-side ─────────────────────────────────────────
-// `owner=…` is intentionally client-side: there's no backend filter for
-// `createdBy` on the v2 SearchApi today, and the task spec forbids
-// backend extension during the Jandex hang. Filed in aidocs/16 as
-// UI21-BACKEND-Q for the server-side enrichment.
-
-const ownerFilter = computed(() => {
-  const raw = route.query.owner;
-  return typeof raw === "string" && raw.trim() ? raw.trim().toLowerCase() : "";
-});
-
-const visibleServerItems = computed<BasicContainer[]>(() => {
-  if (!ownerFilter.value) return serverItems.value;
-  return serverItems.value.filter(c =>
-    c.createdBy.toLowerCase().includes(ownerFilter.value),
-  );
-});
-
 // ── Advanced-mode grouping (g) ──────────────────────────────────────────────
 // The orphan/reference map is populated by ContainerList's `refs-resolved`
 // listener. Mirror the events here so the grouped view can read them.
@@ -144,7 +126,7 @@ function onRefsResolved(payload: { id: number; refs: number[] | null }) {
 }
 
 const groupedView = computed<Map<string, BasicContainer[]>>(() => {
-  const rows: ContainerWithRefs<BasicContainer>[] = visibleServerItems.value.map(c => ({
+  const rows: ContainerWithRefs<BasicContainer>[] = serverItems.value.map(c => ({
     container: c,
     referencingCollectionIds: refsById.get(c.id) ?? null,
   }));
@@ -233,10 +215,10 @@ async function confirmBulkDelete() {
 // ── Empty / search-empty / populated state ─────────────────────────────────
 
 const isEmpty = computed(
-  () => !loading.value && visibleServerItems.value.length === 0 && !searchResultHint.value,
+  () => !loading.value && serverItems.value.length === 0 && !searchResultHint.value,
 );
 const isSearchEmpty = computed(
-  () => !loading.value && visibleServerItems.value.length === 0 && !!searchResultHint.value,
+  () => !loading.value && serverItems.value.length === 0 && !!searchResultHint.value,
 );
 </script>
 
@@ -362,7 +344,7 @@ const isSearchEmpty = computed(
               :items-per-page="itemsPerPage"
               :loading="loading"
               :page-count="pageCount"
-              :server-items="visibleServerItems"
+              :server-items="serverItems"
               @request-bulk-delete="onRequestBulkDelete"
               @refs-resolved="onRefsResolved"
             />
@@ -424,7 +406,7 @@ const isSearchEmpty = computed(
                 :items-per-page="itemsPerPage"
                 :loading="loading"
                 :page-count="1"
-                :server-items="visibleServerItems"
+                :server-items="serverItems"
                 @request-bulk-delete="onRequestBulkDelete"
                 @refs-resolved="onRefsResolved"
               />

--- a/frontend/components/container/containerListQueryParams.ts
+++ b/frontend/components/container/containerListQueryParams.ts
@@ -11,12 +11,14 @@ import {
 export type ContainerListQueryParams =
   ListQueryParams<BasicContainerAttributes> & {
     selectedFilter?: ContainerFilterType;
+    owner?: string;
   };
 
 export function parseContainerListQueryParams(
   queryParams: LocationQueryRaw,
 ): ContainerListQueryParams {
   const basicParams = parseListQueryParams(queryParams);
+  const owner = parseOwner(queryParams);
 
   if (
     !basicParams.sortBy ||
@@ -26,6 +28,7 @@ export function parseContainerListQueryParams(
       page: basicParams.page,
       searchText: basicParams.searchText,
       selectedFilter: parseSelectedFilter(queryParams),
+      owner,
     };
   }
 
@@ -37,7 +40,14 @@ export function parseContainerListQueryParams(
       order: basicParams.sortBy.order,
     },
     selectedFilter: parseSelectedFilter(queryParams),
+    owner,
   };
+}
+
+function parseOwner(queryParams: LocationQueryRaw): string | undefined {
+  const raw = queryParams.owner;
+  if (typeof raw === "string" && raw.trim()) return raw.trim();
+  return undefined;
 }
 
 function parseSelectedFilter(

--- a/frontend/components/container/useSearchContainers.ts
+++ b/frontend/components/container/useSearchContainers.ts
@@ -21,6 +21,7 @@ export function useSearchContainers(itemsPerPage: number) {
     sortByAttributes: SortBy<BasicContainerAttributes> | undefined,
     searchQuery: string,
     selectedFilter: ContainerFilterType | null | undefined,
+    owner?: string,
   ) {
     loading.value = true;
 
@@ -36,6 +37,7 @@ export function useSearchContainers(itemsPerPage: number) {
           searchParams: {
             query: searchQuery,
             queryType: selectedFilter ?? ContainerType.Basic,
+            ...(owner ? { createdBy: owner } : {}),
           },
         },
         page: page - 1,
@@ -64,6 +66,7 @@ export function useSearchContainers(itemsPerPage: number) {
         newParams.sortBy,
         buildQueryString(newParams.searchText ?? null),
         newParams.selectedFilter,
+        newParams.owner,
       );
     },
     { immediate: true },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes backlog row **UI21-BACKEND-Q**.

The containers list page (`/containers?owner=alice`) previously filtered results client-side via a `visibleServerItems` computed that re-filtered the current page. This breaks at scale (≥1000 containers shows at most `itemsPerPage` items even if all pass the owner filter).

This PR moves the `owner=` filter server-side.

### Backend (`/v2/` only — no upstream compat surface touched)

- **`ContainerSearchParams.java`**: adds nullable `createdBy` field + 3-arg constructor.
- **`Neo4jQueryBuilder.containerSelectionQueryWithNeo4jId`**: new 5-arg overload that accepts an optional `createdBy` string; when non-blank appends `AND (EXISTS {MATCH (var)-[:created_by]->(u) WHERE toLower(u.username) contains $p})` to the Cypher WHERE clause. The 4-arg overload delegates with `null` so all existing callers are unaffected.
- **`ContainerSearchService`**: passes `containerSearchParams.getCreatedBy()` to the query builder.
- **`ContainerSearchServiceTest`**: two new unit tests — `searchContainerWithCreatedByFilterTest` (asserts Cypher contains `created_by` when filter is set, verifies results) and `searchContainerWithNullCreatedByIgnoresFilterTest` (asserts Cypher does NOT contain `created_by` when filter is null).

### Frontend client (`backend-client/src/models/ContainerSearchParams.ts`)

- Adds optional `createdBy?: string` field with `FromJSON`/`ToJSON` serialisation.

### Frontend

- **`containerListQueryParams.ts`**: extends `ContainerListQueryParams` with `owner?: string`; adds `parseOwner()` helper that reads `?owner=` from URL query.
- **`useSearchContainers.ts`**: forwards `owner` from `queryParams` as `createdBy` in the `SearchApi.searchContainers` body.
- **`ContainerListPage.vue`**: removes `ownerFilter` and `visibleServerItems` computed (18 lines); all template and composable references updated to use `serverItems` directly. The comment block explaining the client-side workaround is removed.

### Gates

- `npm run lint` — pre-existing failures only (unrelated to this PR); my changed files produce zero ESLint findings.
- `npm run test` — pre-existing `useFetchRecentCollections` failures only; zero new test failures.
- `npm run typecheck` — passes clean.
- `mvn verify -pl backend` — backend plugin chain not pre-installed on dev box; CI will verify. The new tests compile correctly against the stub-installed backend; the two new test methods assert Cypher string content and mock DAO interactions, identical pattern to the existing four passing tests.

https://claude.ai/code/session_01QPPLMygM55ij3owoEkxQtm
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPPLMygM55ij3owoEkxQtm)_