### PR TITLE
feat(TEMPLATE-ICONS-1): add nullable iconKey to ShepardTemplate + V107 seed migration

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/template/daos/ShepardTemplateDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/template/daos/ShepardTemplateDAO.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 /**
  * DAO for {@link ShepardTemplate}. Designed in {@code aidocs/54}.
  *
- * <p>Listings filter out {@code retired = true} rows by default —
+ * <p>Listings filter out {@code retired = true} rows by default --
  * the picker UI never shows superseded templates. Admin endpoints
  * can opt into seeing retired rows via {@link #list(String, boolean)}.
  */
@@ -64,7 +64,7 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
 
   /**
    * Mint a copy-on-write next version of the given template. Returns
-   * a new {@link ShepardTemplate} (NOT saved — caller saves) with
+   * a new {@link ShepardTemplate} (NOT saved -- caller saves) with
    * {@code version} incremented and the old appId untouched.
    */
   public ShepardTemplate nextVersionOf(ShepardTemplate prior) {
@@ -82,11 +82,11 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
 
   /**
    * Templates the Collection's owner has curated as visible inside
-   * the Collection — the picker UI filters its list down to these
+   * the Collection -- the picker UI filters its list down to these
    * when the user opens the new-DataObject dialog from inside the
    * Collection. Returns empty when no curation is set.
    *
-   * <p>Design: {@code aidocs/54 §3} `:ALLOWS_TEMPLATE` edge.
+   * <p>Design: {@code aidocs/54 §3} {@code :ALLOWS_TEMPLATE} edge.
    */
   public List<ShepardTemplate> listAllowedForCollection(String collectionAppId) {
     String cypher =
@@ -100,7 +100,7 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
 
   /**
    * Templates the Collection has cited via {@code :USES_TEMPLATE}
-   * (the provenance edge — "this Collection was created from
+   * (the provenance edge -- "this Collection was created from
    * template X"). Includes retired templates because past citations
    * stay valid per the copy-on-write semantics of {@code aidocs/54}.
    */
@@ -117,7 +117,7 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
    * Replace the {@code :ALLOWS_TEMPLATE} edge set for one Collection.
    * Existing edges are wiped; new edges are minted for every appId in
    * {@code templateAppIds}. Missing templates / missing Collection
-   * are silent — the caller validates first. Idempotent.
+   * are silent -- the caller validates first. Idempotent.
    */
   public void setAllowedForCollection(String collectionAppId, List<String> templateAppIds) {
     session.query(
@@ -160,7 +160,7 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
   }
 
   /**
-   * Record that a Collection was instantiated from a given template —
+   * Record that a Collection was instantiated from a given template --
    * idempotent {@code :USES_TEMPLATE} edge.
    */
   public void recordUsage(String collectionAppId, String templateAppId) {
@@ -177,7 +177,7 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
    * endpoint to surface "you've already used this template" vs
    * "first time you're using it" in the response.
    *
-   * <p>Returns {@code false} when either node is missing — caller
+   * <p>Returns {@code false} when either node is missing -- caller
    * should validate first.
    */
   public boolean recordUsageReportingCreation(String collectionAppId, String templateAppId) {
@@ -204,7 +204,7 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
    * <p>The DataObject is matched by its indexed {@code shepardId} property.
    * The relationship is {@code MERGE}-ed (idempotent on the pair of nodes) so
    * that calling this method twice for the same DataObject + Template is safe
-   * — the second call is a no-op.
+   * -- the second call is a no-op.
    *
    * @param dataObjectShepardId
    *          the {@code shepardId} of the newly-created DataObject

--- a/backend/src/main/java/de/dlr/shepard/template/daos/ShepardTemplateDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/template/daos/ShepardTemplateDAO.java
@@ -75,6 +75,7 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
     next.setBody(prior.getBody());
     next.setDescription(prior.getDescription());
     next.setTags(prior.getTags() == null ? new ArrayList<>() : new ArrayList<>(prior.getTags()));
+    next.setIconKey(prior.getIconKey());
     next.setRetired(false);
     return next;
   }

--- a/backend/src/main/java/de/dlr/shepard/template/entities/ShepardTemplate.java
+++ b/backend/src/main/java/de/dlr/shepard/template/entities/ShepardTemplate.java
@@ -107,6 +107,14 @@ public class ShepardTemplate implements HasId, HasAppId {
   private String description;
 
   /**
+   * Optional MDI icon name (e.g. {@code "mdi-layers"}). Null means
+   * "use the per-kind default" (see {@code aidocs/integrations/122 §3}).
+   * The UI resolves it via {@code useTemplateIcon(template, kindHint)}.
+   */
+  @Property("iconKey")
+  private String iconKey;
+
+  /**
    * Free-form author-supplied tags — {@code ["lumen", "rocket",
    * "calibration"]} on a hot-fire test recipe, say. Used by the
    * picker for filtering.

--- a/backend/src/main/java/de/dlr/shepard/v2/template/io/CreateShepardTemplateIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/io/CreateShepardTemplateIO.java
@@ -10,7 +10,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
  * POST body for {@code POST /v2/templates}.
  *
  * <p>{@code appId} is server-minted; {@code version} starts at 1.
- * {@code createdBy} comes from the authenticated principal — never
+ * {@code createdBy} comes from the authenticated principal, never
  * from the body.
  */
 @Data
@@ -34,6 +34,6 @@ public class CreateShepardTemplateIO {
   @Schema(required = false, nullable = true, description = "Author-supplied tags for picker filtering.")
   private List<String> tags;
 
-  @Schema(required = false, nullable = true, description = "MDI icon name, e.g. 'mdi-layers'. Null means use the per-kind default.")
+  @Schema(required = false, nullable = true, description = "MDI icon name, e.g. mdi-layers. Null means use the per-kind default.")
   private String iconKey;
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/template/io/CreateShepardTemplateIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/io/CreateShepardTemplateIO.java
@@ -33,4 +33,7 @@ public class CreateShepardTemplateIO {
 
   @Schema(required = false, nullable = true, description = "Author-supplied tags for picker filtering.")
   private List<String> tags;
+
+  @Schema(required = false, nullable = true, description = "MDI icon name, e.g. 'mdi-layers'. Null means use the per-kind default.")
+  private String iconKey;
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/template/io/PatchShepardTemplateIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/io/PatchShepardTemplateIO.java
@@ -9,7 +9,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 /**
  * PATCH body for {@code PATCH /v2/templates/{appId}}.
  *
- * <p>Every field is nullable — only supplied fields apply. Editing
+ * <p>Every field is nullable -- only supplied fields apply. Editing
  * triggers a copy-on-write per {@code aidocs/54 §7}: a new
  * {@code :ShepardTemplate} node is minted with {@code version + 1};
  * the prior row is marked {@code retired = true}.
@@ -32,6 +32,6 @@ public class PatchShepardTemplateIO {
   @Schema(required = false, nullable = true, description = "If set, replaces the tag list (full replace, not merge).")
   private List<String> tags;
 
-  @Schema(required = false, nullable = true, description = "If set, replaces the MDI icon name. Supply null explicitly to clear the icon (use the per-kind default).")
+  @Schema(required = false, nullable = true, description = "If set, replaces the MDI icon name.")
   private String iconKey;
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/template/io/PatchShepardTemplateIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/io/PatchShepardTemplateIO.java
@@ -31,4 +31,7 @@ public class PatchShepardTemplateIO {
 
   @Schema(required = false, nullable = true, description = "If set, replaces the tag list (full replace, not merge).")
   private List<String> tags;
+
+  @Schema(required = false, nullable = true, description = "If set, replaces the MDI icon name. Supply null explicitly to clear the icon (use the per-kind default).")
+  private String iconKey;
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/template/io/ShepardTemplateIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/io/ShepardTemplateIO.java
@@ -31,14 +31,14 @@ public class ShepardTemplateIO {
   private Integer version;
 
   /**
-   * SHAPES-V-PREFILL-3-EXTRACT-SHACL — Template authors may embed a
+   * SHAPES-V-PREFILL-3-EXTRACT-SHACL -- Template authors may embed a
    * SHACL shape graph (Turtle) under the optional JSON field
    * {@code shapeGraph} inside this opaque body. The SHACL validation
    * playground ({@code /shapes/validate?templateAppId=<...>}) reads
    * that field via {@code frontend/utils/shaclTemplateBody.ts} and
    * pre-fills the shape-graph textarea when present. The Java IO does
-   * not parse the body — the convention is forward-compat and
-   * frontend-extracted — but the convention is recorded here so
+   * not parse the body -- the convention is forward-compat and
+   * frontend-extracted -- but the convention is recorded here so
    * template authors can discover it.
    */
   @Schema(required = true, description = "Recipe body. JSON DSL per aidocs/54 §7 (opaque to the entity; validation is service-layer). Optional field `shapeGraph` (Turtle string) is read by /shapes/validate per SHAPES-V-PREFILL-3-EXTRACT-SHACL.")
@@ -62,7 +62,7 @@ public class ShepardTemplateIO {
   @Schema(required = true, description = "true when retired and filtered from picker listings (still kept on disk).")
   private boolean retired;
 
-  @Schema(required = false, nullable = true, description = "MDI icon name, e.g. 'mdi-layers'. Null means use the per-kind default.")
+  @Schema(required = false, nullable = true, description = "MDI icon name, e.g. mdi-layers. Null means use the per-kind default.")
   private String iconKey;
 
   public static ShepardTemplateIO from(ShepardTemplate t) {

--- a/backend/src/main/java/de/dlr/shepard/v2/template/io/ShepardTemplateIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/io/ShepardTemplateIO.java
@@ -62,6 +62,9 @@ public class ShepardTemplateIO {
   @Schema(required = true, description = "true when retired and filtered from picker listings (still kept on disk).")
   private boolean retired;
 
+  @Schema(required = false, nullable = true, description = "MDI icon name, e.g. 'mdi-layers'. Null means use the per-kind default.")
+  private String iconKey;
+
   public static ShepardTemplateIO from(ShepardTemplate t) {
     return new ShepardTemplateIO(
       t.getAppId(),
@@ -74,7 +77,8 @@ public class ShepardTemplateIO {
       DisplayNameResolver.redactUsername(t.getCreatedBy()),
       t.getCreatedAt(),
       t.getUpdatedAt(),
-      t.isRetired()
+      t.isRetired(),
+      t.getIconKey()
     );
   }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
@@ -46,7 +46,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
  * a new node is minted with {@code version + 1} and the prior row
  * is retired (soft-delete). Existing
  * {@code (:Collection)-[:USES_TEMPLATE]->(prior)} citations stay
- * valid — reproducibility per {@code aidocs/41} snapshots.
+ * valid -- reproducibility per {@code aidocs/41} snapshots.
  */
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
@@ -130,6 +130,7 @@ public class ShepardTemplateRest {
     ShepardTemplate t = new ShepardTemplate(body.getName(), body.getTemplateKind(), body.getBody());
     t.setDescription(body.getDescription());
     if (body.getTags() != null) t.setTags(body.getTags());
+    t.setIconKey(body.getIconKey());
     t.setCreatedBy(caller);
     t.setCreatedAt(now);
     t.setUpdatedAt(now);
@@ -179,6 +180,7 @@ public class ShepardTemplateRest {
       if (body.getBody() != null) next.setBody(body.getBody());
       if (body.getDescription() != null) next.setDescription(body.getDescription());
       if (body.getTags() != null) next.setTags(body.getTags());
+      if (body.getIconKey() != null) next.setIconKey(body.getIconKey());
     }
     next.setCreatedBy(caller);
     next.setCreatedAt(now);

--- a/backend/src/main/resources/neo4j/migrations/V107_R__Add_iconKey_to_ShepardTemplate.cypher
+++ b/backend/src/main/resources/neo4j/migrations/V107_R__Add_iconKey_to_ShepardTemplate.cypher
@@ -1,0 +1,47 @@
+// TEMPLATE-ICONS-1 rollback — remove iconKey from the 10 MFFD templates.
+//
+// Scoped to the specific template names set by V107. Templates that an
+// admin has since edited (and thereby copy-on-write-versioned) carry a
+// different node; REMOVE on the v1 row does not affect those later versions.
+//
+// OPTIONAL MATCH means missing nodes are silently skipped.
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDStepRoot'})
+WHERE t IS NOT NULL
+REMOVE t.iconKey;
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDLayer'})
+WHERE t IS NOT NULL
+REMOVE t.iconKey;
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDPlyGroup'})
+WHERE t IS NOT NULL
+REMOVE t.iconKey;
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDTrack'})
+WHERE t IS NOT NULL
+REMOVE t.iconKey;
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDExecution'})
+WHERE t IS NOT NULL
+REMOVE t.iconKey;
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDBridgeWeldExecution'})
+WHERE t IS NOT NULL
+REMOVE t.iconKey;
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDSpotWeld'})
+WHERE t IS NOT NULL
+REMOVE t.iconKey;
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDNDTScan'})
+WHERE t IS NOT NULL
+REMOVE t.iconKey;
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDCell'})
+WHERE t IS NOT NULL
+REMOVE t.iconKey;
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDLayerOverview'})
+WHERE t IS NOT NULL
+REMOVE t.iconKey;

--- a/backend/src/main/resources/neo4j/migrations/V107__Add_iconKey_to_ShepardTemplate.cypher
+++ b/backend/src/main/resources/neo4j/migrations/V107__Add_iconKey_to_ShepardTemplate.cypher
@@ -1,0 +1,63 @@
+// TEMPLATE-ICONS-1 — seed iconKey on the 10 shipped MFFD process-type templates.
+//
+// Neo4j is schema-less, so the iconKey property is additive on existing
+// :ShepardTemplate nodes. Nodes without iconKey read as null in the OGM
+// (ShepardTemplateIO.from() maps null through; the UI falls back to the
+// per-kind default per aidocs/integrations/122 §3).
+//
+// Idempotency: each SET uses coalesce(t.iconKey, $icon) so a re-run is a
+// no-op — if iconKey is already set the coalesce returns the existing value
+// and the SET is a no-op. MATCH (instead of MERGE) + OPTIONAL MATCH means
+// missing template names are silently skipped; the migration does not fail
+// if a template has not yet been seeded.
+//
+// Operator runbook:
+//   Apply via the standard MigrationsRunner (Flyway-style ordering).
+//   Manual run: cypher-shell -u neo4j -p <password> -f V107__Add_iconKey_to_ShepardTemplate.cypher
+//   Verify:     MATCH (t:ShepardTemplate)
+//               WHERE t.iconKey IS NOT NULL
+//               RETURN t.name, t.iconKey ORDER BY t.name;
+//               → up to 10 rows for the templates that exist on this instance.
+//
+// Rollback: V107_R__Add_iconKey_to_ShepardTemplate.cypher
+// aidocs/16 TEMPLATE-ICONS-1; aidocs/34 V107 row.
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDStepRoot'})
+WHERE t IS NOT NULL
+SET t.iconKey = coalesce(t.iconKey, 'mdi-factory');
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDLayer'})
+WHERE t IS NOT NULL
+SET t.iconKey = coalesce(t.iconKey, 'mdi-layers');
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDPlyGroup'})
+WHERE t IS NOT NULL
+SET t.iconKey = coalesce(t.iconKey, 'mdi-format-list-group');
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDTrack'})
+WHERE t IS NOT NULL
+SET t.iconKey = coalesce(t.iconKey, 'mdi-vector-polyline');
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDExecution'})
+WHERE t IS NOT NULL
+SET t.iconKey = coalesce(t.iconKey, 'mdi-play-circle-outline');
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDBridgeWeldExecution'})
+WHERE t IS NOT NULL
+SET t.iconKey = coalesce(t.iconKey, 'mdi-flash-outline');
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDSpotWeld'})
+WHERE t IS NOT NULL
+SET t.iconKey = coalesce(t.iconKey, 'mdi-dots-circle');
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDNDTScan'})
+WHERE t IS NOT NULL
+SET t.iconKey = coalesce(t.iconKey, 'mdi-radar');
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDCell'})
+WHERE t IS NOT NULL
+SET t.iconKey = coalesce(t.iconKey, 'mdi-floor-plan');
+
+OPTIONAL MATCH (t:ShepardTemplate {name: 'MFFDLayerOverview'})
+WHERE t IS NOT NULL
+SET t.iconKey = coalesce(t.iconKey, 'mdi-view-dashboard-variant');

--- a/backend/src/test/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRestTest.java
@@ -73,7 +73,7 @@ class ShepardTemplateRestTest {
     when(securityContext.isUserInRole("instance-admin")).thenReturn(false);
     when(dao.list(null, false)).thenReturn(List.of());
     resource.list(null, true, securityContext);
-    verify(dao).list(null, false); // includeRetired=true downgraded to false
+    verify(dao).list(null, false);
     verify(dao, never()).list(null, true);
   }
 
@@ -161,7 +161,6 @@ class ShepardTemplateRestTest {
     Response r = resource.patch("prior-appid", body, securityContext);
 
     assertEquals(200, r.getStatus());
-    // dao.createOrUpdate called twice — once for prior (retire), once for new.
     ArgumentCaptor<ShepardTemplate> captor = ArgumentCaptor.forClass(ShepardTemplate.class);
     verify(dao, times(2)).createOrUpdate(captor.capture());
 

--- a/backend/src/test/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRestTest.java
@@ -105,7 +105,7 @@ class ShepardTemplateRestTest {
 
   @Test
   void createReturns400WhenBodyMissingRequiredFields() {
-    Response r = resource.create(new CreateShepardTemplateIO(null, "EXPERIMENT_RECIPE", "{}", null, null), securityContext);
+    Response r = resource.create(new CreateShepardTemplateIO(null, "EXPERIMENT_RECIPE", "{}", null, null, null), securityContext);
     assertEquals(400, r.getStatus());
   }
 
@@ -122,7 +122,7 @@ class ShepardTemplateRestTest {
       t.setAppId("server-minted-appid");
       return t;
     });
-    var body = new CreateShepardTemplateIO("Recipe", "EXPERIMENT_RECIPE", "{\"experiment\":{\"steps\":[]}}", "desc", List.of("lumen"));
+    var body = new CreateShepardTemplateIO("Recipe", "EXPERIMENT_RECIPE", "{\"experiment\":{\"steps\":[]}}", "desc", List.of("lumen"), null);
     Response r = resource.create(body, securityContext);
     assertEquals(201, r.getStatus());
     var io = (ShepardTemplateIO) r.getEntity();
@@ -136,7 +136,7 @@ class ShepardTemplateRestTest {
   @Test
   void patchReturns404WhenMissing() {
     when(dao.findByAppId("ghost")).thenReturn(Optional.empty());
-    Response r = resource.patch("ghost", new PatchShepardTemplateIO("new", null, null, null), securityContext);
+    Response r = resource.patch("ghost", new PatchShepardTemplateIO("new", null, null, null, null), securityContext);
     assertEquals(404, r.getStatus());
   }
 
@@ -157,7 +157,7 @@ class ShepardTemplateRestTest {
       return t;
     });
 
-    var body = new PatchShepardTemplateIO(null, "{\"experiment\":{\"v\":2}}", null, null);
+    var body = new PatchShepardTemplateIO(null, "{\"experiment\":{\"v\":2}}", null, null, null);
     Response r = resource.patch("prior-appid", body, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -227,7 +227,7 @@ class ShepardTemplateRestTest {
 
   @Test
   void createReturns400OnMalformedJson() {
-    var body = new CreateShepardTemplateIO("Recipe", "EXPERIMENT_RECIPE", "{ not valid json", null, null);
+    var body = new CreateShepardTemplateIO("Recipe", "EXPERIMENT_RECIPE", "{ not valid json", null, null, null);
     Response r = resource.create(body, securityContext);
     assertEquals(400, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -239,7 +239,7 @@ class ShepardTemplateRestTest {
 
   @Test
   void createReturns400OnWrongShapeBodyForKind() {
-    var body = new CreateShepardTemplateIO("Recipe", "EXPERIMENT_RECIPE", "{\"collection\":{}}", null, null);
+    var body = new CreateShepardTemplateIO("Recipe", "EXPERIMENT_RECIPE", "{\"collection\":{}}", null, null, null);
     Response r = resource.create(body, securityContext);
     assertEquals(400, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -255,10 +255,51 @@ class ShepardTemplateRestTest {
     prior.setAppId("prior-appid");
     when(dao.findByAppId("prior-appid")).thenReturn(Optional.of(prior));
 
-    var body = new PatchShepardTemplateIO(null, "[]", null, null);
+    var body = new PatchShepardTemplateIO(null, "[]", null, null, null);
     Response r = resource.patch("prior-appid", body, securityContext);
 
     assertEquals(400, r.getStatus());
     verify(dao, never()).createOrUpdate(any());
+  }
+
+  @Test
+  void createSetsIconKey() {
+    when(dao.createOrUpdate(any(ShepardTemplate.class))).thenAnswer(inv -> {
+      ShepardTemplate t = inv.getArgument(0);
+      t.setAppId("server-minted-appid");
+      return t;
+    });
+    var body = new CreateShepardTemplateIO("Recipe", "EXPERIMENT_RECIPE", "{\"experiment\":{\"steps\":[]}}", null, null, "mdi-factory");
+    Response r = resource.create(body, securityContext);
+    assertEquals(201, r.getStatus());
+    var io = (ShepardTemplateIO) r.getEntity();
+    assertEquals("mdi-factory", io.getIconKey());
+  }
+
+  @Test
+  void patchCarriesIconKeyThroughCopyOnWrite() {
+    var prior = new ShepardTemplate("Recipe", "EXPERIMENT_RECIPE", "{\"experiment\":{}}");
+    prior.setAppId("prior-appid");
+    prior.setVersion(1);
+    prior.setIconKey("mdi-layers");
+    when(dao.findByAppId("prior-appid")).thenReturn(Optional.of(prior));
+    when(dao.nextVersionOf(prior)).thenAnswer(inv -> {
+      ShepardTemplate next = new ShepardTemplate("Recipe", "EXPERIMENT_RECIPE", "{\"experiment\":{}}");
+      next.setVersion(2);
+      next.setIconKey("mdi-layers");
+      return next;
+    });
+    when(dao.createOrUpdate(any(ShepardTemplate.class))).thenAnswer(inv -> {
+      ShepardTemplate t = inv.getArgument(0);
+      if (t.getAppId() == null) t.setAppId("new-appid");
+      return t;
+    });
+
+    var body = new PatchShepardTemplateIO(null, null, null, null, "mdi-factory");
+    Response r = resource.patch("prior-appid", body, securityContext);
+
+    assertEquals(200, r.getStatus());
+    var io = (ShepardTemplateIO) r.getEntity();
+    assertEquals("mdi-factory", io.getIconKey());
   }
 }


### PR DESCRIPTION
## Summary

Implements backlog row **TEMPLATE-ICONS-1** per spec in `aidocs/integrations/122-template-icons.md`.

- **`ShepardTemplate.java`** — nullable `@Property("iconKey") String iconKey` field
- **`ShepardTemplateIO` / `CreateShepardTemplateIO` / `PatchShepardTemplateIO`** — expose `iconKey`; PATCH uses COW semantics (null = keep existing value)
- **`ShepardTemplateDAO`** — pass-through on create + update
- **`ShepardTemplateRest`** — GET / POST / PATCH `/v2/templates/{appId}` carry the field
- **`V107__Add_iconKey_to_ShepardTemplate.cypher`** — idempotent seed migration sets icons on 10 shipped MFFD templates using `coalesce(t.iconKey, $icon)` (re-run safe; OPTIONAL MATCH skips absent templates)
- **`V107_R__Add_iconKey_to_ShepardTemplate.cypher`** — rollback removes the property

### MFFD icon map (V107)
| Template | Icon |
|---|---|
| MFFDStepRoot | `mdi-factory` |
| MFFDLayer | `mdi-layers` |
| MFFDPlyGroup | `mdi-format-list-group` |
| MFFDTrack | `mdi-vector-polyline` |
| MFFDExecution | `mdi-play-circle-outline` |
| MFFDBridgeWeldExecution | `mdi-flash-outline` |
| MFFDSpotWeld | `mdi-dots-circle` |
| MFFDNDTScan | `mdi-radar` |
| MFFDCell | `mdi-floor-plan` |
| MFFDLayerOverview | `mdi-view-dashboard-variant` |

Frontend follow-up: **TEMPLATE-ICONS-2-FE** — `useTemplateIcon(template, kindHint)` composable + wiring into `CollectionDataObjectsPanel`, tree views, breadcrumbs, etc.

Note: backlog cited V104 but that slot was already taken (`V104__Collection_scene_graph_link.cypher`); corrected to V107.

https://claude.ai/code/session_013v7W8pYh6DDGpJBvZhVrna

---
_Generated by [Claude Code](https://claude.ai/code/session_013v7W8pYh6DDGpJBvZhVrna)_