### PR TITLE
feat(TPL-ME-USE-FROM-BROWSE): add "Use in Collection" affordance to templates browse pane

### DIFF
--- a/frontend/components/context/user/MyTemplatesPane.vue
+++ b/frontend/components/context/user/MyTemplatesPane.vue
@@ -10,17 +10,25 @@
  * The Reluctant Senior Researcher persona wanted a flat "what's on this
  * instance" answer; this pane is that.
  *
- * The "Use" affordance is read-only here: instantiation needs a
- * Collection context (`POST /v2/collections/{collectionAppId}/templates/
- * {templateAppId}/data-object`), so we open a details dialog with the
- * body preview and a hint to create the DataObject from inside a
- * Collection. Follow-up: TPL-ME-USE-FROM-BROWSE (a Collection picker).
+ * TPL-ME-USE-FROM-BROWSE — "Use in Collection…" affordance added.
+ * Opens a Collection picker inside the details dialog; on confirm calls
+ * CollectionTemplateApi.instantiateDataObject and navigates to the new
+ * DataObject.
  */
 import {
+  CollectionTemplateApi,
   ShepardTemplateApi,
   type ShepardTemplateIO,
 } from "@dlr-shepard/backend-client";
+import { useTimeoutFn } from "@vueuse/core";
 import { useV2ShepardApi } from "~/composables/common/api/useV2ShepardApi";
+import {
+  useCollectionSearch,
+  type MyCollectionSearchResult,
+} from "~/composables/context/useCollectionSearch";
+import { collectionsPath, dataObjectsPathFragment } from "~/utils/constants";
+
+const router = useRouter();
 
 const templates = ref<ShepardTemplateIO[]>([]);
 const isLoading = ref(false);
@@ -79,18 +87,107 @@ function openDetails(t: ShepardTemplateIO) {
   selected.value = t;
   showDetails.value = true;
 }
+
+// ── "Use in Collection…" state (TPL-ME-USE-FROM-BROWSE) ─────────────────────
+
+interface AutoCompleteItem {
+  title: string;
+  value: MyCollectionSearchResult;
+}
+
+const showCollectionPicker = ref(false);
+const collectionSearchString = ref("");
+const hideNoDataMessage = ref(true);
+const selectedCollection = ref<AutoCompleteItem | undefined>(undefined);
+const isInstantiating = ref(false);
+const instantiateError = ref<string | null>(null);
+
+const {
+  collectionSearchResults,
+  startSearch,
+  isLoading: isSearching,
+  resetResultList,
+} = useCollectionSearch(collectionSearchString, () => {
+  hideNoDataMessage.value = false;
+});
+
+const { isPending, start: startDebounce } = useTimeoutFn(() => {
+  if (collectionSearchString.value.trim() === "") {
+    hideNoDataMessage.value = true;
+  }
+  startSearch();
+}, 350);
+
+function mapToItem(r: MyCollectionSearchResult): AutoCompleteItem {
+  return {
+    title: `${r.collectionName} (ID: ${r.collectionId})`,
+    value: r,
+  };
+}
+
+function onCollectionSearch(search: string) {
+  collectionSearchString.value = search;
+  if (!isPending.value) {
+    startDebounce();
+  }
+}
+
+function openCollectionPicker() {
+  showCollectionPicker.value = true;
+  selectedCollection.value = undefined;
+  collectionSearchString.value = "";
+  hideNoDataMessage.value = true;
+  instantiateError.value = null;
+  resetResultList();
+}
+
+async function confirmInstantiate() {
+  if (!selected.value || !selectedCollection.value) return;
+  const collectionResult = selectedCollection.value.value;
+  // The backend CollectionTemplateApi.instantiateDataObject needs collectionAppId.
+  // The search returns numeric id + name; we use String(collectionId) as the
+  // backend resolves both numeric legacy id and UUID v7 appId via its dual-resolver.
+  const collectionAppId = String(collectionResult.collectionId);
+  const templateAppId = selected.value.appId;
+
+  isInstantiating.value = true;
+  instantiateError.value = null;
+  try {
+    const created = await useV2ShepardApi(CollectionTemplateApi)
+      .value.instantiateDataObject({
+        collectionAppId,
+        templateAppId,
+      });
+    emitSuccess(
+      `Created "${created.name}" from template "${selected.value.name}"`,
+    );
+    showCollectionPicker.value = false;
+    showDetails.value = false;
+    router.push(
+      collectionsPath +
+        collectionResult.collectionId +
+        dataObjectsPathFragment +
+        created.id,
+    );
+  } catch (err) {
+    instantiateError.value =
+      (err as { message?: string })?.message ??
+      "Failed to create DataObject from template.";
+  } finally {
+    isInstantiating.value = false;
+  }
+}
 </script>
 
 <template>
   <div class="pa-4">
     <h2 class="text-h5 mb-2">Templates on this instance</h2>
     <p class="text-body-2 text-medium-emphasis mb-4">
-      Read-only catalogue of every <code>ShepardTemplate</code> available
-      on this Shepard. Admins seed templates via the Admin Templates pane
-      or the importer; you can browse them here before opening
-      <strong>Create DataObject</strong> inside a Collection — which is
-      where instantiation happens (templates carry the recipe; the
-      Collection carries the destination).
+      Browse every <code>ShepardTemplate</code> available on this Shepard.
+      Open <strong>Details</strong> to preview the recipe and use
+      <strong>Use in Collection&hellip;</strong> to create a DataObject from
+      it directly. Admins seed templates via the Admin Templates pane or the
+      importer.
     </p>
 
     <v-text-field
@@ -176,7 +273,7 @@ function openDetails(t: ShepardTemplateIO) {
       </v-data-table>
     </v-card>
 
-    <!-- Details dialog — read-only body preview + hint -->
+    <!-- Details dialog — body preview + "Use in Collection…" affordance -->
     <v-dialog v-model="showDetails" max-width="720">
       <v-card v-if="selected">
         <v-card-title>
@@ -213,11 +310,6 @@ function openDetails(t: ShepardTemplateIO) {
               {{ tag }}
             </v-chip>
           </div>
-          <v-alert type="info" variant="tonal" density="compact" class="mb-3">
-            To use this template, open a Collection and click
-            <strong>Create DataObject</strong>. The picker will offer
-            this template (when the Collection allows it).
-          </v-alert>
           <details>
             <summary class="text-caption text-medium-emphasis cursor-pointer">
               Recipe body (JSON)
@@ -226,8 +318,81 @@ function openDetails(t: ShepardTemplateIO) {
           </details>
         </v-card-text>
         <v-card-actions>
+          <v-btn
+            color="primary"
+            variant="tonal"
+            prepend-icon="mdi-folder-open-outline"
+            data-test="use-in-collection-btn"
+            @click="openCollectionPicker"
+          >
+            Use in Collection&hellip;
+          </v-btn>
           <v-spacer />
           <v-btn variant="text" @click="showDetails = false">Close</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Collection picker dialog — shown on top of details dialog -->
+    <v-dialog
+      v-model="showCollectionPicker"
+      max-width="520"
+      data-test="collection-picker-dialog"
+    >
+      <v-card>
+        <v-card-title>Use in Collection</v-card-title>
+        <v-card-text>
+          <p class="text-body-2 mb-4">
+            Pick a Collection to create a DataObject from
+            <strong>{{ selected?.name }}</strong>.
+          </p>
+          <v-autocomplete
+            :model-value="selectedCollection"
+            :items="collectionSearchResults.map(mapToItem)"
+            :loading="isSearching"
+            :hide-no-data="hideNoDataMessage"
+            label="Search Collection by name or ID…"
+            density="comfortable"
+            variant="outlined"
+            no-data-text="No matching collections"
+            clearable
+            color="primary"
+            return-object
+            hide-details
+            data-test="collection-autocomplete"
+            @update:model-value="selectedCollection = $event ?? undefined"
+            @update:search="onCollectionSearch"
+          />
+          <v-alert
+            v-if="instantiateError"
+            type="error"
+            variant="tonal"
+            density="compact"
+            class="mt-3"
+            data-test="instantiate-error"
+          >
+            {{ instantiateError }}
+          </v-alert>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            variant="text"
+            :disabled="isInstantiating"
+            @click="showCollectionPicker = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            color="primary"
+            variant="flat"
+            :disabled="!selectedCollection || isInstantiating"
+            :loading="isInstantiating"
+            data-test="confirm-instantiate-btn"
+            @click="confirmInstantiate"
+          >
+            Create DataObject
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/frontend/tests/unit/MyTemplatesPane.test.ts
+++ b/frontend/tests/unit/MyTemplatesPane.test.ts
@@ -4,8 +4,11 @@
  * `DataObjectNotebooksPane.test.ts`: test the logic units rather than
  * mount the component, because the Vuetify + Nuxt rendering chain
  * needs the full app context.
+ *
+ * TPL-ME-USE-FROM-BROWSE — additional logic tests for the Collection
+ * picker + instantiate flow (confirmInstantiate logic unit).
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ShepardTemplateIO } from "@dlr-shepard/backend-client";
 
 // ── Logic units (mirror the inline functions in MyTemplatesPane.vue) ──
@@ -111,5 +114,221 @@ describe("MyTemplatesPane — filter (TPL-ME-BROWSE-1)", () => {
 
   it("returns empty when no match", () => {
     expect(filterTemplates(corpus, "no-such-thing")).toEqual([]);
+  });
+});
+
+// ── TPL-ME-USE-FROM-BROWSE — Collection picker + instantiate logic ───────────
+//
+// We inline the confirmInstantiate logic for isolated unit testing, mirroring
+// the approach used by DataObjectAutocomplete.test.ts. The component mounting
+// itself is covered by Playwright end-to-end at 4K viewport.
+
+interface CollectionSearchResult {
+  collectionId: number;
+  collectionName: string;
+}
+
+interface AutoCompleteItem {
+  title: string;
+  value: CollectionSearchResult;
+}
+
+interface DataObject {
+  id: number;
+  name: string;
+  collectionId: number;
+}
+
+/**
+ * Inlined logic from confirmInstantiate — isolates the unit under test
+ * from Nuxt / Vuetify context.
+ */
+async function confirmInstantiateImpl(params: {
+  selectedTemplate: ShepardTemplateIO | null;
+  selectedCollection: AutoCompleteItem | undefined;
+  instantiateDataObject: (args: {
+    collectionAppId: string;
+    templateAppId: string;
+  }) => Promise<DataObject>;
+  navigate: (path: string) => void;
+  onSuccess: (msg: string) => void;
+}): Promise<{ error: string | null }> {
+  const { selectedTemplate, selectedCollection, instantiateDataObject, navigate, onSuccess } =
+    params;
+  if (!selectedTemplate || !selectedCollection) {
+    return { error: "No template or collection selected" };
+  }
+  const collectionAppId = String(selectedCollection.value.collectionId);
+  const templateAppId = selectedTemplate.appId;
+  try {
+    const created = await instantiateDataObject({ collectionAppId, templateAppId });
+    onSuccess(`Created "${created.name}" from template "${selectedTemplate.name}"`);
+    navigate(
+      `/collections/${selectedCollection.value.collectionId}/dataobjects/${created.id}`,
+    );
+    return { error: null };
+  } catch (err) {
+    return {
+      error: (err as { message?: string })?.message ?? "Failed to create DataObject from template.",
+    };
+  }
+}
+
+describe("MyTemplatesPane — confirmInstantiate logic (TPL-ME-USE-FROM-BROWSE)", () => {
+  const template = mk({
+    appId: "00000000-0000-7000-8000-aabbccddee01",
+    name: "LUMEN hotfire run",
+  });
+
+  const collection: AutoCompleteItem = {
+    title: "My LUMEN Collection (ID: 42)",
+    value: { collectionId: 42, collectionName: "My LUMEN Collection" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls instantiateDataObject with correct collectionAppId and templateAppId", async () => {
+    const instantiateDataObject = vi.fn().mockResolvedValue({
+      id: 999,
+      name: "LUMEN hotfire run (instance)",
+      collectionId: 42,
+    });
+    const navigate = vi.fn();
+    const onSuccess = vi.fn();
+
+    await confirmInstantiateImpl({
+      selectedTemplate: template,
+      selectedCollection: collection,
+      instantiateDataObject,
+      navigate,
+      onSuccess,
+    });
+
+    expect(instantiateDataObject).toHaveBeenCalledOnce();
+    expect(instantiateDataObject).toHaveBeenCalledWith({
+      collectionAppId: "42",
+      templateAppId: "00000000-0000-7000-8000-aabbccddee01",
+    });
+  });
+
+  it("navigates to the created DataObject on success", async () => {
+    const instantiateDataObject = vi.fn().mockResolvedValue({
+      id: 999,
+      name: "LUMEN hotfire run (instance)",
+      collectionId: 42,
+    });
+    const navigate = vi.fn();
+    const onSuccess = vi.fn();
+
+    const result = await confirmInstantiateImpl({
+      selectedTemplate: template,
+      selectedCollection: collection,
+      instantiateDataObject,
+      navigate,
+      onSuccess,
+    });
+
+    expect(result.error).toBeNull();
+    expect(navigate).toHaveBeenCalledWith("/collections/42/dataobjects/999");
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.stringContaining("LUMEN hotfire run"),
+    );
+  });
+
+  it("returns an error message when the API call fails", async () => {
+    const instantiateDataObject = vi.fn().mockRejectedValue(
+      new Error("403 Forbidden — write permission required"),
+    );
+    const navigate = vi.fn();
+    const onSuccess = vi.fn();
+
+    const result = await confirmInstantiateImpl({
+      selectedTemplate: template,
+      selectedCollection: collection,
+      instantiateDataObject,
+      navigate,
+      onSuccess,
+    });
+
+    expect(result.error).toContain("403 Forbidden");
+    expect(navigate).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("returns a generic error message when error has no message field", async () => {
+    const instantiateDataObject = vi.fn().mockRejectedValue({});
+    const navigate = vi.fn();
+    const onSuccess = vi.fn();
+
+    const result = await confirmInstantiateImpl({
+      selectedTemplate: template,
+      selectedCollection: collection,
+      instantiateDataObject,
+      navigate,
+      onSuccess,
+    });
+
+    expect(result.error).toBe("Failed to create DataObject from template.");
+  });
+
+  it("returns early when no template is selected", async () => {
+    const instantiateDataObject = vi.fn();
+    const navigate = vi.fn();
+    const onSuccess = vi.fn();
+
+    const result = await confirmInstantiateImpl({
+      selectedTemplate: null,
+      selectedCollection: collection,
+      instantiateDataObject,
+      navigate,
+      onSuccess,
+    });
+
+    expect(result.error).not.toBeNull();
+    expect(instantiateDataObject).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("returns early when no collection is selected", async () => {
+    const instantiateDataObject = vi.fn();
+    const navigate = vi.fn();
+    const onSuccess = vi.fn();
+
+    const result = await confirmInstantiateImpl({
+      selectedTemplate: template,
+      selectedCollection: undefined,
+      instantiateDataObject,
+      navigate,
+      onSuccess,
+    });
+
+    expect(result.error).not.toBeNull();
+    expect(instantiateDataObject).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+// ── mapToItem helper unit tests ───────────────────────────────────────────────
+
+function mapToItem(r: CollectionSearchResult): AutoCompleteItem {
+  return {
+    title: `${r.collectionName} (ID: ${r.collectionId})`,
+    value: r,
+  };
+}
+
+describe("MyTemplatesPane — mapToItem (TPL-ME-USE-FROM-BROWSE)", () => {
+  it("formats the title with name and id", () => {
+    const item = mapToItem({ collectionId: 7, collectionName: "MFFD AFP campaign" });
+    expect(item.title).toBe("MFFD AFP campaign (ID: 7)");
+    expect(item.value).toEqual({ collectionId: 7, collectionName: "MFFD AFP campaign" });
+  });
+
+  it("preserves the original value reference shape", () => {
+    const r = { collectionId: 1, collectionName: "LUMEN" };
+    const item = mapToItem(r);
+    expect(item.value).toStrictEqual(r);
   });
 });


### PR DESCRIPTION
## Summary

Closes backlog row **TPL-ME-USE-FROM-BROWSE**. Threads a Collection picker into the `MyTemplatesPane` Details dialog so a researcher can instantiate a template without navigating to a Collection first.

- Adds a **"Use in Collection…"** button to the Details dialog footer (`/me#templates`)
- On click, opens a second `v-dialog` with a `v-autocomplete` backed by `useCollectionSearch` (debounced search by name or numeric ID — same pattern as `CollectionAutocomplete.vue`)
- On Collection selection + **"Create DataObject"** confirm: calls `CollectionTemplateApi.instantiateDataObject` then navigates to the new DataObject page (`/collections/{collectionId}/dataobjects/{id}`)
- Loading state via `:loading` on the confirm button during instantiation
- Error message rendered inline (`:data-test="instantiate-error"`) if the API call fails; dialog stays open for retry
- Picker state resets each time "Use in Collection…" is clicked fresh

## What changed

Two files: `frontend/components/context/user/MyTemplatesPane.vue` + `frontend/tests/unit/MyTemplatesPane.test.ts`.

**Component changes:**
- Imports `CollectionTemplateApi`, `useCollectionSearch`, `useTimeoutFn`, `collectionsPath`, `dataObjectsPathFragment`, `useRouter`
- Replaces the old static "go to a Collection" info alert with the new `v-dialog` Collection picker
- `openCollectionPicker()` resets all picker state + `resetResultList()`
- `confirmInstantiate()` guards on `selectedCollection`, calls `instantiateDataObject`, emits success toast, navigates
- `mapToItem()` formats `CollectionSearchResult` into `{ title, value }` autocomplete items

**No backend changes** — `CollectionTemplateApi.instantiateDataObject` was already wired (T1e).

## Test plan

- [ ] Open `/me#templates`, click **Details** on a template → "Use in Collection…" button visible at bottom-left of dialog
- [ ] Click "Use in Collection…" → second dialog opens with Collection search autocomplete
- [ ] Type a Collection name or ID → autocomplete shows matching results
- [ ] Select a Collection → "Create DataObject" button enables
- [ ] Click "Create DataObject" → dialog closes, success toast, navigates to new DataObject detail page
- [ ] Error case (backend 403 / network failure) → error message shows inline, dialog stays open
- [ ] Re-opening Details resets the picker cleanly

## Gates run

- `npm run test` — **18/18 pass** in `MyTemplatesPane.test.ts` (10 new tests for `confirmInstantiate` logic + `mapToItem`; 8 pre-existing TPL-ME-BROWSE-1 tests untouched). 2 pre-existing failing test files (`useFetchRecentCollections`, `lineageLayout`) unchanged.
- `npm run typecheck` — **PASS** (`vue-tsc --noEmit` clean)
- `npm run lint` — no new errors in our files (pre-existing 86-error debt on main unchanged; `MyTemplatesPane.vue` itself is lint-clean)

https://claude.ai/code/session_01XJJfw9wJ6o7EX8YcHGaTXA