### PR TITLE
feat(PLACEHOLDER-REPLACE-P10c): replace sql-timeseries placeholder with real admin form

### DIFF
--- a/frontend/components/common/placeholder/placeholderRegistry.ts
+++ b/frontend/components/common/placeholder/placeholderRegistry.ts
@@ -46,17 +46,6 @@ export const PLACEHOLDER_ENTRIES: PlaceholderEntry[] = [
     backend: "shipped",
   },
   {
-    slug: "sql-timeseries",
-    surface: "admin",
-    title: "SQL-over-HTTP for timeseries",
-    subtitle:
-      "Runtime caps for the bulk-read SQL endpoint (POST /v2/sql/timeseries). Flip max-rows and max-duration without a restart.",
-    endpoint: "/v2/admin/sql-timeseries/config",
-    backlogRow: "P10c",
-    designDoc: "aidocs/platform/29-p10-implementation-design.md",
-    backend: "shipped",
-  },
-  {
     slug: "notifications-admin",
     surface: "admin",
     title: "Notification transports",
@@ -238,7 +227,7 @@ export const PLACEHOLDER_ENTRIES: PlaceholderEntry[] = [
   },
 ];
 
-// TS-SEMANTIC-REST: +1 for ts-channel-annotations (2026-05-27)
+// PLACEHOLDER-REPLACE-P10c: -1 sql-timeseries replaced by real AdminSqlTimeseriesPane (2026-06-01)
 export const EXPECTED_PLACEHOLDER_COUNT = PLACEHOLDER_ENTRIES.length;
 
 export function findPlaceholder(slug: string): PlaceholderEntry | undefined {

--- a/frontend/tests/unit/placeholderRegistry.test.ts
+++ b/frontend/tests/unit/placeholderRegistry.test.ts
@@ -11,7 +11,7 @@ describe("placeholderRegistry — no-UI-gap roll-out (2026-05-24)", () => {
   it("ships the documented count of placeholders", () => {
     // findings doc commits to a specific count; if this changes the doc
     // must change too (forces same-PR coupling).
-    expect(EXPECTED_PLACEHOLDER_COUNT).toBe(18); // TS-SEMANTIC-REST: +1 ts-channel-annotations (2026-05-27)
+    expect(EXPECTED_PLACEHOLDER_COUNT).toBe(17); // PLACEHOLDER-REPLACE-P10c: -1 sql-timeseries → real AdminSqlTimeseriesPane (2026-06-01)
     expect(PLACEHOLDER_ENTRIES).toHaveLength(EXPECTED_PLACEHOLDER_COUNT);
   });
 
@@ -67,7 +67,7 @@ describe("placeholderRegistry — no-UI-gap roll-out (2026-05-24)", () => {
     const admin = placeholdersBySurface("admin");
     const profile = placeholdersBySurface("profile");
     const route = placeholdersBySurface("route");
-    expect(admin.length).toBe(10);
+    expect(admin.length).toBe(9); // PLACEHOLDER-REPLACE-P10c: sql-timeseries removed (2026-06-01)
     expect(profile.length).toBe(1);
     expect(route.length).toBe(7); // TS-SEMANTIC-REST: +1 ts-channel-annotations (2026-05-27)
     expect(admin.length + profile.length + route.length).toBe(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes the `sql-timeseries` entry from `placeholderRegistry.ts` — it was the last blocking piece of backlog row **PLACEHOLDER-REPLACE-P10c**.
- The real `AdminSqlTimeseriesPane.vue` and `useSqlTimeseriesConfig.ts` composable were already on `main`; `admin/index.vue` already imported and wired the component. This PR closes the loop by removing the stale placeholder registry entry.
- Updates `EXPECTED_PLACEHOLDER_COUNT` (18 → 17) and the `admin` surface count assertion (10 → 9) in `placeholderRegistry.test.ts` to match.

## What the real form does

- On mount: calls `GET /v2/admin/sql-timeseries/config` and populates two fields.
- **Max rows** (`v-text-field`, `inputmode="numeric"`): positive-integer cap per `POST /v2/sql/timeseries` call; leave blank to revert to the deploy-time default in `application.properties`.
- **Max duration** (ISO-8601 string): PostgreSQL statement timeout (e.g. `PT60S`, `PT2M30S`, `PT1H`); validated client-side with a regex before submit; leave blank to revert.
- Save button: `PATCH /v2/admin/sql-timeseries/config` with `Content-Type: application/merge-patch+json`; shows inline error in the dialog on failure; closes dialog on success.
- Refresh button with loading state; error alert for load failures.

## Gates

- `npm run typecheck` — clean (no errors)
- `npm run lint` — changed files clean; pre-existing errors in unrelated files unchanged
- `npm run test tests/unit/placeholderRegistry.test.ts` — 12/12 pass

## Backlog row

PLACEHOLDER-REPLACE-P10c

https://claude.ai/code/session_01MbQsJG6Rr28mvXSW3cfSSh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbQsJG6Rr28mvXSW3cfSSh)_