### PR TITLE
feat(ux-walk-2026-05-29-07): add "Visualize in 3D" CTA button to timeseries container page

### DIFF
--- a/frontend/pages/containers/timeseries/[containerId]/index.vue
+++ b/frontend/pages/containers/timeseries/[containerId]/index.vue
@@ -10,6 +10,11 @@ const { routeParams } = useContainerRouteParams();
 const containerId = routeParams.value.containerId;
 const urlSegment = containerTypeUrlPathSegmentMappings.TIMESERIES;
 
+const router = useRouter();
+function openTrace3D() {
+  router.push({ path: "/shapes/render", query: { renderer: "trace-3d", containerId: String(containerId) } });
+}
+
 const containerAccessor = new TimeseriesContainerAccessor(containerId);
 const { dataObjects: linkedDataObjects, isLoading: linkedDataObjectsLoading } =
   useTimeseriesContainerLinkedDataObjects(containerId);
@@ -141,6 +146,14 @@ useHead({
                 :type-label="'Timeseries Container'"
               >
                 <template #buttons>
+                  <v-btn
+                    data-testid="ts-container-visualize-3d-btn"
+                    variant="tonal"
+                    prepend-icon="mdi-cube-outline"
+                    @click="openTrace3D"
+                  >
+                    Visualize in 3D
+                  </v-btn>
                   <UploadFilesButton
                     v-if="containerAccessor.isAllowedToEditData.value"
                     accept=".csv"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a "Visualize in 3D" button (`mdi-cube-outline`, `variant="tonal"`) to the `ContainerTitleAndMetadataDisplay` `#buttons` slot on the timeseries container detail page (`frontend/pages/containers/timeseries/[containerId]/index.vue`)
- Button navigates via `router.push` to `/shapes/render?renderer=trace-3d&containerId=<numericId>` — same tab, no new window
- Button carries `data-testid="ts-container-visualize-3d-btn"` for Playwright targeting
- Closes backlog row **UX-WALK-2026-05-29-07**

## Test plan

- [ ] Navigate to any timeseries container detail page — "Visualize in 3D" button appears in the header action area
- [ ] Click the button — browser navigates to `/shapes/render?renderer=trace-3d&containerId=<id>` (same tab)
- [ ] `npm run typecheck` passes (confirmed locally — no TS errors)
- [ ] Pre-existing lint errors and test failures (`useFetchRecentCollections`) are unrelated to this change and existed before it

https://claude.ai/code/session_01JSypzFXPFJ9gog2sn9XNUy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSypzFXPFJ9gog2sn9XNUy)_