### PR TITLE
feat(SNAPSHOTS-DIFF-NAV-01): add Compare row action to SnapshotsPane

### DIFF
--- a/frontend/components/context/snapshot/SnapshotsPane.vue
+++ b/frontend/components/context/snapshot/SnapshotsPane.vue
@@ -263,6 +263,14 @@ const nameRules = [
           <v-btn
             variant="text"
             size="x-small"
+            icon="mdi-vector-difference"
+            :aria-label="`Compare snapshots starting from ${snap.name}`"
+            :disabled="!snap.appId"
+            @click="navigateTo({ path: '/snapshots/diff', query: { a: snap.appId } })"
+          />
+          <v-btn
+            variant="text"
+            size="x-small"
             icon="mdi-delete-outline"
             color="error"
             :loading="isSaving"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The snapshot diff page (`/snapshots/diff`) existed but had no in-context entry point — a user standing in the snapshot list had no way to reach it without typing the URL manually.
- Adds an icon button (`mdi-vector-difference`) to each snapshot row in `SnapshotsPane.vue`. Clicking it calls `navigateTo({ path: '/snapshots/diff', query: { a: snap.appId } })`, pre-populating the "from" snapshot field on the diff page.
- The button is disabled when `snap.appId` is absent (defensive guard), and carries `aria-label="Compare snapshots starting from <name>"` for accessibility.
- Implements the CLAUDE.md "tool entry points are in-context first" rule: the diff page is a tool whose natural entry context is a snapshot row.

**Backlog row:** SNAPSHOTS-DIFF-NAV-01

## Test plan

- [ ] Open a Collection detail page that shows the Snapshots panel with ≥ 1 snapshot.
- [ ] Confirm each snapshot row now shows the `mdi-vector-difference` icon button alongside the existing "Diff" and "Delete" actions.
- [ ] Click the Compare button on a snapshot — confirm navigation to `/snapshots/diff?a=<appId>` with the "Base snapshot (A)" field pre-populated.
- [ ] Confirm the button is disabled when `snap.appId` is falsy (not normally reachable in practice, but the guard should be visible in DevTools).
- [ ] `npm run typecheck` — clean (confirmed).
- [ ] `npm run lint` on `SnapshotsPane.vue` — clean (confirmed; pre-existing lint errors in other files are unchanged).

https://claude.ai/code/session_01MbQsJG6Rr28mvXSW3cfSSh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbQsJG6Rr28mvXSW3cfSSh)_