### PR TITLE
fix(thermography): accept L&lt;n&gt;+ layer-plus suffix in OTvis filename

### DIFF
--- a/plugins/fileformat-thermography/src/main/java/de/dlr/shepard/plugin/fileformat/thermography/OTvisFilenameParser.java
+++ b/plugins/fileformat-thermography/src/main/java/de/dlr/shepard/plugin/fileformat/thermography/OTvisFilenameParser.java
@@ -38,7 +38,7 @@ public final class OTvisFilenameParser {
     // accidentally produce false positives. Capture groups intentionally
     // include the S/M/L/F prefix letter for round-trip fidelity.
     private static final Pattern PATTERN = Pattern.compile(
-            "(?i)(S\\d+)_(M\\d+)_(L\\d+)_(F\\d+)\\.OTvis$");
+            "(?i)(S\\d+)_(M\\d+)_(L\\d+\\+?)_(F\\d+)\\.OTvis$");
 
     private OTvisFilenameParser() {
         // utility class

--- a/plugins/fileformat-thermography/src/test/java/de/dlr/shepard/plugin/fileformat/thermography/OTvisFilenameParserTest.java
+++ b/plugins/fileformat-thermography/src/test/java/de/dlr/shepard/plugin/fileformat/thermography/OTvisFilenameParserTest.java
@@ -77,4 +77,23 @@ class OTvisFilenameParserTest {
         assertThat(g.get().layer()).isEqualTo("L1234");
         assertThat(g.get().frame()).isEqualTo("F5678");
     }
+
+    @Test
+    void acceptsLayerPlusSuffix() {
+        Optional<OTvisFilenameParser.GridPosition> g =
+                OTvisFilenameParser.parse("S4_M13_L19+_F4.OTvis");
+        assertThat(g).isPresent();
+        assertThat(g.get().section()).isEqualTo("S4");
+        assertThat(g.get().module()).isEqualTo("M13");
+        assertThat(g.get().layer()).isEqualTo("L19+");
+        assertThat(g.get().frame()).isEqualTo("F4");
+    }
+
+    @Test
+    void acceptsLayerPlusSuffixLowercase() {
+        Optional<OTvisFilenameParser.GridPosition> g =
+                OTvisFilenameParser.parse("s1_m2_l3+_f4.otvis");
+        assertThat(g).isPresent();
+        assertThat(g.get().layer()).isEqualTo("L3+");
+    }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Problem

The MFFD thermography archive contains 143 OTvis files whose layer segment ends with `+`, for example:

```
S4_M13_L19+_F4.OTvis
```

The `OTvisFilenameParser` regex did not allow a trailing `+` on the layer group, so `parse()` returned `Optional.empty()` for all 143 files — silently dropping them without error. None of those files received the four `urn:shepard:mffd:*` grid-position annotations.

## Fix

One character change in the compiled `Pattern` in `OTvisFilenameParser.java`:

```
- "(?i)(S\\d+)_(M\\d+)_(L\\d+)_(F\\d+)\\.OTvis$"
+ "(?i)(S\\d+)_(M\\d+)_(L\\d+\\+?)_(F\\d+)\\.OTvis$"
```

`\\+?` makes the trailing `+` optional. All existing filenames without `+` continue to match unchanged. The `toUpperCase()` call already in the parser preserves the `+` character intact, so `l3+` normalises to `L3+`.

## Tests added

Two new test methods in `OTvisFilenameParserTest`, added after `handlesLargeGridNumbers`:

- `acceptsLayerPlusSuffix` — verifies `S4_M13_L19+_F4.OTvis` parses to `layer = "L19+"` with all four groups correct.
- `acceptsLayerPlusSuffixLowercase` — verifies that lowercase input `s1_m2_l3+_f4.otvis` normalises to `layer = "L3+"`.

All existing tests continue to pass.

## Scope

Only two files changed:
- `plugins/fileformat-thermography/src/main/java/de/dlr/shepard/plugin/fileformat/thermography/OTvisFilenameParser.java`
- `plugins/fileformat-thermography/src/test/java/de/dlr/shepard/plugin/fileformat/thermography/OTvisFilenameParserTest.java`

No schema changes, no migration, no frontend touch (internal parser fix).

https://claude.ai/code/session_01Xo7LybHqhb3xg8DTRW9yCa
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xo7LybHqhb3xg8DTRW9yCa)_