### PR TITLE
fix(btkvs-a2-ops): add bind-mount for semantic user-bundles dir in docker-compose

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     volumes:
       - /opt/shepard/backend/logs:/deployments/logs
       - /opt/shepard/backend/config:/home/default/.shepard
+      - /opt/shepard/semantic-bundles:/var/lib/shepard/ontologies
     depends_on:
       - neo4j
       - mongodb


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `- /opt/shepard/semantic-bundles:/var/lib/shepard/ontologies` to the backend service `volumes:` block in `infrastructure/docker-compose.yml`. Without this mount, the container path `/var/lib/shepard/ontologies` (configured via `shepard.semantic.internal.user-bundles-dir`) is ephemeral and non-writable, causing ontology bundle uploads via `POST /v2/admin/semantic/ontologies` to fail with a 500 error. The bind-mount makes uploads persistent across container restarts and ensures the path is writable.

## Test / operator plan

- [ ] On the host, run `mkdir -p /opt/shepard/semantic-bundles` before redeploying (required — Docker will not create a bind-mount source directory automatically on all platforms).
- [ ] Run `docker compose pull && docker compose up -d backend` to apply the new mount.
- [ ] Verify the mount is active: `docker compose exec backend ls /var/lib/shepard/ontologies` should return without error.
- [ ] Upload a test ontology bundle via `POST /v2/admin/semantic/ontologies` and confirm a 201 response and that the file appears in `/opt/shepard/semantic-bundles` on the host.
- [ ] Restart the backend container and confirm the uploaded bundle persists.

> **Operator action required before redeploy:** `mkdir -p /opt/shepard/semantic-bundles` on the Docker host.

https://claude.ai/code/session_01JSypzFXPFJ9gog2sn9XNUy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSypzFXPFJ9gog2sn9XNUy)_