### PR TITLE
fix(BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH): accept predecessorAppIds in DataObject PATCH body

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -2735,3 +2735,11 @@ shape.
 **Effort sizing:** XL across the 8 sub-rows; -01 (design) is the gate
 for everything else. The hourly dispatcher will NOT pick this up
 autonomously — design first, then sub-row dispatch.
+
+---
+
+## Bug: predecessor appIds in v2 PATCH body
+
+| ID | Item | Size | Status | Notes |
+|---|---|---|---|---|
+| **BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH** | `DataObjectIO.predecessorIds: long[]` forces predecessor body writes to use numeric ids. Post-Neo4j-reset DataObjects have UUID v7 only — the predecessor target may have no numeric id, breaking the PATCH body. Right shape: a `predecessorAppIds: string[]` companion field on the v2 IO (additive + nullable per the schema rule), populated in parallel with `predecessorIds` for the back-compat window. **shipped 2026-06-02** — added `predecessorAppIds: List<String>` to `DataObjectIO`; `DataObjectService.updateDataObject` resolves appIds via `DataObjectDAO.findByAppId` (fail-soft: WARN + skip on unresolvable); frontend `useUpdateDataObjectPredecessor.ts` sends `predecessorAppIds` when predecessor id is UUID v7-shaped; 4 backend tests in `DataObjectPatchPredecessorAppIdTest` + 4 Vitest tests in `useUpdateDataObjectPredecessorAppIds.test.ts`. | S | **shipped (2026-06-02)** | Surfaced by BUG-COLL-APPID-ROUTE-003. The route migration is necessary but not sufficient for the rework UI flow until this follow-up lands. |

--- a/backend/src/main/java/de/dlr/shepard/context/collection/io/DataObjectIO.java
+++ b/backend/src/main/java/de/dlr/shepard/context/collection/io/DataObjectIO.java
@@ -6,7 +6,9 @@ import de.dlr.shepard.context.collection.entities.DataObject;
 import de.dlr.shepard.context.references.file.entities.FileBundleReference;
 import de.dlr.shepard.context.references.structureddata.entities.StructuredDataReference;
 import de.dlr.shepard.context.references.timeseriesreference.model.TimeseriesReference;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import de.dlr.shepard.context.references.videostreamreference.VideoPayload;
+import java.util.List;
 import java.util.Objects;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -27,6 +29,41 @@ public class DataObjectIO extends AbstractDataObjectIO {
   private long[] successorIds;
 
   private long[] predecessorIds;
+
+  /**
+   * BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH — companion to {@code predecessorIds}
+   * that accepts UUID v7 appIds instead of legacy Neo4j numeric long IDs.
+   *
+   * <p>Post-Neo4j-reset DataObjects have only a UUID v7 {@code appId} — no numeric
+   * {@code shepardId} — so callers cannot populate {@code predecessorIds} for them.
+   * This field provides the appId-keyed alternative accepted in the same PATCH body.
+   *
+   * <p>Precedence rule (applied in the service):
+   * <ul>
+   *   <li>When non-null and non-empty, the service resolves each appId to a DataObject
+   *       and unions the result with any DataObjects resolved from {@code predecessorIds}
+   *       as the new predecessor set.</li>
+   *   <li>When null (the default), only {@code predecessorIds} is used — existing
+   *       callers are completely unaffected.</li>
+   * </ul>
+   *
+   * <p>Absent from the wire when null ({@link JsonInclude.Include#NON_NULL}) so the
+   * upstream v5.2.0 wire shape is preserved for any caller that does not set this field.
+   *
+   * <p>Fail-soft: any appId that cannot be resolved in the current collection is logged
+   * at WARN and skipped (never a 4xx) per CLAUDE.md fail-soft rule.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Schema(
+    nullable = true,
+    description =
+      "BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH — UUID v7 appIds of predecessor DataObjects. " +
+      "Companion to predecessorIds for DataObjects that have only a UUID v7 appId " +
+      "(post-Neo4j-reset). When present, the service resolves each appId and unions the " +
+      "result with predecessorIds. Unresolvable appIds are skipped with a WARN (fail-soft). " +
+      "Absent from the response wire when null."
+  )
+  private List<String> predecessorAppIds;
 
   @Schema(readOnly = true, required = true)
   private long[] childrenIds;
@@ -133,6 +170,7 @@ public class DataObjectIO extends AbstractDataObjectIO {
       HasId.areEqualSets(referenceIds, other.referenceIds) &&
       HasId.areEqualSets(successorIds, other.successorIds) &&
       HasId.areEqualSets(predecessorIds, other.predecessorIds) &&
+      Objects.equals(predecessorAppIds, other.predecessorAppIds) &&
       HasId.areEqualSets(childrenIds, other.childrenIds) &&
       Objects.equals(parentId, other.parentId) &&
       HasId.areEqualSets(incomingIds, other.incomingIds)
@@ -149,6 +187,7 @@ public class DataObjectIO extends AbstractDataObjectIO {
     result = prime * result + HasId.hashcodeHelper(childrenIds);
     result = prime * result + HasId.hashcodeHelper(incomingIds);
     result = prime * result + HasId.hashcodeHelper(predecessorIds);
+    result = prime * result + Objects.hashCode(predecessorAppIds);
     result = prime * result + Objects.hashCode(parentId);
 
     return result;

--- a/backend/src/main/java/de/dlr/shepard/context/collection/services/DataObjectService.java
+++ b/backend/src/main/java/de/dlr/shepard/context/collection/services/DataObjectService.java
@@ -433,11 +433,55 @@ public class DataObjectService {
       );
       newTypedPredecessorsJson = serialiseTypedPredecessors(updateTypedPredecessors);
     } else {
+      // BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH: resolve predecessorIds (numeric) first,
+      // then union with any appId-keyed predecessors from predecessorAppIds (additive,
+      // nullable). Fail-soft: unresolvable appIds are logged at WARN and skipped.
       newPredecessors = findRelatedDataObjects(
         old.getCollection().getShepardId(),
         dataObject.getPredecessorIds(),
         dataObjectShepardId
       );
+      List<String> predecessorAppIds = dataObject.getPredecessorAppIds();
+      if (predecessorAppIds != null && !predecessorAppIds.isEmpty()) {
+        java.util.Set<Long> seenShepardIds = newPredecessors.stream()
+          .map(DataObject::getShepardId)
+          .collect(Collectors.toSet());
+        for (String appId : predecessorAppIds) {
+          try {
+            DataObject resolvedPred = dataObjectDAO.findByAppId(appId);
+            if (resolvedPred == null || resolvedPred.isDeleted()) {
+              Log.warnf(
+                "BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH: predecessor appId '%s' not found or deleted — skipped",
+                appId
+              );
+              continue;
+            }
+            if (resolvedPred.getShepardId() != null && dataObjectShepardId == resolvedPred.getShepardId()) {
+              Log.warnf(
+                "BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH: predecessor appId '%s' is a self-reference — skipped",
+                appId
+              );
+              continue;
+            }
+            if (!resolvedPred.getCollection().getShepardId().equals(old.getCollection().getShepardId())) {
+              Log.warnf(
+                "BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH: predecessor appId '%s' belongs to a different collection — skipped",
+                appId
+              );
+              continue;
+            }
+            if (seenShepardIds.add(resolvedPred.getShepardId())) {
+              newPredecessors.add(resolvedPred);
+            }
+          } catch (Exception e) {
+            Log.warnf(
+              "BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH: failed to resolve predecessor appId '%s': %s — skipped",
+              appId,
+              e.getMessage()
+            );
+          }
+        }
+      }
       // On update: if no typed predecessors provided, clear the stored JSON
       // (the untyped list becomes the authoritative source).
       newTypedPredecessorsJson = null;

--- a/backend/src/test/java/de/dlr/shepard/context/collection/services/DataObjectPatchPredecessorAppIdTest.java
+++ b/backend/src/test/java/de/dlr/shepard/context/collection/services/DataObjectPatchPredecessorAppIdTest.java
@@ -1,0 +1,250 @@
+package de.dlr.shepard.context.collection.services;
+
+import static de.dlr.shepard.testing.fixtures.ShepardTestFixtures.aCollection;
+import static de.dlr.shepard.testing.fixtures.ShepardTestFixtures.aDataObject;
+import static de.dlr.shepard.testing.fixtures.ShepardTestFixtures.aUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.dlr.shepard.auth.permission.daos.PermissionsDAO;
+import de.dlr.shepard.auth.permission.services.PermissionsService;
+import de.dlr.shepard.auth.users.daos.UserDAO;
+import de.dlr.shepard.auth.users.entities.User;
+import de.dlr.shepard.auth.users.services.UserService;
+import de.dlr.shepard.common.util.AccessType;
+import de.dlr.shepard.common.util.DateHelper;
+import de.dlr.shepard.context.collection.daos.DataObjectDAO;
+import de.dlr.shepard.context.collection.entities.Collection;
+import de.dlr.shepard.context.collection.entities.DataObject;
+import de.dlr.shepard.context.collection.io.DataObjectIO;
+import de.dlr.shepard.context.references.basicreference.daos.BasicReferenceDAO;
+import de.dlr.shepard.context.version.daos.VersionDAO;
+import de.dlr.shepard.context.version.entities.Version;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH — unit tests proving that
+ * {@code DataObjectIO.predecessorAppIds} is accepted alongside (and in addition
+ * to) the legacy {@code predecessorIds} numeric array when the PATCH handler
+ * calls {@link DataObjectService#updateDataObject}.
+ *
+ * <p>Four cases:
+ * <ol>
+ *   <li>PATCH with {@code predecessorIds} only — existing behavior preserved.</li>
+ *   <li>PATCH with {@code predecessorAppIds} only — appId resolves, predecessor set updated.</li>
+ *   <li>PATCH with both fields — union of the two sets applied.</li>
+ *   <li>PATCH with an unresolvable appId in {@code predecessorAppIds} — WARN logged,
+ *       graceful (no exception, unresolvable entry silently skipped).</li>
+ * </ol>
+ */
+@QuarkusComponentTest
+public class DataObjectPatchPredecessorAppIdTest {
+
+  @InjectMock
+  DataObjectDAO dao;
+
+  @InjectMock
+  CollectionService collectionService;
+
+  @InjectMock
+  BasicReferenceDAO referenceDAO;
+
+  @InjectMock
+  UserDAO userDAO;
+
+  @InjectMock
+  VersionDAO versionDAO;
+
+  @InjectMock
+  DateHelper dateHelper;
+
+  @InjectMock
+  UserService userService;
+
+  @InjectMock
+  PermissionsService permissionsService;
+
+  @InjectMock
+  PermissionsDAO permissionsDAO;
+
+  @Inject
+  DataObjectService service;
+
+  private final User defaultUser = aUser().username("alice").build();
+  private final Date date = new Date(100);
+
+  // ── helpers ─────────────────────────────────────────────────────────────────
+
+  private Collection makeCollection(long id, long shepardId) {
+    Collection c = aCollection().id(id).shepardId(shepardId).build();
+    Version v = new Version(new UUID(1L, 2L));
+    c.setVersion(v);
+    return c;
+  }
+
+  private DataObject makeSubject(Collection collection) {
+    return aDataObject()
+      .id(1L).shepardId(10L)
+      .named("subject")
+      .inCollection(collection)
+      .build();
+  }
+
+  private void stubDefaults(Collection collection, DataObject subject) {
+    when(dao.findByShepardId(subject.getShepardId())).thenReturn(subject);
+    when(dao.createOrUpdate(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(dateHelper.getDate()).thenReturn(date);
+    when(userService.getCurrentUser()).thenReturn(defaultUser);
+    when(collectionService.getCollection(collection.getShepardId())).thenReturn(collection);
+    when(
+      permissionsService.isAccessTypeAllowedForUser(
+        anyLong(), eq(AccessType.Read), eq(defaultUser.getUsername()), anyLong()
+      )
+    ).thenReturn(true);
+  }
+
+  // ── case 1: predecessorIds only — existing behavior preserved ─────────────
+
+  @Test
+  public void patchWithPredecessorIdsOnly_existingBehaviourPreserved() {
+    Collection collection = makeCollection(2L, 20L);
+    DataObject subject = makeSubject(collection);
+    DataObject pred1 = aDataObject().id(4L).shepardId(40L).inCollection(collection).build();
+
+    stubDefaults(collection, subject);
+    // findByCollectionAndShepardIds is called by findRelatedDataObjects (PERF5).
+    when(dao.findByCollectionAndShepardIds(eq(collection.getShepardId()), anyList()))
+      .thenReturn(List.of(pred1));
+    // findByNeo4jId is called in getDataObject for each predecessor.
+    when(dao.findByNeo4jId(pred1.getId())).thenReturn(pred1);
+
+    DataObjectIO input = new DataObjectIO();
+    input.setName("subject");
+    input.setPredecessorIds(new long[] { pred1.getShepardId() });
+    // predecessorAppIds is null (absent from body) — must not trigger any appId lookup.
+
+    DataObject result = service.updateDataObject(collection.getShepardId(), subject.getShepardId(), input);
+
+    // predecessor set must contain pred1.
+    assertTrue(
+      result.getPredecessors().stream().anyMatch(p -> p.getShepardId().equals(pred1.getShepardId())),
+      "predecessor resolved from predecessorIds must appear in result"
+    );
+  }
+
+  // ── case 2: predecessorAppIds only ─────────────────────────────────────────
+
+  @Test
+  public void patchWithPredecessorAppIdsOnly_appIdResolvesToPredecessor() {
+    Collection collection = makeCollection(3L, 30L);
+    DataObject subject = makeSubject(collection);
+    String predAppId = "019e6ffc-aaaa-7abc-9def-000000000099";
+    DataObject pred2 = aDataObject()
+      .id(5L).shepardId(50L)
+      .appId(predAppId)
+      .inCollection(collection)
+      .build();
+
+    stubDefaults(collection, subject);
+    // predecessorIds is null/empty → findRelatedDataObjects returns [].
+    when(dao.findByCollectionAndShepardIds(eq(collection.getShepardId()), anyList()))
+      .thenReturn(new ArrayList<>());
+    // findByAppId is called for the appId-keyed predecessor.
+    when(dao.findByAppId(predAppId)).thenReturn(pred2);
+    when(dao.findByNeo4jId(pred2.getId())).thenReturn(pred2);
+
+    DataObjectIO input = new DataObjectIO();
+    input.setName("subject");
+    input.setPredecessorIds(new long[0]);
+    input.setPredecessorAppIds(List.of(predAppId));
+
+    DataObject result = service.updateDataObject(collection.getShepardId(), subject.getShepardId(), input);
+
+    assertTrue(
+      result.getPredecessors().stream().anyMatch(p -> predAppId.equals(p.getAppId())),
+      "predecessor resolved from predecessorAppIds must appear in result"
+    );
+    verify(dao).findByAppId(predAppId);
+  }
+
+  // ── case 3: both fields — union applied ────────────────────────────────────
+
+  @Test
+  public void patchWithBothFields_unionApplied() {
+    Collection collection = makeCollection(4L, 40L);
+    DataObject subject = makeSubject(collection);
+
+    DataObject pred1 = aDataObject().id(6L).shepardId(60L).inCollection(collection).build();
+    String pred2AppId = "019e6ffc-bbbb-7abc-9def-000000000088";
+    DataObject pred2 = aDataObject()
+      .id(7L).shepardId(70L)
+      .appId(pred2AppId)
+      .inCollection(collection)
+      .build();
+
+    stubDefaults(collection, subject);
+    when(dao.findByCollectionAndShepardIds(eq(collection.getShepardId()), anyList()))
+      .thenReturn(List.of(pred1));
+    when(dao.findByNeo4jId(pred1.getId())).thenReturn(pred1);
+    when(dao.findByAppId(pred2AppId)).thenReturn(pred2);
+    when(dao.findByNeo4jId(pred2.getId())).thenReturn(pred2);
+
+    DataObjectIO input = new DataObjectIO();
+    input.setName("subject");
+    input.setPredecessorIds(new long[] { pred1.getShepardId() });
+    input.setPredecessorAppIds(List.of(pred2AppId));
+
+    DataObject result = service.updateDataObject(collection.getShepardId(), subject.getShepardId(), input);
+
+    List<DataObject> preds = result.getPredecessors();
+    assertTrue(
+      preds.stream().anyMatch(p -> p.getShepardId().equals(pred1.getShepardId())),
+      "pred1 (from predecessorIds) must appear in union"
+    );
+    assertTrue(
+      preds.stream().anyMatch(p -> pred2AppId.equals(p.getAppId())),
+      "pred2 (from predecessorAppIds) must appear in union"
+    );
+    assertEquals(2, preds.size(), "union must contain exactly 2 unique predecessors");
+  }
+
+  // ── case 4: unresolvable appId — WARN logged, no exception ─────────────────
+
+  @Test
+  public void patchWithUnresolvableAppId_gracefulSkip() {
+    Collection collection = makeCollection(5L, 50L);
+    DataObject subject = makeSubject(collection);
+
+    String missingAppId = "019e6ffc-cccc-7abc-9def-000000000000";
+
+    stubDefaults(collection, subject);
+    when(dao.findByCollectionAndShepardIds(eq(collection.getShepardId()), anyList()))
+      .thenReturn(new ArrayList<>());
+    // findByAppId returns null — simulates DataObject not found.
+    when(dao.findByAppId(missingAppId)).thenReturn(null);
+
+    DataObjectIO input = new DataObjectIO();
+    input.setName("subject");
+    input.setPredecessorIds(new long[0]);
+    input.setPredecessorAppIds(List.of(missingAppId));
+
+    // Must not throw — fail-soft per CLAUDE.md.
+    DataObject result = service.updateDataObject(collection.getShepardId(), subject.getShepardId(), input);
+
+    assertTrue(result.getPredecessors().isEmpty(), "unresolvable appId must produce empty predecessor set");
+    verify(dao).findByAppId(missingAppId);
+  }
+}

--- a/frontend/composables/references/useUpdateDataObjectPredecessor.ts
+++ b/frontend/composables/references/useUpdateDataObjectPredecessor.ts
@@ -1,8 +1,117 @@
-import { DataObjectApi, type DataObject } from "@dlr-shepard/backend-client";
-import { useShepardApi } from "../common/api/useShepardApi";
+import type { DataObject, ResponseError } from "@dlr-shepard/backend-client";
 
+/**
+ * BUG-COLL-APPID-ROUTE-003 (2026-06-02): the predecessor / successor mutation
+ * flow routes through the v2 appId-keyed endpoints
+ * (`/v2/collections/{collectionAppId}/data-objects/{dataObjectAppId}`) so
+ * post-Neo4j-reset DataObjects (UUID v7 only, no numeric long `id`) resolve.
+ * The body shape is unchanged — `predecessorIds: long[]` is a v1-and-v2
+ * DataObjectIO field; v2 PATCH consumes the same IO. The v2 backing resolver
+ * (`EntityIdResolver`) accepts UUID v7 or numeric stringified id, so legacy
+ * numeric handles keep working when callers haven't been widened yet.
+ *
+ * BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH (2026-06-02): companion
+ * `predecessorAppIds` field added to the PATCH body. When the predecessor
+ * DataObject being added/removed has a UUID v7 `appId` (no legacy numeric id),
+ * the composable now also sends that appId in `predecessorAppIds` so the
+ * backend can resolve it without a numeric shepardId.
+ */
+
+/** Extended DataObject body shape that includes the new predecessorAppIds field. */
+type DataObjectPatchBody = Partial<DataObject> & {
+  predecessorAppIds?: string[];
+};
+
+function v2BaseUrl(): string {
+  const config = useRuntimeConfig().public;
+  const explicit = config.backendV2ApiUrl as string | undefined;
+  if (explicit && explicit.length > 0) return explicit.replace(/\/$/, "");
+  return (config.backendApiUrl as string)
+    .replace(/\/shepard\/api\/?$/, "")
+    .replace(/\/$/, "");
+}
+
+async function v2Fetch(
+  path: string,
+  init: RequestInit,
+): Promise<Response> {
+  const { data: session } = useAuth();
+  const accessToken = session.value?.accessToken;
+  const headers: Record<string, string> = {
+    ...((init.headers as Record<string, string> | undefined) ?? {}),
+    Accept: "application/json",
+  };
+  if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+  const resp = await fetch(`${v2BaseUrl()}${path}`, { ...init, headers });
+  if (!resp.ok) {
+    throw {
+      response: resp,
+      message: `HTTP ${resp.status}`,
+    } as unknown as ResponseError;
+  }
+  return resp;
+}
+
+async function getDataObjectV2(
+  collectionHandle: string | number,
+  dataObjectHandle: string | number,
+): Promise<DataObject> {
+  const resp = await v2Fetch(
+    `/v2/collections/${encodeURIComponent(String(collectionHandle))}` +
+      `/data-objects/${encodeURIComponent(String(dataObjectHandle))}`,
+    { method: "GET" },
+  );
+  return (await resp.json()) as DataObject;
+}
+
+async function patchDataObjectV2(
+  collectionHandle: string | number,
+  dataObjectHandle: string | number,
+  body: DataObjectPatchBody,
+): Promise<DataObject> {
+  const resp = await v2Fetch(
+    `/v2/collections/${encodeURIComponent(String(collectionHandle))}` +
+      `/data-objects/${encodeURIComponent(String(dataObjectHandle))}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/merge-patch+json" },
+      body: JSON.stringify(body),
+    },
+  );
+  return (await resp.json()) as DataObject;
+}
+
+/**
+ * Returns the UUID v7 appId string for a DataObject node when the
+ * `predecessorDataObjectId` is itself a UUID v7 (post-reset, no numeric id).
+ * The appId is looked up in `predecessorDataObject` when provided; otherwise
+ * the id itself is treated as a string appId when it looks like a UUID v7.
+ *
+ * Returns undefined when no appId can be derived (legacy numeric-only id).
+ */
+function deriveAppId(
+  id: number,
+  predecessorDataObject?: DataObject,
+): string | undefined {
+  // If the caller has the DataObject and it has an appId, use it directly.
+  if (predecessorDataObject?.appId) return predecessorDataObject.appId;
+  // If the id is actually a stringified UUID v7 (post-reset case), use it.
+  const s = String(id);
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s)) {
+    return s;
+  }
+  return undefined;
+}
+
+/**
+ * `collectionHandle` accepts either a UUID v7 string (post-reset) or a
+ * numeric id (legacy / pre-reset). The page-level cast in
+ * `pages/collections/[collectionId]/dataobjects/[dataObjectId]/index.vue`
+ * still labels these as `number`, but the value behind the cast is the raw
+ * route segment — so `String(handle)` is always the correct stringification.
+ */
 export function useUpdateDataObjectRelationship(
-  collectionId: number,
+  collectionHandle: string | number,
   onSuccess: () => void,
   isLoading?: Ref<boolean>,
 ) {
@@ -15,12 +124,8 @@ export function useUpdateDataObjectRelationship(
     loading.value = true;
 
     let dataObject: DataObject | undefined = undefined;
-    const dataObjectApi = useShepardApi(DataObjectApi);
     try {
-      dataObject = await dataObjectApi.value.getDataObject({
-        collectionId: collectionId,
-        dataObjectId: dataobjectId,
-      });
+      dataObject = await getDataObjectV2(collectionHandle, dataobjectId);
     } catch (error) {
       dataObject = undefined;
       handleError(error, "getDataObject");
@@ -46,27 +151,40 @@ export function useUpdateDataObjectRelationship(
 
     dataObject.predecessorIds.push(newPredecessorDataObjectId);
 
-    dataObjectApi.value
-      .updateDataObject({
-        collectionId: collectionId,
-        dataObjectId: dataobjectId,
-        dataObject: {
-          ...dataObject,
-          predecessorIds: uniqueNumbersOf(
-            // clean up possible remaining placeholder entries
-            dataObject.predecessorIds.filter(entry => entry !== -1) ?? [],
-          ),
-        },
-      })
-      .then(_ => {
-        emitSuccess("Successfully updated data object");
-        handleDataObjectUpdate();
-        onSuccess();
-      })
-      .catch(error => {
-        handleError(error, "updateDataObject");
-      });
-    loading.value = false;
+    // BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH: also send predecessorAppIds
+    // when the new predecessor has a UUID v7 appId so the backend can resolve
+    // it even when there is no numeric shepardId.
+    const newPredAppId = deriveAppId(newPredecessorDataObjectId);
+    const existingAppIds: string[] = (dataObject.predecessorIds ?? [])
+      .map(id => deriveAppId(id))
+      .filter((a): a is string => a !== undefined);
+    const predecessorAppIds =
+      newPredAppId !== undefined
+        ? [...new Set([...existingAppIds, newPredAppId])]
+        : existingAppIds.length > 0
+          ? existingAppIds
+          : undefined;
+
+    try {
+      const patchBody: DataObjectPatchBody = {
+        ...dataObject,
+        predecessorIds: uniqueNumbersOf(
+          // clean up possible remaining placeholder entries
+          dataObject.predecessorIds.filter(entry => entry !== -1) ?? [],
+        ),
+      };
+      if (predecessorAppIds && predecessorAppIds.length > 0) {
+        patchBody.predecessorAppIds = predecessorAppIds;
+      }
+      await patchDataObjectV2(collectionHandle, dataobjectId, patchBody);
+      emitSuccess("Successfully updated data object");
+      handleDataObjectUpdate();
+      onSuccess();
+    } catch (error) {
+      handleError(error, "updateDataObject");
+    } finally {
+      loading.value = false;
+    }
   }
 
   /**
@@ -96,12 +214,8 @@ export function useUpdateDataObjectRelationship(
     loading.value = true;
 
     let dataObject: DataObject | undefined = undefined;
-    const dataObjectApi = useShepardApi(DataObjectApi);
     try {
-      dataObject = await dataObjectApi.value.getDataObject({
-        collectionId: collectionId,
-        dataObjectId: dataobjectId,
-      });
+      dataObject = await getDataObjectV2(collectionHandle, dataobjectId);
     } catch (error) {
       dataObject = undefined;
       handleError(error, "getDataObject");
@@ -125,27 +239,34 @@ export function useUpdateDataObjectRelationship(
       id => id !== toBeDeletedPredecessorId,
     );
 
-    dataObjectApi.value
-      .updateDataObject({
-        collectionId: collectionId,
-        dataObjectId: dataobjectId,
-        dataObject: {
-          ...dataObject,
-          predecessorIds: uniqueNumbersOf(
-            // clean up possible remaining placeholder entries
-            updatedPredecessorList.filter(entry => entry !== -1) ?? [],
-          ),
-        },
-      })
-      .then(_ => {
-        emitSuccess("Successfully updated data object");
-        handleDataObjectUpdate();
-        onSuccess();
-      })
-      .catch(error => {
-        handleError(error, "updateDataObject");
-      });
-    loading.value = false;
+    // BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH: rebuild predecessorAppIds from
+    // the updated list, excluding the deleted predecessor's appId.
+    const deletedPredAppId = deriveAppId(toBeDeletedPredecessorId);
+    const updatedPredAppIds: string[] = updatedPredecessorList
+      .map(id => deriveAppId(id))
+      .filter((a): a is string => a !== undefined)
+      .filter(a => a !== deletedPredAppId);
+
+    try {
+      const patchBody: DataObjectPatchBody = {
+        ...dataObject,
+        predecessorIds: uniqueNumbersOf(
+          // clean up possible remaining placeholder entries
+          updatedPredecessorList.filter(entry => entry !== -1) ?? [],
+        ),
+      };
+      if (updatedPredAppIds.length > 0) {
+        patchBody.predecessorAppIds = updatedPredAppIds;
+      }
+      await patchDataObjectV2(collectionHandle, dataobjectId, patchBody);
+      emitSuccess("Successfully updated data object");
+      handleDataObjectUpdate();
+      onSuccess();
+    } catch (error) {
+      handleError(error, "updateDataObject");
+    } finally {
+      loading.value = false;
+    }
   }
 
   async function deleteSuccessor(

--- a/frontend/tests/unit/useUpdateDataObjectPredecessorAppIds.test.ts
+++ b/frontend/tests/unit/useUpdateDataObjectPredecessorAppIds.test.ts
@@ -1,0 +1,219 @@
+/**
+ * BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH — unit tests proving that
+ * `useUpdateDataObjectRelationship` sends `predecessorAppIds` in the PATCH body
+ * when the predecessor DataObject has a UUID v7 appId, and that it routes
+ * through the v2 appId-keyed endpoint (BUG-COLL-APPID-ROUTE-003 behaviour
+ * retained).
+ *
+ * Coverage:
+ *   - addPredecessor() sends predecessorAppIds when new predecessor id is a UUID v7
+ *   - addPredecessor() does NOT send predecessorAppIds when ids are numeric only
+ *   - deletePredecessor() rebuilds predecessorAppIds excluding the removed appId
+ *   - v2 routing is used for both GET and PATCH (BUG-COLL-APPID-ROUTE-003 check)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+
+const ACCESS_TOKEN = "test-token";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.assign(globalThis, {
+    useAuth: () => ({
+      data: ref<{ accessToken: string }>({ accessToken: ACCESS_TOKEN }),
+    }),
+    useRuntimeConfig: () => ({
+      public: { backendApiUrl: "http://localhost:8080/shepard/api" },
+    }),
+    handleError: vi.fn(),
+    emitSuccess: vi.fn(),
+    handleDataObjectUpdate: vi.fn(),
+    uniqueNumbersOf: (xs: number[]) => Array.from(new Set(xs)),
+    ref,
+  });
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+const flush = () => new Promise<void>(r => setTimeout(r, 0));
+
+const COLL_APP = "019e6ffc-1111-7abc-9def-000000000001";
+const DO_APP = "019e6ffc-2222-7abc-9def-000000000002";
+/** A UUID v7 style id string for a post-reset predecessor DataObject. */
+const PRED_UUID_V7 = "019e6ffc-3333-7abc-9def-000000000003";
+
+function makeBodyWithNumericPredecessors() {
+  return {
+    id: 100,
+    appId: DO_APP,
+    collectionId: 1,
+    name: "TR-004",
+    predecessorIds: [10, 20],
+    successorIds: [],
+  };
+}
+
+function makeBodyWithUuidPredecessors() {
+  // Predecessor ids are UUID v7-looking strings cast to numbers by the caller.
+  // The page layer casts route segments to `number` even when they are UUID strings.
+  return {
+    id: 100,
+    appId: DO_APP,
+    collectionId: 1,
+    name: "TR-004",
+    // We store the UUID v7 string in the numeric predecessorIds array using the
+    // same page-level cast the real caller performs.
+    predecessorIds: [] as number[],
+    successorIds: [],
+  };
+}
+
+describe("useUpdateDataObjectRelationship — BUG-PREDECESSOR-IDS-NUMERIC-IN-V2-PATCH", () => {
+  it("addPredecessor sends predecessorAppIds when new predecessor id looks like UUID v7", async () => {
+    const fetchSpy = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      if (!init.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(makeBodyWithUuidPredecessors()),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ ...makeBodyWithUuidPredecessors() }),
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { useUpdateDataObjectRelationship } = await import(
+      "~/composables/references/useUpdateDataObjectPredecessor"
+    );
+    const onSuccess = vi.fn();
+    const { addPredecessor } = useUpdateDataObjectRelationship(COLL_APP, onSuccess);
+
+    // Caller passes the UUID v7 as the "numeric" id (page-level cast).
+    await addPredecessor(
+      DO_APP as unknown as number,
+      PRED_UUID_V7 as unknown as number,
+    );
+    await flush();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const patchCall = fetchSpy.mock.calls[1];
+    expect(patchCall?.[1].method).toBe("PATCH");
+
+    const body = JSON.parse(patchCall?.[1].body as string);
+    // The new UUID v7 predecessor must appear in predecessorAppIds.
+    expect(body.predecessorAppIds).toBeDefined();
+    expect(body.predecessorAppIds).toContain(PRED_UUID_V7);
+  });
+
+  it("addPredecessor does NOT include predecessorAppIds when ids are numeric only", async () => {
+    const fetchSpy = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      if (!init.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(makeBodyWithNumericPredecessors()),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ ...makeBodyWithNumericPredecessors(), predecessorIds: [10, 20, 30] }),
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { useUpdateDataObjectRelationship } = await import(
+      "~/composables/references/useUpdateDataObjectPredecessor"
+    );
+    const { addPredecessor } = useUpdateDataObjectRelationship(COLL_APP, () => undefined);
+    await addPredecessor(100, 30);
+    await flush();
+
+    const patchCall = fetchSpy.mock.calls[1];
+    const body = JSON.parse(patchCall?.[1].body as string);
+    // No UUID v7-shaped ids in the mix → predecessorAppIds must be absent.
+    expect(body.predecessorAppIds).toBeUndefined();
+    expect(body.predecessorIds).toEqual([10, 20, 30]);
+  });
+
+  it("deletePredecessor rebuilds predecessorAppIds excluding the removed UUID v7 id", async () => {
+    // DataObject currently has two UUID v7-shaped predecessors.
+    const PRED_A = "019e6ffc-aaaa-7abc-9def-000000000011";
+    const PRED_B = "019e6ffc-bbbb-7abc-9def-000000000022";
+
+    const fetchSpy = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      if (!init.method || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              id: 100,
+              appId: DO_APP,
+              collectionId: 1,
+              name: "TR-004",
+              // Both are stored as UUID strings in the numeric array slot.
+              predecessorIds: [
+                PRED_A as unknown as number,
+                PRED_B as unknown as number,
+              ],
+              successorIds: [],
+            }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ predecessorIds: [PRED_A as unknown as number] }),
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { useUpdateDataObjectRelationship } = await import(
+      "~/composables/references/useUpdateDataObjectPredecessor"
+    );
+    const { deletePredecessor } = useUpdateDataObjectRelationship(COLL_APP, () => undefined);
+    // Delete PRED_B.
+    await deletePredecessor(
+      DO_APP as unknown as number,
+      PRED_B as unknown as number,
+    );
+    await flush();
+
+    const patchCall = fetchSpy.mock.calls[1];
+    const body = JSON.parse(patchCall?.[1].body as string);
+    // predecessorAppIds must contain PRED_A only (PRED_B excluded).
+    expect(body.predecessorAppIds).toBeDefined();
+    expect(body.predecessorAppIds).toContain(PRED_A);
+    expect(body.predecessorAppIds).not.toContain(PRED_B);
+  });
+
+  it("routes GET + PATCH through v2 appId-keyed endpoint (BUG-COLL-APPID-ROUTE-003 retained)", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(makeBodyWithNumericPredecessors()),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { useUpdateDataObjectRelationship } = await import(
+      "~/composables/references/useUpdateDataObjectPredecessor"
+    );
+    const { addPredecessor } = useUpdateDataObjectRelationship(COLL_APP, () => undefined);
+    await addPredecessor(100, 30);
+    await flush();
+
+    const getUrl = fetchSpy.mock.calls[0]?.[0] as string;
+    const patchUrl = fetchSpy.mock.calls[1]?.[0] as string;
+    const expectedBase =
+      `http://localhost:8080/v2/collections/` +
+      `${encodeURIComponent(COLL_APP)}/data-objects/` +
+      `${encodeURIComponent("100")}`;
+    expect(getUrl).toBe(expectedBase);
+    expect(patchUrl).toBe(expectedBase);
+    expect(fetchSpy.mock.calls[1]?.[1].method).toBe("PATCH");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `predecessorAppIds: List<String>` (nullable, `@JsonInclude(NON_NULL)`) to `DataObjectIO` so callers can reference predecessor DataObjects by UUID v7 `appId` rather than requiring a legacy numeric `shepardId`
- Backend service unions appId-resolved predecessors with numeric ones; unresolvable appIds are logged at WARN and skipped (fail-soft, never 4xx)
- Frontend composable (`useUpdateDataObjectPredecessor.ts`) rewritten to route through the v2 appId-keyed endpoint (BUG-COLL-APPID-ROUTE-003 retained) and populate `predecessorAppIds` when UUID v7-shaped ids are detected
- `DataObjectIO.equals`/`hashCode` updated to include the new field (caught by existing `equalsContract` EqualsVerifier test)

## Root cause

Post-Neo4j-reset DataObjects have only a UUID v7 `appId` — no numeric `shepardId` — so `predecessorIds: long[]` cannot reference them. This is additive (`@JsonInclude(NON_NULL)`) so all existing callers sending only `predecessorIds` are unaffected.

## Test plan

- [x] `DataObjectPatchPredecessorAppIdTest` (4 new `@QuarkusComponentTest` cases): predecessorIds-only, predecessorAppIds-only, union of both, unresolvable appId graceful skip
- [x] `DataObjectIOTest.equalsContract` passes after equals/hashCode update
- [x] `useUpdateDataObjectPredecessorAppIds.test.ts` (4 new Vitest cases): UUID v7 triggers predecessorAppIds, numeric-only skips it, delete rebuilds list, v2 routing retained
- [x] `npm run typecheck` — clean
- [x] New files: zero lint errors

https://claude.ai/code/session_01FgYop6ioKxracQ5DPdWbPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgYop6ioKxracQ5DPdWbPF)_