### PR TITLE
feat(J1e-PR-06-AUTOFETCH-02): canonical ?file= URL encoding + round-trip test for Open in Jupyter

### DIFF
--- a/frontend/components/context/display-components/data-references/DataObjectDataReferencesTable.vue
+++ b/frontend/components/context/display-components/data-references/DataObjectDataReferencesTable.vue
@@ -5,6 +5,7 @@ import type { DataTableElement } from "./dataTableElement";
 import { mapDataReferenceToDataTableElement } from "./dataTableElementMappingUtil";
 import { useManageGitReferences } from "~/composables/context/useManageGitReferences";
 import { useJupyterConfig } from "~/composables/context/admin/useJupyterConfig";
+import { buildJupyterLaunchUrl, buildShepardFileDownloadUrl } from "~/utils/jupyterLaunchUrl";
 
 interface DataObjectDataReferencesTableProps {
   collectionId: number;
@@ -257,23 +258,27 @@ const jupyterAffordanceVisible = computed(
 
 /**
  * Build the JupyterHub launch URL for a singleton FileReference appId.
- * Follows the `{hubUrl}/hub/spawn?file={downloadUrl}` shape — see
- * docs/admin/runbooks/jupyterhub-config.md for the JupyterHub-side
- * convention map (nbgitpuller / `?fromURL=` / `/user-redirect/`).
+ * Delegates to `buildJupyterLaunchUrl` (utils/jupyterLaunchUrl.ts) which
+ * ensures the `?file=` value is percent-encoded with `encodeURIComponent`.
+ *
+ * The canonical shape is:
+ *   {hubBase}/hub/spawn?file={encodeURIComponent(shepardFileDownloadUrl)}
+ *
+ * See `plugins/jupyter/docs/quickstart.md` for the user-facing description
+ * and `plugins/jupyter/config/jupyterhub_config.py` for the server-side
+ * pre-spawn hook that reads `?file=`.
  *
  * Returns null when the affordance gate is closed.
  */
 function jupyterLaunchUrl(appId: string): string | null {
   const cfg = jupyterConfig.value;
   if (!cfg || !cfg.enabled || !cfg.hubUrl) return null;
-  const downloadUrl = `${v2BaseUrl()}/v2/files/${encodeURIComponent(appId)}/content`;
-  const hubBase = cfg.hubUrl.replace(/\/$/, "");
-  return `${hubBase}/hub/spawn?file=${encodeURIComponent(downloadUrl)}`;
+  return buildJupyterLaunchUrl(cfg.hubUrl, v2BaseUrl(), appId);
 }
 
 /** Build the direct download URL for a FR1b singleton appId. */
 function singletonDownloadUrl(appId: string): string {
-  return `${v2BaseUrl()}/v2/files/${encodeURIComponent(appId)}/content`;
+  return buildShepardFileDownloadUrl(v2BaseUrl(), appId);
 }
 
 /** Format a byte count as B / KB / MB / GB. */

--- a/frontend/tests/unit/jupyterLaunchUrl.test.ts
+++ b/frontend/tests/unit/jupyterLaunchUrl.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for utils/jupyterLaunchUrl.ts (J1e-PR-06-AUTOFETCH-02).
+ *
+ * Covers:
+ * - `buildShepardFileDownloadUrl` — constructs the Shepard file content URL
+ *   with the appId percent-encoded.
+ * - `buildJupyterLaunchUrl` — builds the canonical JupyterHub launch URL
+ *   with the entire Shepard download URL percent-encoded in the `?file=`
+ *   query parameter.
+ * - Round-trip invariant: `decodeURIComponent(encodedParam)` === original URL.
+ * - Edge cases: URLs with `?`, `&`, `=`, spaces, and unicode.
+ * - Guard clauses: null / empty / undefined inputs return null.
+ * - Trailing-slash normalisation on both hubUrl and v2BaseUrl.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildShepardFileDownloadUrl,
+  buildJupyterLaunchUrl,
+} from "~/utils/jupyterLaunchUrl";
+
+// ---------------------------------------------------------------------------
+// buildShepardFileDownloadUrl
+// ---------------------------------------------------------------------------
+
+describe("buildShepardFileDownloadUrl", () => {
+  it("constructs the canonical /v2/files/{appId}/content URL", () => {
+    const url = buildShepardFileDownloadUrl(
+      "https://shepard.example.org",
+      "01900000-0000-7000-8000-000000000001",
+    );
+    expect(url).toBe(
+      "https://shepard.example.org/v2/files/01900000-0000-7000-8000-000000000001/content",
+    );
+  });
+
+  it("strips a trailing slash from v2BaseUrl", () => {
+    const url = buildShepardFileDownloadUrl(
+      "https://shepard.example.org/",
+      "abc123",
+    );
+    expect(url).toBe(
+      "https://shepard.example.org/v2/files/abc123/content",
+    );
+  });
+
+  it("percent-encodes special characters in the appId (defensive, UUIDs are safe)", () => {
+    // UUIDs only contain [0-9a-f-] which are already URL-safe, but the
+    // implementation uses encodeURIComponent for robustness.
+    const url = buildShepardFileDownloadUrl(
+      "https://shepard.example.org",
+      "id with spaces",
+    );
+    expect(url).toBe(
+      "https://shepard.example.org/v2/files/id%20with%20spaces/content",
+    );
+  });
+
+  it("works with a path-mounted base URL (no trailing slash)", () => {
+    const url = buildShepardFileDownloadUrl(
+      "https://shepard.example.org/shepard-api",
+      "abc123",
+    );
+    expect(url).toBe(
+      "https://shepard.example.org/shepard-api/v2/files/abc123/content",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildJupyterLaunchUrl — canonical URL shape
+// ---------------------------------------------------------------------------
+
+describe("buildJupyterLaunchUrl — canonical shape", () => {
+  const HUB = "https://shepard.example.org/jupyterhub";
+  const API = "https://shepard.example.org";
+  const APP_ID = "01900000-0000-7000-8000-000000000001";
+
+  it("produces the canonical {hubBase}/hub/spawn?file=<encoded-url> shape", () => {
+    const result = buildJupyterLaunchUrl(HUB, API, APP_ID);
+    expect(result).not.toBeNull();
+    // Must start with the hub base + /hub/spawn
+    expect(result).toMatch(/^https:\/\/shepard\.example\.org\/jupyterhub\/hub\/spawn\?file=/);
+  });
+
+  it("encodes the Shepard download URL in the ?file= parameter", () => {
+    const result = buildJupyterLaunchUrl(HUB, API, APP_ID)!;
+    const queryPart = result.split("?file=")[1]!;
+    const decoded = decodeURIComponent(queryPart);
+    expect(decoded).toBe(
+      `${API}/v2/files/${APP_ID}/content`,
+    );
+  });
+
+  it("round-trip invariant: decode(encoded) === original download URL", () => {
+    const expectedDownloadUrl = buildShepardFileDownloadUrl(API, APP_ID);
+    const launchUrl = buildJupyterLaunchUrl(HUB, API, APP_ID)!;
+    const encodedFileParam = launchUrl.split("?file=")[1]!;
+    expect(decodeURIComponent(encodedFileParam)).toBe(expectedDownloadUrl);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildJupyterLaunchUrl — URL-encoding correctness for special characters
+// ---------------------------------------------------------------------------
+
+describe("buildJupyterLaunchUrl — encoding of special characters in the inner URL", () => {
+  const APP_ID = "abc123";
+
+  /**
+   * Returns the decoded `?file=` value from the generated launch URL.
+   * The Shepard download URL itself does not contain `?` or `&` in the
+   * happy path (it is a clean /v2/files/{appId}/content path), but a
+   * future signed-URL variant or query-string augmentation could add them.
+   * We verify the encoding is correct end-to-end by constructing a realistic
+   * "complex" inner URL and checking the round-trip.
+   */
+  it("?  in the inner URL is encoded as %3F so JupyterHub parses correctly", () => {
+    // Simulate an inner URL that contains a query string
+    const innerUrl = `https://shepard.example.org/v2/files/${APP_ID}/content?token=abc&expires=999`;
+    // Build a launch URL manually using the same encoding logic to verify
+    const hubBase = "https://hub.example.org/jupyterhub";
+    const launchUrl = `${hubBase}/hub/spawn?file=${encodeURIComponent(innerUrl)}`;
+
+    const encoded = launchUrl.split("?file=")[1]!;
+    // '?' must appear as %3F, '&' as %26, '=' as %3D
+    expect(encoded).toContain("%3F");
+    expect(encoded).toContain("%26");
+    expect(encoded).toContain("%3D");
+    // Round-trip
+    expect(decodeURIComponent(encoded)).toBe(innerUrl);
+  });
+
+  it("spaces in a file path segment are encoded as %20", () => {
+    const appId = "id with spaces and=equals";
+    const result = buildJupyterLaunchUrl(
+      "https://hub.example.org",
+      "https://shepard.example.org",
+      appId,
+    )!;
+    const encoded = result.split("?file=")[1]!;
+    // Decoded must equal the download URL
+    const decoded = decodeURIComponent(encoded);
+    expect(decoded).toBe(
+      `https://shepard.example.org/v2/files/${encodeURIComponent(appId)}/content`,
+    );
+  });
+
+  it("encodes & in a hypothetical signed URL so it does not split the outer query", () => {
+    const innerUrl = "https://shepard.example.org/v2/files/abc/content&sig=XYZ";
+    const encoded = encodeURIComponent(innerUrl);
+    // & must not appear literally in the encoded value
+    expect(encoded).not.toContain("&");
+    expect(encoded).toContain("%26");
+    expect(decodeURIComponent(encoded)).toBe(innerUrl);
+  });
+
+  it("encodes = in a hypothetical signed URL so it does not confuse the outer parser", () => {
+    const innerUrl = "https://shepard.example.org/v2/files/abc/content?key=val";
+    const encoded = encodeURIComponent(innerUrl);
+    expect(encoded).not.toContain("=");
+    expect(decodeURIComponent(encoded)).toBe(innerUrl);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildJupyterLaunchUrl — trailing-slash normalisation
+// ---------------------------------------------------------------------------
+
+describe("buildJupyterLaunchUrl — trailing-slash normalisation", () => {
+  const APP_ID = "abc123";
+  const API = "https://shepard.example.org";
+
+  it("strips a trailing slash from hubUrl", () => {
+    const result = buildJupyterLaunchUrl(
+      "https://hub.example.org/jupyterhub/",
+      API,
+      APP_ID,
+    )!;
+    expect(result).toMatch(/^https:\/\/hub\.example\.org\/jupyterhub\/hub\/spawn\?file=/);
+    // Must NOT produce a double slash like /jupyterhub//hub/spawn
+    expect(result).not.toContain("//hub/spawn");
+  });
+
+  it("strips a trailing slash from v2BaseUrl", () => {
+    const result = buildJupyterLaunchUrl(
+      "https://hub.example.org",
+      "https://shepard.example.org/",
+      APP_ID,
+    )!;
+    const downloadUrl = decodeURIComponent(result.split("?file=")[1]!);
+    // Must NOT produce a double slash like //v2/files
+    expect(downloadUrl).not.toContain("//v2");
+    expect(downloadUrl).toBe(
+      `https://shepard.example.org/v2/files/${APP_ID}/content`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildJupyterLaunchUrl — guard clauses (null / empty inputs)
+// ---------------------------------------------------------------------------
+
+describe("buildJupyterLaunchUrl — guard clauses", () => {
+  const API = "https://shepard.example.org";
+  const APP_ID = "abc123";
+
+  it("returns null when hubUrl is null", () => {
+    expect(buildJupyterLaunchUrl(null, API, APP_ID)).toBeNull();
+  });
+
+  it("returns null when hubUrl is undefined", () => {
+    expect(buildJupyterLaunchUrl(undefined, API, APP_ID)).toBeNull();
+  });
+
+  it("returns null when hubUrl is an empty string", () => {
+    expect(buildJupyterLaunchUrl("", API, APP_ID)).toBeNull();
+  });
+
+  it("returns null when appId is an empty string", () => {
+    expect(buildJupyterLaunchUrl("https://hub.example.org", API, "")).toBeNull();
+  });
+});

--- a/frontend/utils/jupyterLaunchUrl.ts
+++ b/frontend/utils/jupyterLaunchUrl.ts
@@ -1,0 +1,58 @@
+/**
+ * Utility for building the canonical JupyterHub launch URL used by the
+ * "Open in JupyterHub" action on Notebook rows (J1e-PR-06-AUTOFETCH-02).
+ *
+ * Shape:
+ *   {hubBase}/hub/spawn?file={encodeURIComponent(shepardFileDownloadUrl)}
+ *
+ * where `shepardFileDownloadUrl` is:
+ *   {v2BaseUrl}/v2/files/{encodeURIComponent(appId)}/content
+ *
+ * The `?file=` value MUST be percent-encoded so that the JupyterHub
+ * pre-spawn hook can parse the outer URL without ambiguity — any `?`, `&`,
+ * `=` characters in the inner Shepard URL would break URL parsing if left
+ * unencoded.  `encodeURIComponent` is the correct encoding: it escapes all
+ * characters that are special in a query-parameter value.
+ *
+ * Round-trip invariant (verified by unit tests):
+ *   decodeURIComponent(encodedFileParam) === originalShepardDownloadUrl
+ */
+
+/**
+ * Build the Shepard file-content download URL for a singleton FileReference.
+ *
+ * @param v2BaseUrl  The base URL of the Shepard v2 API (no trailing slash),
+ *                   e.g. "https://shepard.example.org".
+ * @param appId      The FileReference appId (UUID v7).
+ * @returns          The absolute download URL for the file content.
+ */
+export function buildShepardFileDownloadUrl(v2BaseUrl: string, appId: string): string {
+  const base = v2BaseUrl.replace(/\/$/, "");
+  return `${base}/v2/files/${encodeURIComponent(appId)}/content`;
+}
+
+/**
+ * Build the canonical JupyterHub launch URL for a singleton FileReference.
+ *
+ * The `?file=` query-parameter value is percent-encoded with
+ * `encodeURIComponent` so the JupyterHub server can safely parse the outer
+ * URL even when the inner Shepard download URL contains `?`, `&`, `=`, or
+ * other query-string special characters.
+ *
+ * @param hubUrl     The JupyterHub base URL (may have trailing slash),
+ *                   e.g. "https://shepard.example.org/jupyterhub".
+ * @param v2BaseUrl  The Shepard v2 API base URL, e.g. "https://shepard.example.org".
+ * @param appId      The FileReference appId (UUID v7).
+ * @returns          The full JupyterHub launch URL with `?file=` encoded, or
+ *                   `null` if any required argument is missing/empty.
+ */
+export function buildJupyterLaunchUrl(
+  hubUrl: string | null | undefined,
+  v2BaseUrl: string,
+  appId: string,
+): string | null {
+  if (!hubUrl || !appId) return null;
+  const hubBase = hubUrl.replace(/\/$/, "");
+  const downloadUrl = buildShepardFileDownloadUrl(v2BaseUrl, appId);
+  return `${hubBase}/hub/spawn?file=${encodeURIComponent(downloadUrl)}`;
+}

--- a/plugins/jupyter/docs/quickstart.md
+++ b/plugins/jupyter/docs/quickstart.md
@@ -1,7 +1,7 @@
 ---
 stage: feature-defined
 last-stage-change: 2026-05-29
-last-content-change: 2026-05-29
+last-content-change: 2026-06-02
 ---
 
 # shepard-plugin-jupyter — User quickstart
@@ -16,6 +16,14 @@ shows an **"Open in Jupyter"** action in its detail view. Clicking it:
 
 1. Redirects you to JupyterHub at
    `https://shepard.<your-domain>/jupyterhub/hub/spawn?file=<encoded-url>`.
+
+   The `<encoded-url>` is the Shepard file-content URL
+   (`/v2/files/{appId}/content`) **percent-encoded with
+   `encodeURIComponent`**.  Every character that is special in a URL
+   query string — `?`, `&`, `=`, `#` — appears as its `%XX` escape so
+   that the JupyterHub server can parse the outer spawn URL without
+   ambiguity.  The round-trip is guaranteed:
+   `decodeURIComponent(encodedParam) === originalShepardDownloadUrl`.
 2. JupyterHub signs you in via the same Keycloak realm as Shepard
    (no second login if you're already in).
 3. **Before the kernel boots**, a pre-spawn hook on the JupyterHub


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Extracts `buildJupyterLaunchUrl` and `buildShepardFileDownloadUrl` into `frontend/utils/jupyterLaunchUrl.ts`, ensuring the `?file=` query parameter in the JupyterHub spawn URL is always `encodeURIComponent`-encoded (so `?`, `&`, `=` in the inner Shepard download URL cannot break outer URL parsing).
- Refactors `DataObjectDataReferencesTable.vue` to delegate to the utility, removing the inline URL construction and guaranteeing a single canonical code path.
- Adds 17 Vitest unit tests in `frontend/tests/unit/jupyterLaunchUrl.test.ts` covering: canonical shape, round-trip invariant, special-character encoding (`?`→`%3F`, `&`→`%26`, `=`→`%3D`, spaces→`%20`), trailing-slash normalisation, and guard clauses.
- Updates `plugins/jupyter/docs/quickstart.md` to document the `encodeURIComponent` encoding guarantee and round-trip property.

## Test plan

- [ ] `npm run test --workspace=frontend` — 17 new tests in `jupyterLaunchUrl.test.ts` all pass (pre-existing 5 failures in `useFetchRecentCollections.test.ts` are unrelated).
- [ ] `npm run typecheck --workspace=frontend` — no errors.
- [ ] `npm run lint --workspace=frontend` — no errors introduced by the new files (pre-existing lint issues unaffected).
- [ ] Manual smoke test: open a DataObject with a `.ipynb` FileReference; click "Open in JupyterHub" — URL in new tab contains `?file=` with the Shepard download URL fully percent-encoded.

https://claude.ai/code/session_01G5eiLvzP86dWDHqwac2wm8
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5eiLvzP86dWDHqwac2wm8)_