### PR TITLE
feat(collections): wire timeline drill-down to DataObject annotation+date filter

### DIFF
--- a/backend-client/src/apis/DataObjectV2Api.ts
+++ b/backend-client/src/apis/DataObjectV2Api.ts
@@ -20,6 +20,25 @@ export interface ListDataObjectsV2Request {
    * name in the response body.
    */
   fields?: string;
+  /**
+   * COLL-TIMELINE-DRILLDOWN-FILTER-1 — filter DataObjects by SemanticAnnotation
+   * predicate + value. Format: `<predicateIRI>=<value>`, e.g.
+   * `urn:shepard:mffd:process-type=AFP`. Split on the first `=`; predicateIRI
+   * may contain `=` characters. When absent, no annotation filter is applied.
+   */
+  annotationFilter?: string;
+  /**
+   * COLL-TIMELINE-DRILLDOWN-FILTER-1 — ISO-8601 date lower bound (inclusive),
+   * e.g. `2024-06-01`. Filters DataObjects whose `createdAt` is on or after
+   * the start of this day (UTC). When absent, no lower bound is applied.
+   */
+  createdAfter?: string;
+  /**
+   * COLL-TIMELINE-DRILLDOWN-FILTER-1 — ISO-8601 date upper bound (inclusive),
+   * e.g. `2024-06-01`. Filters DataObjects whose `createdAt` is on or before
+   * the end of this day (UTC). When absent, no upper bound is applied.
+   */
+  createdBefore?: string;
 }
 
 /**
@@ -46,6 +65,9 @@ export class DataObjectV2Api extends runtime.BaseAPI {
     if (requestParameters['size'] != null) queryParameters['size'] = requestParameters['size'];
     if (requestParameters['include'] != null) queryParameters['include'] = requestParameters['include'];
     if (requestParameters['fields'] != null) queryParameters['fields'] = requestParameters['fields'];
+    if (requestParameters['annotationFilter'] != null) queryParameters['annotationFilter'] = requestParameters['annotationFilter'];
+    if (requestParameters['createdAfter'] != null) queryParameters['createdAfter'] = requestParameters['createdAfter'];
+    if (requestParameters['createdBefore'] != null) queryParameters['createdBefore'] = requestParameters['createdBefore'];
 
     const headerParameters: runtime.HTTPHeaders = {};
     if (this.configuration && this.configuration.accessToken) {

--- a/backend/src/main/java/de/dlr/shepard/context/collection/daos/DataObjectDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/context/collection/daos/DataObjectDAO.java
@@ -5,6 +5,7 @@ import de.dlr.shepard.common.util.Constants;
 import de.dlr.shepard.common.util.CypherQueryHelper;
 import de.dlr.shepard.common.util.QueryParamHelper;
 import de.dlr.shepard.context.collection.entities.DataObject;
+import de.dlr.shepard.context.semantic.entities.SemanticAnnotation;
 import de.dlr.shepard.context.version.daos.VersionableEntityDAO;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.RequestScoped;
@@ -715,6 +716,33 @@ public class DataObjectDAO extends VersionableEntityDAO<DataObject> {
       out.put(appId, ids);
     }
     return out;
+  }
+
+  /**
+   * COLL-TIMELINE-DRILLDOWN-FILTER-1 — fetch all SemanticAnnotations attached
+   * to the DataObject identified by {@code dataObjectAppId} in a single Cypher
+   * round-trip. Used by the annotation post-filter in
+   * {@code DataObjectV2Rest.list()} when the caller supplies
+   * {@code ?annotationFilter=<predicateIRI>=<value>}.
+   *
+   * <p>Returns an empty list when the DataObject has no annotations or when
+   * the appId is null/blank.
+   *
+   * <p>TODO(COLL-TIMELINE-DRILLDOWN-FILTER-1): Replace the per-DO call with
+   * a DAO-level Cypher join so annotation matching happens inside Neo4j
+   * rather than in the service layer. The current shape does one Cypher call
+   * per DataObject on the page — acceptable for the initial ship but will
+   * fan-out on large pages.
+   *
+   * @param dataObjectAppId the UUID v7 of the DataObject
+   * @return list of SemanticAnnotations; empty when none found
+   */
+  public List<SemanticAnnotation> findAnnotationsForDataObject(String dataObjectAppId) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) return Collections.emptyList();
+    String cypher =
+      "MATCH (d:DataObject {appId: $appId})-[:has_annotation]->(a:SemanticAnnotation) RETURN a";
+    var hits = session.query(SemanticAnnotation.class, cypher, Map.of("appId", dataObjectAppId));
+    return StreamSupport.stream(hits.spliterator(), false).collect(java.util.stream.Collectors.toList());
   }
 
   /**

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
@@ -50,8 +50,12 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -185,6 +189,9 @@ public class DataObjectV2Rest {
     @QueryParam("size") @DefaultValue("50") @PositiveOrZero int size,
     @QueryParam("include") String include,
     @QueryParam("fields") String fields,
+    @QueryParam("annotationFilter") String annotationFilter,
+    @QueryParam("createdAfter") String createdAfter,
+    @QueryParam("createdBefore") String createdBefore,
     @Context SecurityContext sc
   ) {
     // DB-OPT5: validate ?fields= early so a bad query returns 400 before any DB hit.
@@ -214,7 +221,77 @@ public class DataObjectV2Rest {
     if (status != null) params = params.withStatus(status);
     params = params.withPageAndSize(safePage, safeSize);
 
+    // Parse annotationFilter — format: <predicateIRI>=<value>
+    // Split on the first '=' so IRIs containing '=' are handled correctly.
+    String annotationPredicate = null;
+    String annotationValue = null;
+    if (annotationFilter != null && !annotationFilter.isBlank()) {
+      int eqIdx = annotationFilter.indexOf('=');
+      if (eqIdx > 0) {
+        annotationPredicate = annotationFilter.substring(0, eqIdx).trim();
+        annotationValue = annotationFilter.substring(eqIdx + 1).trim();
+      }
+    }
+
+    // Parse createdAfter / createdBefore — ISO-8601 date strings (YYYY-MM-DD).
+    // Inclusive on both ends: createdAfter is start of that day (00:00 UTC),
+    // createdBefore is start of the next day (exclusive).
+    Date afterDate = null;
+    Date beforeDate = null;
+    if (createdAfter != null && !createdAfter.isBlank()) {
+      try {
+        afterDate = Date.from(LocalDate.parse(createdAfter).atStartOfDay(ZoneOffset.UTC).toInstant());
+      } catch (DateTimeParseException ignored) {
+        // Invalid date string — treat as absent (no filter).
+      }
+    }
+    if (createdBefore != null && !createdBefore.isBlank()) {
+      try {
+        // Exclusive upper bound: start of the day after createdBefore.
+        beforeDate = Date.from(LocalDate.parse(createdBefore).plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant());
+      } catch (DateTimeParseException ignored) {
+        // Invalid date string — treat as absent (no filter).
+      }
+    }
+
     var dataObjects = dataObjectService.getAllDataObjectsByShepardIds(collectionOgmId, params, null);
+
+    // Post-filter: annotation predicate+value filter.
+    // TODO(COLL-TIMELINE-DRILLDOWN-FILTER-1): move to DAO-level Cypher for
+    // large collections; currently a page-level post-filter which is correct
+    // for paginated responses but may produce under-full pages when many DOs
+    // are excluded. Acceptable for the initial ship (typical page size 25).
+    final String finalAnnotationPredicate = annotationPredicate;
+    final String finalAnnotationValue = annotationValue;
+    final Date finalAfterDate = afterDate;
+    final Date finalBeforeDate = beforeDate;
+
+    boolean hasAnnotationFilter = finalAnnotationPredicate != null && finalAnnotationValue != null;
+    boolean hasDateFilter = finalAfterDate != null || finalBeforeDate != null;
+
+    if (hasAnnotationFilter || hasDateFilter) {
+      dataObjects = dataObjects.stream()
+        .filter(d -> {
+          if (hasDateFilter) {
+            Date ca = d.getCreatedAt();
+            if (ca == null) return false;
+            if (finalAfterDate != null && ca.before(finalAfterDate)) return false;
+            if (finalBeforeDate != null && !ca.before(finalBeforeDate)) return false;
+          }
+          if (hasAnnotationFilter) {
+            // Check whether any SemanticAnnotation on this DataObject matches.
+            // SemanticAnnotation.propertyIRI == predicate AND
+            // (SemanticAnnotation.valueIRI == value OR SemanticAnnotation.valueName == value).
+            var annotations = dataObjectDAO.findAnnotationsForDataObject(d.getAppId());
+            return annotations.stream().anyMatch(a ->
+              finalAnnotationPredicate.equals(a.getPropertyIRI()) &&
+              (finalAnnotationValue.equals(a.getValueIRI()) || finalAnnotationValue.equals(a.getValueName()))
+            );
+          }
+          return true;
+        })
+        .collect(Collectors.toList());
+    }
 
     // Collect appIds for the batch count query (one round-trip for the whole page).
     List<String> appIds = new ArrayList<>(dataObjects.size());

--- a/frontend/components/context/collection/CollectionDataObjectsPanel.vue
+++ b/frontend/components/context/collection/CollectionDataObjectsPanel.vue
@@ -1,5 +1,45 @@
 <template>
   <div>
+    <!-- COLL-TIMELINE-DRILLDOWN-FILTER-1: Active timeline drill-down filter banner.
+         Shown when a user clicked a timeline bin and landed here with URL params
+         ?process-type=<value>&date=<ISO>. Gives clear visual feedback that fewer
+         DataObjects are shown, with a one-click dismiss. -->
+    <v-alert
+      v-if="hasActiveTimelineFilter"
+      type="info"
+      density="compact"
+      variant="tonal"
+      class="mb-3"
+      closable
+      @click:close="clearTimelineFilter"
+    >
+      <div class="d-flex align-center flex-wrap ga-2">
+        <span>Timeline filter active:</span>
+        <v-chip
+          v-if="activeProcessType"
+          size="small"
+          variant="flat"
+          color="primary"
+          prepend-icon="mdi-tag-outline"
+          closable
+          @click:close="clearTimelineFilter"
+        >
+          process-type: {{ activeProcessType }}
+        </v-chip>
+        <v-chip
+          v-if="activeDateFilter"
+          size="small"
+          variant="flat"
+          color="secondary"
+          prepend-icon="mdi-calendar-outline"
+          closable
+          @click:close="clearTimelineFilter"
+        >
+          date: {{ activeDateFilter }}
+        </v-chip>
+      </div>
+    </v-alert>
+
     <!-- Search + status filter row -->
     <div class="d-flex flex-wrap align-center ga-2 pb-3">
       <v-text-field
@@ -172,7 +212,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { useRouter } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
 import { usePagedDataObjects } from "~/composables/context/usePagedDataObjects";
 import { useTimeoutFn } from "@vueuse/core";
 
@@ -182,7 +222,44 @@ const props = defineProps<{
 }>();
 
 const router = useRouter();
+const route = useRoute();
 const collectionAppId = computed(() => props.collectionAppId ?? null);
+
+// ── COLL-TIMELINE-DRILLDOWN-FILTER-1: timeline drill-down URL params ──────
+// The timeline pane navigates here with ?process-type=<value>&date=<ISO-day>
+// when a user clicks a bin. We read those params and wire them to the API.
+
+const activeProcessType = computed<string | null>(() => {
+  const v = route.query['process-type'];
+  return typeof v === 'string' && v.length > 0 ? v : null;
+});
+
+const activeDateFilter = computed<string | null>(() => {
+  const v = route.query['date'];
+  return typeof v === 'string' && v.length > 0 ? v : null;
+});
+
+const hasActiveTimelineFilter = computed(() =>
+  activeProcessType.value !== null || activeDateFilter.value !== null
+);
+
+// Convert process-type → annotationFilter query param format.
+const annotationFilterParam = computed<string | null>(() => {
+  const pt = activeProcessType.value;
+  return pt ? `urn:shepard:mffd:process-type=${pt}` : null;
+});
+
+// For a single-day click the date range is [date, date] (inclusive).
+// createdAfter = date, createdBefore = date (backend makes it exclusive by adding 1 day).
+const createdAfterParam = computed<string | null>(() => activeDateFilter.value);
+const createdBeforeParam = computed<string | null>(() => activeDateFilter.value);
+
+function clearTimelineFilter(): void {
+  const q = { ...route.query };
+  delete q['process-type'];
+  delete q['date'];
+  void router.replace({ query: q });
+}
 
 const STATUSES = [
   "DRAFT", "IN_REVIEW", "READY", "PUBLISHED", "ARCHIVED", "FAILED",
@@ -206,8 +283,9 @@ function onSearchChange() {
   scheduleSearch();
 }
 
-// Reset page when status filter changes and trigger a server-side refetch
+// Reset page when status filter or timeline filter changes.
 watch(statusFilter, () => { page.value = 0; });
+watch([activeProcessType, activeDateFilter], () => { page.value = 0; });
 
 const pageSize = 25;
 
@@ -219,6 +297,9 @@ const { items: rawItems, loading, hasMore, totalItems } = usePagedDataObjects({
   page,
   pageSize,
   includeTimeBounds: true,
+  annotationFilter: annotationFilterParam,
+  createdAfter: createdAfterParam,
+  createdBefore: createdBeforeParam,
 });
 
 // Computed total pages for the page-jump widget

--- a/frontend/composables/context/usePagedDataObjects.ts
+++ b/frontend/composables/context/usePagedDataObjects.ts
@@ -12,6 +12,22 @@ export interface PagedDataObjectsOptions {
   pageSize?: number;
   /** When true, each item includes timeBoundsStart / timeBoundsEnd (2 extra DB round-trips). */
   includeTimeBounds?: boolean;
+  /**
+   * COLL-TIMELINE-DRILLDOWN-FILTER-1 — annotation filter in the form
+   * `<predicateIRI>=<value>` (e.g. `urn:shepard:mffd:process-type=AFP`).
+   * When null / empty, no annotation filter is applied.
+   */
+  annotationFilter?: Ref<string | null>;
+  /**
+   * COLL-TIMELINE-DRILLDOWN-FILTER-1 — ISO-8601 date lower bound (inclusive).
+   * When null / empty, no lower date bound is applied.
+   */
+  createdAfter?: Ref<string | null>;
+  /**
+   * COLL-TIMELINE-DRILLDOWN-FILTER-1 — ISO-8601 date upper bound (inclusive).
+   * When null / empty, no upper date bound is applied.
+   */
+  createdBefore?: Ref<string | null>;
 }
 
 export interface PagedDataObjectsResult {
@@ -38,6 +54,9 @@ export function usePagedDataObjects(opts: PagedDataObjectsOptions): PagedDataObj
   const status = opts.status;
   const pageSize = opts.pageSize ?? 25;
   const includeTimeBounds = opts.includeTimeBounds ?? false;
+  const annotationFilter = opts.annotationFilter;
+  const createdAfter = opts.createdAfter;
+  const createdBefore = opts.createdBefore;
 
   // DB-OPT5: explicit ?fields= allow-list of exactly what the collection-detail
   // panel renders. Drops description, attributes, predecessor/successor arrays,
@@ -80,6 +99,9 @@ export function usePagedDataObjects(opts: PagedDataObjectsOptions): PagedDataObj
     const nameFilter = name.value.trim() || undefined;
     const statusFilter = status?.value || undefined;
     const currentPage = page.value;
+    const annotationFilterVal = annotationFilter?.value || undefined;
+    const createdAfterVal = createdAfter?.value || undefined;
+    const createdBeforeVal = createdBefore?.value || undefined;
 
     loading.value = true;
     try {
@@ -96,6 +118,9 @@ export function usePagedDataObjects(opts: PagedDataObjectsOptions): PagedDataObj
           size: pageSize,
           include: includeTimeBounds ? 'time-bounds' : undefined,
           fields: DO_LIST_FIELDS,
+          annotationFilter: annotationFilterVal,
+          createdAfter: createdAfterVal,
+          createdBefore: createdBeforeVal,
         } as unknown as Parameters<typeof v2Api.value.listDataObjectsWithCount>[0]);
         batch = fetched;
         totalItems.value = fetchedTotal;
@@ -119,12 +144,24 @@ export function usePagedDataObjects(opts: PagedDataObjectsOptions): PagedDataObj
     }
   }
 
-  const watchSources = status
-    ? [collectionAppId, name, status, page] as const
-    : [collectionAppId, name, page] as const;
-  watch(watchSources, () => {
-    void fetch();
-  }, { immediate: true });
+  // Watch all filter sources as a computed snapshot so Vue can deep-compare.
+  // This replaces the earlier status-conditional array which couldn't accommodate
+  // the optional annotationFilter / createdAfter / createdBefore refs.
+  watch(
+    computed(() => ({
+      appId: collectionAppId.value,
+      name: name.value,
+      status: status?.value,
+      page: page.value,
+      annotationFilter: annotationFilter?.value,
+      createdAfter: createdAfter?.value,
+      createdBefore: createdBefore?.value,
+    })),
+    () => {
+      void fetch();
+    },
+    { immediate: true }
+  );
 
   return { items, totalItems, loading, hasMore };
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes **COLL-TIMELINE-DRILLDOWN-FILTER-1**. The Collection landing page timeline (shipped 2026-06-02) emits `?process-type=<value>&date=<ISO>` URL params when a user clicks a swimlane bin. Previously those params were silently ignored — the full unfiltered DataObjects list appeared every time. This PR wires them all the way through.

- **Backend** — three new `@QueryParam` args on `DataObjectV2Rest.list()`: `annotationFilter`, `createdAfter`, `createdBefore`. Post-page filter: `annotationFilter` is matched against `SemanticAnnotation.propertyIRI` + `valueName/valueIRI`; date params are applied as epoch-millis bounds on `DataObject.createdAt` (UTC).
- **DAO** — `DataObjectDAO.findAnnotationsForDataObject(appId)` — single Cypher round-trip returning all `has_annotation` SemanticAnnotations for a DataObject.
- **Backend-client** — `ListDataObjectsV2Request` extended with the three new optional params; query-string wiring added to `listDataObjectsRaw`.
- **Frontend composable** (`usePagedDataObjects`) — accepts `annotationFilter / createdAfter / createdBefore` as optional `Ref<string | null>`; passes them to the API call; watch source switched to a computed snapshot so all filter changes trigger a refetch.
- **Frontend component** (`CollectionDataObjectsPanel`) — reads `route.query['process-type']` and `route.query['date']`; derives `annotationFilter=urn:shepard:mffd:process-type=<value>` and same-day `createdAfter`/`createdBefore`; passes to the composable. Shows a dismissable `v-alert` banner with per-chip close buttons when a timeline filter is active.

## TODOs (noted inline, not blocking)

- **DAO-level filter** — the annotation filter currently does one Cypher call per DataObject on the page (`findAnnotationsForDataObject`). For typical page sizes (25) this is 25 extra round-trips — fine for the initial ship. The proper fix is a single Cypher `MATCH … WHERE a.propertyIRI = $pred AND (a.valueIRI = $val OR a.valueName = $val)` join inside `findByCollectionByShepardIds`. Tracked as `COLL-TIMELINE-DRILLDOWN-FILTER-1` TODO in the code.
- **Post-page count discrepancy** — because annotation filtering happens after the paginated DB fetch, pages with many annotated-excluded DOs may appear shorter than `pageSize`. The `X-Total-Count` header may over-count. Acceptable for this initial ship; the DAO-level fix resolves this.

## Test plan

- [ ] In a Collection with MFFD `urn:shepard:mffd:process-type` annotations, click a swimlane bin in the timeline pane.
- [ ] Confirm the DataObjects panel shows only DOs annotated with that process-type created on that day.
- [ ] Confirm the filter banner appears with the correct process-type and date chips.
- [ ] Click the ✕ on either chip or the banner close — confirm URL params are removed and the unfiltered list reappears.
- [ ] Navigate directly to `/collections/{appId}?process-type=AFP&date=2024-06-01` — same filter should apply.
- [ ] Navigate without query params — panel behaves identically to pre-PR (no regression).

https://claude.ai/code/session_01Xo7LybHqhb3xg8DTRW9yCa
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xo7LybHqhb3xg8DTRW9yCa)_