### PR TITLE
docs(AI1c-UI,J1d-UI): flip backlog to shipped

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -1730,8 +1730,8 @@ SSOT: [`aidocs/agent-findings/no-ui-gap-survey-2026-05-24.md`](agent-findings/no
 | AI1a-UI | Per-user AI settings frontend — admin REST endpoint not yet shipped; placeholder mounted at `/me#ai-settings` advertises the surface | S | gated-on-AI1a-backend | Survey §1; gate on AI1a admin REST |
 | PG-COLLAPSE-002-UI | Backup configuration UI — placeholder at `/admin#backup` advertises `:BackupConfig` surface from `aidocs/strategy/105`; promotes when the endpoint ships | S | gated-on-PG-COLLAPSE-002 | Survey §2 |
 | AI1b-UI | "Detect anomalies" button on TimeseriesReference page wiring `POST /v2/timeseries-references/{}/detect-anomalies` | XS | **✓ shipped (2026-05-27)** | Survey §3; button + `DetectAnomaliesDialog.vue` (parametrized window/threshold/createAnnotations, inline results table) were already implemented by a prior agent session; row marked shipped on audit confirmation. |
-| AI1c-UI | `qualityScore` badge on TimeseriesReference cards + detail page | XS | queued (backend shipped) | Survey §4; sibling of task #62 |
-| J1d-UI | Revision-history drawer on lab-journal entry detail page (J1d backend shipped) | S | queued | Survey §6 |
+| AI1c-UI | `qualityScore` badge on TimeseriesReference cards + detail page | XS | **shipped (2026-06-01, verified by dispatcher)** | Survey §4; sibling of task #62 |
+| J1d-UI | Revision-history drawer on lab-journal entry detail page (J1d backend shipped) | S | **shipped (2026-06-01, verified by dispatcher)** | Survey §6 |
 | A5-UI-PHASE-1 | Full HDF container browsing UI — placeholder at `/containers/hdf/[containerId]` advertises but doesn't walk the H5 tree | M | queued | Survey §7; sibling of task #65 |
 | NTF1-UI | Full notifications admin pane — configure SMTP / Matrix transports + per-transport test; placeholder at `/admin#notifications-admin` is partial | M | gated-on-NTF1-backend-completion | Survey §8 |
 | SHAPES-V-UI | Full SHACL validation UI — placeholder at `/shapes/validate` advertises; real UI shows shape definitions + validation results inline | M | queued | Survey §9 |


### PR DESCRIPTION
## Summary
- Flips aidocs/16 row AI1c-UI from 'queued (backend shipped)' to 'shipped (2026-06-01)'
- Flips aidocs/16 row J1d-UI from 'queued' to 'shipped (2026-06-01)'

## Verification

### AI1c-UI
- QualityScoreChip.vue exists and is wired into:
  - ShowTimeseriesReferenceDialog.vue:254
  - DataObjectDataMetaCell.vue:36 (cards in unified table)
  - timeseriesereferences/[id]/index.vue:488 (detail page)
- Covers "TimeseriesReference cards + detail page" per acceptance criterion

### J1d-UI
- LabJournalHistoryDialog.vue — full revision history dialog implemented
- useFetchLabJournalHistory.ts — composable calling GET /v2/lab-journal/{entryAppId}/history
- useFetchLabJournalHistory.test.ts — tests pass

## Test plan
- [ ] Confirm aidocs/16 line 1733 AI1c-UI shows shipped
- [ ] Confirm aidocs/16 line 1734 J1d-UI shows shipped

Dispatched by hourly dispatcher fire 2026-06-01.

https://claude.ai/code/session_01QoTuvuwAbZA1DxEUvY6hv1

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoTuvuwAbZA1DxEUvY6hv1)_