### PR TITLE
feat(UX-WALK-2026-05-29-08): replace — in Access column with FAIR-A vocab chip

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -1953,7 +1953,7 @@ Live regression-sweep dispatch results. Full report:
 | UX-WALK-2026-05-29-05 | Collections list at 4K leaves ~1500 px of empty whitespace below 3-row table. Add either a dense view toggle, a "Create another collection" CTA in the void, or skeleton rows scaled to viewport height. Pre-existing pattern but flo's hardware makes it acute. | S | queued | MINOR | Step 2 evidence. UX-PATTERN-D sibling concern. |
 | UX-WALK-2026-05-29-06 | DataObject detail page perpetually shows `v-progress-circular` when `fetchTreeviewItem` fails. Render the parts that loaded (name, attributes, panes) and surface a dismissable "Some data couldn't load" banner instead of blocking the whole page on one failed dependency. | M | queued | MAJOR | Graceful-degradation pattern. Currently makes the entire DO page useless on any single sub-fetch failure. |
 | UX-WALK-2026-05-29-07 | Add "Visualize all in 3D" / Trace3D CTA on the TS container page (one click upstream of the current TimeseriesReference-level entry point per `aidocs/platform/98`). Shortens the path for researchers who land on the container first. NICE — not a regression. | S | queued | NICE | Step 6 evidence: no affordance found via `getByRole("button", { name: /trace3d\|3d\|visualize/i })`. |
-| UX-WALK-2026-05-29-08 | "Access" column on `/collections` shows ambiguous `—` for two of three rows. Replace with a controlled vocabulary chip (Open / Shared / Restricted / Closed) — closes one of the FAIR-A surface gaps surfaced in `research-data-manager.md`. | S | queued | MINOR | Step 2 evidence. |
+| UX-WALK-2026-05-29-08 | "Access" column on `/collections` shows ambiguous `—` for two of three rows. Replace with a controlled vocabulary chip (Open / Shared / Restricted / Closed) — closes one of the FAIR-A surface gaps surfaced in `research-data-manager.md`. | S | **✓ done (2026-06-01, PR #1706, `d0bbaa3`)** | MINOR | `AccessRightsChip.vue` extended to accept `string \| null \| undefined`; null/unset renders "Not set" chip (`mdi-help-circle-outline`, default/grey). `CollectionList.vue` passes `rowAccessRights()` directly — no inline fallback needed. Tests: `AccessRightsChipNullState.test.ts` (8 cases). |
 
 ## TS-INGEST-222GB-CHOKEPOINTS — pre-flight bottleneck review
 
@@ -2501,7 +2501,7 @@ them up immediately.
 | FE-BUILD-03-REGEN | Regenerate `@dlr-shepard/backend-client` from current OpenAPI; retires the `as unknown as` cast in `usePagedDataObjects.ts`. | S | Real fix; cast holdover is shipped. |
 | UX-WALK-2026-05-29-05 | Collections list at 4K leaves ~1500 px whitespace; add density toggle or skeleton rows. | S | UX-PATTERN-D sibling concern. |
 | UX-WALK-2026-05-29-07 | Add "Visualize all in 3D" CTA to TS container page; shortens click-path to Trace3D. | S | NICE — not a regression. |
-| UX-WALK-2026-05-29-08 | Replace `—` in Collections list Access column with controlled-vocab chip (Open / Shared / Restricted / Closed). | S | Closes one FAIR-A surface gap. |
+| UX-WALK-2026-05-29-08 | ~~Replace `—` in Collections list Access column with controlled-vocab chip.~~ **✓ done (2026-06-01, PR #1706)** | S | Closes one FAIR-A surface gap. |
 | FRONTEND-LINT-DEBT-02 | Replace `any` casts with `unknown` + narrowing (~10 instances). | M | Each instance needs a real type. |
 | FRONTEND-LINT-DEBT-04 | Add explanations to `@ts-expect-error` / `@ts-ignore`. | S | Trivial doc-style fix per instance. |
 | TS-INGEST-222GB-DASHBOARD | Lightweight live-ingest watch page polling capacity + chunk counts + Activity row growth. | S | Reuses `shepard.measures.itself` observability primitives. |

--- a/frontend/components/context/collection/list/CollectionList.vue
+++ b/frontend/components/context/collection/list/CollectionList.vue
@@ -157,11 +157,7 @@ function onPageChange(page: number) {
           >({{ (rowProps.item as any).importedFrom }})</span>
         </template>
         <template #[`item.accessRights`]>
-          <AccessRightsChip
-            v-if="rowAccessRights(rowProps.item)"
-            :access-rights="rowAccessRights(rowProps.item)!"
-          />
-          <span v-else class="text-disabled">—</span>
+          <AccessRightsChip :access-rights="rowAccessRights(rowProps.item)" />
         </template>
         <template #[`item.description`]>
           <span

--- a/frontend/components/context/display-components/AccessRightsChip.vue
+++ b/frontend/components/context/display-components/AccessRightsChip.vue
@@ -6,16 +6,22 @@
 //   CLOSED     -> error   (red)
 //   EMBARGOED  -> info    (blue)
 //
+// When accessRights is null/undefined (collections that predate LIC1), renders
+// a neutral "Not set" chip (UX-WALK-2026-05-29-08) so the column always shows
+// a chip rather than a bare dash.
+//
 // Unknown / unmapped values fall back to a neutral default chip so the UI
 // never breaks on a server-side value the frontend hasn't seen yet.
 import { getAccessRightsOption } from "~/utils/spdxLicenses";
 
-const props = defineProps<{ accessRights: string }>();
+const props = defineProps<{ accessRights: string | null | undefined }>();
 
-const option = computed(() => getAccessRightsOption(props.accessRights));
-const color = computed(() => option.value?.color ?? "default");
-const label = computed(() => option.value?.label ?? props.accessRights);
-const description = computed(() => option.value?.description ?? "");
+const isUnset = computed(() => !props.accessRights);
+const option = computed(() => (props.accessRights ? getAccessRightsOption(props.accessRights) : undefined));
+const color = computed(() => (isUnset.value ? "default" : (option.value?.color ?? "default")));
+const label = computed(() => (isUnset.value ? "Not set" : (option.value?.label ?? props.accessRights)));
+const icon = computed(() => (isUnset.value ? "mdi-help-circle-outline" : "mdi-shield-lock-outline"));
+const description = computed(() => (isUnset.value ? "" : (option.value?.description ?? "")));
 </script>
 
 <template>
@@ -26,7 +32,7 @@ const description = computed(() => option.value?.description ?? "");
         :color="color"
         size="small"
         variant="tonal"
-        prepend-icon="mdi-shield-lock-outline"
+        :prepend-icon="icon"
         label
       >
         {{ label }}

--- a/frontend/tests/unit/AccessRightsChipNullState.test.ts
+++ b/frontend/tests/unit/AccessRightsChipNullState.test.ts
@@ -1,0 +1,91 @@
+/**
+ * UX-WALK-2026-05-29-08 — AccessRightsChip null / undefined / unset render path.
+ *
+ * The AccessRightsChip component now accepts `accessRights: string | null |
+ * undefined`. When the prop is absent (pre-LIC1 collections), it must render
+ * a "Not set" chip rather than a bare dash. This file tests the computed
+ * properties logic mirrored from the component.
+ */
+import { describe, it, expect } from "vitest";
+import { getAccessRightsOption } from "../../utils/spdxLicenses";
+
+// ── Logic mirror ──────────────────────────────────────────────────────────────
+// These functions replicate exactly the computed logic inside AccessRightsChip.vue
+// so we can unit-test them without the full Vuetify rendering chain.
+
+function resolveChip(accessRights: string | null | undefined) {
+  const isUnset = !accessRights;
+  const option = accessRights ? getAccessRightsOption(accessRights) : undefined;
+  return {
+    isUnset,
+    color: isUnset ? "default" : (option?.color ?? "default"),
+    label: isUnset ? "Not set" : (option?.label ?? accessRights),
+    icon: isUnset ? "mdi-help-circle-outline" : "mdi-shield-lock-outline",
+    description: isUnset ? "" : (option?.description ?? ""),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("AccessRightsChip — null / undefined / unset path (UX-WALK-2026-05-29-08)", () => {
+  it("renders 'Not set' chip for null accessRights", () => {
+    const chip = resolveChip(null);
+    expect(chip.isUnset).toBe(true);
+    expect(chip.label).toBe("Not set");
+    expect(chip.color).toBe("default");
+    expect(chip.icon).toBe("mdi-help-circle-outline");
+    expect(chip.description).toBe("");
+  });
+
+  it("renders 'Not set' chip for undefined accessRights", () => {
+    const chip = resolveChip(undefined);
+    expect(chip.isUnset).toBe(true);
+    expect(chip.label).toBe("Not set");
+    expect(chip.color).toBe("default");
+    expect(chip.icon).toBe("mdi-help-circle-outline");
+  });
+
+  it("renders 'Not set' chip for empty string accessRights", () => {
+    const chip = resolveChip("");
+    expect(chip.isUnset).toBe(true);
+    expect(chip.label).toBe("Not set");
+  });
+});
+
+describe("AccessRightsChip — known controlled-vocabulary values", () => {
+  it("OPEN renders with success color and shield icon", () => {
+    const chip = resolveChip("OPEN");
+    expect(chip.isUnset).toBe(false);
+    expect(chip.color).toBe("success");
+    expect(chip.label).toBe("Open");
+    expect(chip.icon).toBe("mdi-shield-lock-outline");
+    expect(chip.description).toBeTruthy();
+  });
+
+  it("RESTRICTED renders with warning color", () => {
+    const chip = resolveChip("RESTRICTED");
+    expect(chip.color).toBe("warning");
+    expect(chip.label).toBe("Restricted");
+  });
+
+  it("CLOSED renders with error color", () => {
+    const chip = resolveChip("CLOSED");
+    expect(chip.color).toBe("error");
+    expect(chip.label).toBe("Closed");
+  });
+
+  it("EMBARGOED renders with info color", () => {
+    const chip = resolveChip("EMBARGOED");
+    expect(chip.color).toBe("info");
+    expect(chip.label).toBe("Embargoed");
+  });
+});
+
+describe("AccessRightsChip — unknown server-side value fallback", () => {
+  it("falls back to raw string label and default color for an unrecognised value", () => {
+    const chip = resolveChip("SOME_FUTURE_VALUE");
+    expect(chip.isUnset).toBe(false);
+    expect(chip.color).toBe("default");
+    expect(chip.label).toBe("SOME_FUTURE_VALUE");
+    expect(chip.icon).toBe("mdi-shield-lock-outline");
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `AccessRightsChip.vue` to accept `accessRights: string | null | undefined`
- When the prop is null/undefined (collections that predate LIC1 or haven't had access rights set), renders a neutral "Not set" chip with `mdi-help-circle-outline`, `color=default`, `variant=tonal` instead of the ambiguous bare `—` dash
- Updates `CollectionList.vue` to pass `rowAccessRights(rowProps.item)` directly to `AccessRightsChip` — the `v-if`/`v-else` fallback is removed; the chip handles the null case internally
- Adds `frontend/tests/unit/AccessRightsChipNullState.test.ts` with 8 unit tests covering null, undefined, empty string, all four controlled-vocabulary values (OPEN/RESTRICTED/CLOSED/EMBARGOED), and an unknown future-server-value fallback
- Marks both `aidocs/16-dispatcher-backlog.md` UX-WALK-2026-05-29-08 rows as done

## Test plan

- [x] `npm run test` — new test file passes (8/8)
- [x] `npm run typecheck` — clean (no errors)
- [x] `npm run lint` — no errors introduced in changed files

## Gates (frontend-only change — `mvn verify` N/A)

| Gate | Status |
|---|---|
| `npm run lint` (changed files only) | ✓ clean |
| `npm run test` (AccessRightsChipNullState.test.ts) | ✓ 8/8 pass |
| `npm run typecheck` | ✓ clean |

Closes FAIR-A surface gap from `research-data-manager.md` — researchers can now distinguish "nobody declared an access policy" from the four explicit states (Open / Restricted / Closed / Embargoed).

https://claude.ai/code/session_01SMLAc5JrM9x2U5ePtnaGtn