### PR TITLE
fix(FRONTEND-LINT-DEBT-04): explain bare @ts-expect-error in SSE test

### DIFF
--- a/frontend/tests/unit/useCollectionEvents.test.ts
+++ b/frontend/tests/unit/useCollectionEvents.test.ts
@@ -193,7 +193,7 @@ describe("parseBuffer — malformed JSON", () => {
 
     // @ts-expect-error result is assigned in the callback above
     expect(result.events).toHaveLength(0);
-    // @ts-expect-error
+    // @ts-expect-error result is assigned in the expect() callback above; TS can't see it
     expect(result.remaining).toBe("");
   });
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds an explanation to the bare `// @ts-expect-error` at line 196 of `frontend/tests/unit/useCollectionEvents.test.ts`
- Explanation matches the pattern already used on line 194 for the same reason: TypeScript cannot see that `result` is assigned inside the `expect()` callback, so the suppression is needed at the point of use on the next line
- No other files touched; one-line change

## Test plan

- [x] `npm run lint` in `frontend/` — no new errors introduced by this change (pre-existing lint debt in other files is unaffected)
- [x] `npm run typecheck` in `frontend/` — passes cleanly
- [x] Only line 196 of `useCollectionEvents.test.ts` changed; line 194 left intact

https://claude.ai/code/session_01Q7zVrmEQRkcTXKQtvLLttF
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7zVrmEQRkcTXKQtvLLttF)_