### PR TITLE
feat(ux-walk-2026-05-29-08): replace bare dash with "Not specified" chip in collections access column

### DIFF
--- a/frontend/components/context/collection/list/CollectionList.vue
+++ b/frontend/components/context/collection/list/CollectionList.vue
@@ -161,7 +161,12 @@ function onPageChange(page: number) {
             v-if="rowAccessRights(rowProps.item)"
             :access-rights="rowAccessRights(rowProps.item)!"
           />
-          <span v-else class="text-disabled">—</span>
+          <v-chip
+            v-else
+            size="small"
+            variant="tonal"
+            data-testid="collection-row-access-not-specified"
+          >Not specified</v-chip>
         </template>
         <template #[`item.description`]>
           <span


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces the bare `—` span in the collections list "Access" column with a `v-chip` (size=small, variant=tonal, no explicit color) reading "Not specified" when `accessRights` is null, so the column always shows a controlled-vocabulary chip rather than an empty-looking dash.
- Change is in `frontend/components/context/collection/list/CollectionList.vue` lines 164–169.
- Closes UX-WALK-2026-05-29-08.

## Test plan

- [ ] `npm run typecheck` in `frontend/` — passes (zero errors)
- [ ] `npm run lint` in `frontend/` — no new errors introduced in `CollectionList.vue` (pre-existing errors elsewhere are unchanged)
- [ ] `npm run test` in `frontend/` — 1053/1058 tests pass; the 5 failing tests are pre-existing failures in `useFetchRecentCollections.test.ts`, unrelated to this change
- [ ] Visual check: open the Collections list with at least one collection that has no `accessRights` set — the "Access" cell should show a small tonal chip labelled "Not specified" instead of a bare dash
- [ ] `data-testid="collection-row-access-not-specified"` present on the chip for Playwright targeting

Backlog row: UX-WALK-2026-05-29-08

https://claude.ai/code/session_01JSypzFXPFJ9gog2sn9XNUy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSypzFXPFJ9gog2sn9XNUy)_