### PR TITLE
feat(SCENEGRAPH-LIST-1): swap scene-graphs index info-card for v-data-table

### DIFF
--- a/frontend/composables/useSceneGraph.ts
+++ b/frontend/composables/useSceneGraph.ts
@@ -1,0 +1,210 @@
+export type FrameKind = "FRAME" | "JOINT" | "TOOL" | "BASE" | "TCP";
+
+export type JointType = "REVOLUTE" | "PRISMATIC" | "FIXED" | "CONTINUOUS";
+
+export interface FrameIO {
+  appId: string;
+  name?: string | null;
+  parentFrameAppId?: string | null;
+  x?: number | null;
+  y?: number | null;
+  z?: number | null;
+  rx?: number | null;
+  ry?: number | null;
+  rz?: number | null;
+  kind?: FrameKind | null;
+}
+
+export interface JointIO {
+  appId: string;
+  name?: string | null;
+  parentFrameAppId?: string | null;
+  childFrameAppId?: string | null;
+  axisX?: number | null;
+  axisY?: number | null;
+  axisZ?: number | null;
+  limitMin?: number | null;
+  limitMax?: number | null;
+  type?: JointType | null;
+  homeAngle?: number | null;
+}
+
+export interface SceneGraphIO {
+  appId: string;
+  name?: string | null;
+  description?: string | null;
+  sourceFileAppId?: string | null;
+  rootFrameAppId?: string | null;
+  frames?: FrameIO[];
+  joints?: JointIO[];
+}
+
+export interface SceneGraphError {
+  status: number;
+  message: string;
+  detail: string;
+}
+
+export interface SceneListItem {
+  appId: string;
+  name?: string | null;
+  description?: string | null;
+  sourceFileAppId?: string | null;
+  rootFrameAppId?: string | null;
+  frameCount: number;
+  jointCount: number;
+  createdAt?: number | null;
+  updatedAt?: number | null;
+}
+
+export interface SceneListPage {
+  items: SceneListItem[];
+  total: number;
+  page: number;
+  size: number;
+}
+
+export interface ListOptions {
+  page?: number;
+  size?: number;
+}
+
+export function sceneGraphErrorMessageForStatus(
+  status: number,
+  fallback?: string,
+): string {
+  switch (status) {
+    case 401:
+      return "Sign in expired — refresh the page.";
+    case 403:
+      return "You don't have access to this scene.";
+    case 404:
+      return "Scene not found.";
+    case 409:
+      return "Conflict — the parent or child frame is missing or invalid.";
+    case 400:
+      return fallback ?? "Malformed request — check the required fields.";
+    case 500:
+      return fallback ?? "Server error while reading the scene graph.";
+    default:
+      return fallback ?? `Unexpected error (HTTP ${status}).`;
+  }
+}
+
+function v2BaseUrl(): string {
+  const config = useRuntimeConfig().public;
+  const explicit = config.backendV2ApiUrl as string | undefined;
+  if (explicit && explicit.length > 0) return explicit.replace(/\/$/, "");
+  return (config.backendApiUrl as string)
+    .replace(/\/shepard\/api\/?$/, "")
+    .replace(/\/$/, "");
+}
+
+export function useSceneGraph() {
+  const loading = ref(false);
+  const error = ref<SceneGraphError | null>(null);
+
+  async function authHeaders(): Promise<Record<string, string> | null> {
+    const { data: session } = useAuth();
+    const accessToken = session.value?.accessToken;
+    if (!accessToken) {
+      error.value = {
+        status: 401,
+        message: sceneGraphErrorMessageForStatus(401),
+        detail: "No access token available.",
+      };
+      return null;
+    }
+    return {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+  }
+
+  async function readErrorBody(response: Response): Promise<string> {
+    try {
+      const json = (await response.json()) as { detail?: string; message?: string };
+      return json.detail ?? json.message ?? "";
+    } catch {
+      try {
+        return await response.text();
+      } catch {
+        return "";
+      }
+    }
+  }
+
+  function setNetworkError(e: unknown): void {
+    const detail = e instanceof Error ? e.message : "Network error";
+    error.value = {
+      status: 0,
+      message:
+        "Network error reaching the scene-graph endpoint — check that the backend is reachable.",
+      detail,
+    };
+  }
+
+  async function list(opts: ListOptions = {}): Promise<SceneListPage | null> {
+    loading.value = true;
+    error.value = null;
+    try {
+      const headers = await authHeaders();
+      if (!headers) return null;
+      const params = new URLSearchParams();
+      if (typeof opts.page === "number") params.set("page", String(opts.page));
+      if (typeof opts.size === "number") params.set("size", String(opts.size));
+      const qs = params.toString();
+      const url = `${v2BaseUrl()}/v2/scene-graphs${qs ? `?${qs}` : ""}`;
+      const response = await fetch(url, { method: "GET", headers });
+      if (response.ok) {
+        return (await response.json()) as SceneListPage;
+      }
+      const detail = await readErrorBody(response);
+      error.value = {
+        status: response.status,
+        message: sceneGraphErrorMessageForStatus(response.status, detail),
+        detail: detail.slice(0, 500),
+      };
+      return null;
+    } catch (e) {
+      setNetworkError(e);
+      return null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function fetchScene(sceneAppId: string): Promise<SceneGraphIO | null> {
+    loading.value = true;
+    error.value = null;
+    try {
+      const headers = await authHeaders();
+      if (!headers) return null;
+      const url = `${v2BaseUrl()}/v2/scene-graphs/${encodeURIComponent(sceneAppId)}`;
+      const response = await fetch(url, { method: "GET", headers });
+      if (response.ok) {
+        return (await response.json()) as SceneGraphIO;
+      }
+      const detail = await readErrorBody(response);
+      error.value = {
+        status: response.status,
+        message: sceneGraphErrorMessageForStatus(response.status, detail),
+        detail: detail.slice(0, 500),
+      };
+      return null;
+    } catch (e) {
+      setNetworkError(e);
+      return null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  return {
+    loading,
+    error,
+    list,
+    fetchScene,
+  };
+}

--- a/frontend/pages/scene-graphs/index.vue
+++ b/frontend/pages/scene-graphs/index.vue
@@ -1,0 +1,215 @@
+<script setup lang="ts">
+import { isPlausibleAppId } from "~/utils/toolsLanding";
+import {
+  formatEpochMillis,
+  resolveLandingBranch,
+} from "~/utils/sceneGraphsLanding";
+import { useSceneGraph, type SceneListItem } from "~/composables/useSceneGraph";
+
+const router = useRouter();
+const { fetchScene, list, error: sceneError } = useSceneGraph();
+
+const rows = ref<SceneListItem[]>([]);
+const totalRows = ref(0);
+const page = ref(1);
+const itemsPerPage = ref(25);
+const listLoading = ref(false);
+const listError = ref<string | null>(null);
+
+const headers = [
+  { title: "Name", key: "name", sortable: false },
+  { title: "# frames", key: "frameCount", sortable: false, align: "end" as const },
+  { title: "# joints", key: "jointCount", sortable: false, align: "end" as const },
+  { title: "Updated", key: "updatedAt", sortable: false },
+  { title: "AppId", key: "appId", sortable: false },
+];
+
+async function loadPage(opts: { page: number; itemsPerPage: number }): Promise<void> {
+  listLoading.value = true;
+  listError.value = null;
+  const result = await list({
+    page: Math.max(0, opts.page - 1),
+    size: opts.itemsPerPage,
+  });
+  if (result) {
+    rows.value = result.items ?? [];
+    totalRows.value = result.total ?? 0;
+  } else {
+    rows.value = [];
+    totalRows.value = 0;
+    listError.value =
+      sceneError.value?.message ?? "Could not load scene graphs.";
+  }
+  listLoading.value = false;
+}
+
+const landingBranch = computed(() =>
+  resolveLandingBranch(totalRows.value, listLoading.value, listError.value),
+);
+
+const openByAppId = ref("");
+const openError = ref<string | null>(null);
+const opening = ref(false);
+
+async function openScene() {
+  const id = openByAppId.value.trim();
+  if (!id) {
+    openError.value = "Enter a scene appId.";
+    return;
+  }
+  if (!isPlausibleAppId(id)) {
+    openError.value = "That doesn't look like a UUID — expected 8-4-4-4-12 hex.";
+    return;
+  }
+  openError.value = null;
+  opening.value = true;
+  try {
+    const scene = await fetchScene(id);
+    if (scene) {
+      await router.push(`/scene-graphs/${id}`);
+    } else {
+      openError.value = "No scene found with that appId, or you lack access.";
+    }
+  } finally {
+    opening.value = false;
+  }
+}
+
+useHead({ title: "Scene graphs | shepard" });
+</script>
+
+<template>
+  <v-container class="pa-6" style="max-width: 1100px">
+    <h1 class="text-h4 mb-2">Scene graphs</h1>
+    <p class="text-body-1 text-medium-emphasis mb-6">
+      Coordinate-frame trees + joints describing a digital twin or robot model.
+      Scenes are created from URDF / RDK uploads, or directly via
+      <code>POST /v2/scene-graphs</code> from the API.
+    </p>
+
+    <v-alert
+      v-if="landingBranch === 'error'"
+      type="error"
+      variant="tonal"
+      class="mb-4"
+      data-testid="scene-graphs-list-error"
+    >
+      {{ listError }}
+    </v-alert>
+
+    <v-card
+      v-if="landingBranch === 'table'"
+      variant="outlined"
+      class="mb-6"
+      data-testid="scene-graphs-list-card"
+    >
+      <v-data-table-server
+        v-model:items-per-page="itemsPerPage"
+        v-model:page="page"
+        :headers="headers"
+        :items="rows"
+        :items-length="totalRows"
+        :loading="listLoading"
+        :items-per-page-options="[10, 25, 50, 100]"
+        item-value="appId"
+        density="comfortable"
+        data-testid="scene-graphs-list-table"
+        @update:options="loadPage"
+      >
+        <template #[`item.name`]="{ item }">
+          <a
+            class="scene-row-link"
+            :href="`/scene-graphs/${item.appId}`"
+            data-testid="scene-graphs-row-name"
+            @click.prevent="router.push(`/scene-graphs/${item.appId}`)"
+          >
+            {{ item.name?.trim() || "(unnamed scene)" }}
+          </a>
+        </template>
+        <template #[`item.updatedAt`]="{ item }">
+          {{ formatEpochMillis(item.updatedAt ?? item.createdAt) }}
+        </template>
+        <template #[`item.appId`]="{ item }">
+          <span class="appid-mono">
+            <CopyTextButton :text="item.appId" />
+          </span>
+        </template>
+      </v-data-table-server>
+    </v-card>
+
+    <v-card
+      v-if="landingBranch === 'help'"
+      variant="outlined"
+      class="mb-6"
+      data-testid="scene-graphs-empty-card"
+    >
+      <v-card-title>No scenes yet</v-card-title>
+      <v-card-text>
+        <ul class="ml-4">
+          <li>
+            Upload a URDF file as a FileReference, then use its "Open in
+            scene viewer" action.
+          </li>
+          <li>
+            Drop an RDK package into a Collection; the RDK importer mints a
+            scene per robot.
+          </li>
+          <li>
+            From the API:
+            <code>POST /v2/scene-graphs</code> with an empty body returns a
+            new <code>appId</code> you can paste below.
+          </li>
+        </ul>
+      </v-card-text>
+    </v-card>
+
+    <v-expansion-panels variant="accordion" class="mb-2">
+      <v-expansion-panel data-testid="scene-graphs-open-by-appid-panel">
+        <v-expansion-panel-title>Open by appId</v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <v-form @submit.prevent="openScene">
+            <v-text-field
+              v-model="openByAppId"
+              label="Scene appId (UUID v7)"
+              placeholder="0197b6a2-…"
+              density="compact"
+              variant="outlined"
+              hide-details="auto"
+              :error-messages="openError ? [openError] : []"
+              :loading="opening"
+              data-testid="scene-graphs-open-by-appid-input"
+              autocomplete="off"
+            />
+            <div class="mt-3">
+              <v-btn
+                color="primary"
+                type="submit"
+                :disabled="opening"
+                data-testid="scene-graphs-open-by-appid-submit"
+              >
+                Open scene
+              </v-btn>
+            </div>
+          </v-form>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+    </v-expansion-panels>
+  </v-container>
+</template>
+
+<style scoped>
+.scene-row-link {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.scene-row-link:hover {
+  text-decoration: underline;
+}
+
+.appid-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+}
+</style>

--- a/frontend/tests/unit/sceneGraphsLanding.test.ts
+++ b/frontend/tests/unit/sceneGraphsLanding.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatEpochMillis,
+  resolveLandingBranch,
+} from "~/utils/sceneGraphsLanding";
+import { isPlausibleAppId } from "~/utils/toolsLanding";
+
+describe("formatEpochMillis", () => {
+  it("returns em-dash for null", () => {
+    expect(formatEpochMillis(null)).toBe("—");
+  });
+
+  it("returns em-dash for undefined", () => {
+    expect(formatEpochMillis(undefined)).toBe("—");
+  });
+
+  it("formats a known epoch millis value", () => {
+    const result = formatEpochMillis(0);
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).not.toBe("—");
+  });
+
+  it("formats a recent timestamp without throwing", () => {
+    const ts = new Date("2026-05-30T12:00:00Z").getTime();
+    const result = formatEpochMillis(ts);
+    expect(result).toMatch(/2026/);
+  });
+});
+
+describe("resolveLandingBranch", () => {
+  it("returns 'table' when there are rows", () => {
+    expect(resolveLandingBranch(5, false, null)).toBe("table");
+  });
+
+  it("returns 'table' while loading even with zero rows", () => {
+    expect(resolveLandingBranch(0, true, null)).toBe("table");
+  });
+
+  it("returns 'error' when error present and not loading and no rows", () => {
+    expect(resolveLandingBranch(0, false, "Something went wrong")).toBe("error");
+  });
+
+  it("returns 'help' when empty and no error and not loading", () => {
+    expect(resolveLandingBranch(0, false, null)).toBe("help");
+  });
+
+  it("returns 'table' when rows > 0 even with an error message", () => {
+    expect(resolveLandingBranch(3, false, "partial error")).toBe("table");
+  });
+});
+
+describe("isPlausibleAppId", () => {
+  it("accepts a valid UUID v7", () => {
+    expect(
+      isPlausibleAppId("0197b6a2-1234-7abc-89de-abcdef012345"),
+    ).toBe(true);
+  });
+
+  it("rejects null", () => {
+    expect(isPlausibleAppId(null)).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isPlausibleAppId(undefined)).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isPlausibleAppId("")).toBe(false);
+  });
+
+  it("rejects a plain string", () => {
+    expect(isPlausibleAppId("not-a-uuid")).toBe(false);
+  });
+
+  it("rejects a UUID missing a segment", () => {
+    expect(isPlausibleAppId("0197b6a2-1234-7abc-89de")).toBe(false);
+  });
+
+  it("accepts uppercase UUID (lowercased internally)", () => {
+    expect(
+      isPlausibleAppId("0197B6A2-1234-7ABC-89DE-ABCDEF012345"),
+    ).toBe(true);
+  });
+});

--- a/frontend/utils/sceneGraphsLanding.ts
+++ b/frontend/utils/sceneGraphsLanding.ts
@@ -1,0 +1,20 @@
+export function formatEpochMillis(epoch: number | null | undefined): string {
+  if (epoch === null || epoch === undefined) return "—";
+  return new Date(epoch).toLocaleDateString("en-UK", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export type LandingBranch = "table" | "help" | "error";
+
+export function resolveLandingBranch(
+  totalRows: number,
+  loading: boolean,
+  errorMessage: string | null,
+): LandingBranch {
+  if (errorMessage !== null && totalRows === 0 && !loading) return "error";
+  if (totalRows > 0 || loading) return "table";
+  return "help";
+}

--- a/frontend/utils/toolsLanding.ts
+++ b/frontend/utils/toolsLanding.ts
@@ -1,0 +1,7 @@
+export function isPlausibleAppId(input: string | null | undefined): boolean {
+  if (!input) return false;
+  const trimmed = input.trim().toLowerCase();
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(
+    trimmed,
+  );
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces the placeholder `/scene-graphs` landing (open-by-appId form only) with a real `v-data-table-server` backed by `GET /v2/scene-graphs`
- Columns: **Name** (click-to-navigate), **# frames**, **# joints**, **Updated** (formatted date), **AppId** (copyable via `CopyTextButton`)
- Three display branches: `table` (≥1 scene or load in-flight), `help` (empty catalogue, onboarding card), `error` (fetch failed, error alert); open-by-appId power-user form retained as a collapsible panel below
- Server-side pagination via `v-data-table-server` (25 rows/page default, options: 10/25/50/100)

## New files

| File | Purpose |
|------|---------|
| `frontend/composables/useSceneGraph.ts` | `list()` + `fetchScene()` wrappers around `/v2/scene-graphs`; exports `SceneListItem`, `SceneListPage`, `SceneGraphIO` types |
| `frontend/utils/toolsLanding.ts` | `isPlausibleAppId()` — UUID shape validator used by the open-by-appId form |
| `frontend/utils/sceneGraphsLanding.ts` | `formatEpochMillis()` + `resolveLandingBranch()` — pure helpers for date formatting and display-branch resolution |
| `frontend/pages/scene-graphs/index.vue` | The new landing page |
| `frontend/tests/unit/sceneGraphsLanding.test.ts` | 16 unit tests covering all three pure-function utils |

## Backlog row

Closes the "Frontend follow-up still queued" item in **SCENEGRAPH-LIST-1** (`aidocs/16-dispatcher-backlog.md` line 943): "swap the `/scene-graphs/index.vue` info-card for a real `v-data-table` once the endpoint exists."

## Test plan

- [ ] `npm run typecheck` — clean (no errors)
- [ ] `npm run lint` — no errors on new files (pre-existing lint debt in unrelated test files unchanged)
- [ ] `npm run test` — `sceneGraphsLanding.test.ts` 16/16 pass; `useFetchRecentCollections` failures are pre-existing, unrelated to this PR
- [ ] Navigate to `/scene-graphs` — table renders when scenes exist, help card shows when catalogue empty, error alert shows on network failure
- [ ] Click a scene name row — navigates to `/scene-graphs/{appId}`
- [ ] "Open by appId" expansion panel — validates UUID shape, navigates on valid scene, shows error on not-found

https://claude.ai/code/session_01V44cRCMYdAtJcFK2k8rwHX
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V44cRCMYdAtJcFK2k8rwHX)_