### PR TITLE
feat(SHAPES-V-PREFILL-2): GET /v2/data-objects/{appId}/rdf — Turtle export of all DO annotations

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/annotations/daos/SemanticAnnotationV2DAO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/annotations/daos/SemanticAnnotationV2DAO.java
@@ -121,6 +121,30 @@ public class SemanticAnnotationV2DAO extends GenericDAO<SemanticAnnotation> {
       .toList();
   }
 
+  // ─── subject-scoped bulk load ─────────────────────────────────────────────
+
+  /**
+   * SHAPES-V-PREFILL-2 — return all annotations whose {@code subjectAppId}
+   * equals the given value. Used by the {@code /v2/data-objects/{appId}/rdf}
+   * Turtle-export endpoint and by the {@code validate.vue} SHACL pre-fill flow.
+   *
+   * <p>No pagination — callers that need pagination should use
+   * {@link #findFiltered} instead. Assumes the annotation count per subject
+   * entity is bounded (expected: single digits to low hundreds).
+   *
+   * @param subjectAppId the entity's UUID v7 appId
+   * @return all annotations for this subject; empty list when none found
+   */
+  public List<SemanticAnnotation> findBySubjectAppId(String subjectAppId) {
+    if (subjectAppId == null || subjectAppId.isBlank()) return List.of();
+    String query =
+      "MATCH (a:SemanticAnnotation) WHERE a.subjectAppId = $sid WITH a " +
+      CypherQueryHelper.getReturnPart("a", Neighborhood.OUTGOING);
+    return StreamSupport
+      .stream(findByQuery(query, Map.of("sid", subjectAppId)).spliterator(), false)
+      .toList();
+  }
+
   // ─── back-pointer stamp ────────────────────────────────────────────────────
 
   /**

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectRdfRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectRdfRest.java
@@ -1,0 +1,224 @@
+package de.dlr.shepard.v2.dataobject.resources;
+
+import de.dlr.shepard.auth.permission.services.PermissionsService;
+import de.dlr.shepard.common.identifier.EntityIdResolver;
+import de.dlr.shepard.common.util.AccessType;
+import de.dlr.shepard.context.semantic.entities.SemanticAnnotation;
+import de.dlr.shepard.v2.annotations.daos.SemanticAnnotationV2DAO;
+import io.quarkus.security.Authenticated;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import java.util.List;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+/**
+ * SHAPES-V-PREFILL-2 — {@code GET /v2/data-objects/{appId}/rdf}.
+ *
+ * <p>Returns all {@link SemanticAnnotation} triples for a given DataObject
+ * as an OA-framed Turtle document. This is the backend half consumed by
+ * the {@code validate.vue} frontend page when {@code ?focusAppId=} is present.
+ *
+ * <p>The Turtle shape follows §3.3 of
+ * {@code aidocs/semantics/100-consistent-semantic-annotation-design.md}:
+ * one flat triple and one OA {@code oa:Annotation} node per annotation.
+ *
+ * <p>When no annotations exist for the DataObject the response is still
+ * HTTP 200 with a valid (prefix-only) Turtle document — the empty set is a
+ * legitimate state, not an error.
+ *
+ * <p><b>Auth.</b> Read permission on the parent Collection (DataObjects
+ * inherit Collection permissions; there is no per-DataObject permission node).
+ * Returns 404 when the DataObject appId is unknown, 401 when the caller is
+ * unauthenticated, 403 when they lack Read access.
+ *
+ * <p><b>API-version policy.</b> This endpoint lives at {@code /v2/} — it is
+ * part of the fork's development surface and must never be added to the
+ * frozen {@code /shepard/api/...} compat surface.
+ */
+@Path("/v2/data-objects")
+@RequestScoped
+@Authenticated
+@Tag(name = "DataObjects (v2)")
+public class DataObjectRdfRest {
+
+  @Inject
+  SemanticAnnotationV2DAO annotationDAO;
+
+  @Inject
+  PermissionsService permissionsService;
+
+  @Inject
+  EntityIdResolver entityIdResolver;
+
+  // ─── endpoint ─────────────────────────────────────────────────────────────
+
+  @GET
+  @Path("/{appId}/rdf")
+  @Produces("text/turtle")
+  @Operation(
+    summary = "Export all semantic annotations for a DataObject as Turtle RDF.",
+    description =
+      "Returns all `:SemanticAnnotation` triples attached to the DataObject " +
+      "identified by `appId` as an OA-framed Turtle document.\n\n" +
+      "The shape follows §3.3 of " +
+      "`aidocs/semantics/100-consistent-semantic-annotation-design.md`: " +
+      "one flat triple and one W3C Open Annotations ({@code oa:Annotation}) " +
+      "node per annotation. Prefix declarations ({@code oa:}, {@code prov:}, " +
+      "{@code rdf:}, {@code sh:}, {@code shepard:}) are always emitted.\n\n" +
+      "When the DataObject has no annotations the response is still HTTP 200 " +
+      "with a valid (prefix-only) Turtle document.\n\n" +
+      "This endpoint is consumed by the {@code validate.vue} frontend page " +
+      "when {@code ?focusAppId=} is present (SHAPES-V-PREFILL-2).\n\n" +
+      "Auth: Read permission on the parent Collection (DataObjects inherit " +
+      "Collection permissions). Returns 404 for unknown appId."
+  )
+  @APIResponse(
+    responseCode = "200",
+    description = "Turtle document containing all SemanticAnnotation triples for the DataObject. " +
+      "Valid Turtle even when the annotation set is empty (prefix-only document).",
+    content = @Content(mediaType = "text/turtle")
+  )
+  @APIResponse(responseCode = "401", description = "Authentication required.")
+  @APIResponse(responseCode = "403", description = "Caller lacks Read permission on the parent Collection.")
+  @APIResponse(responseCode = "404", description = "No DataObject with that appId.")
+  public Response getDataObjectRdf(
+      @PathParam("appId") String appId,
+      @Context SecurityContext sc) {
+
+    // ── auth gate ──────────────────────────────────────────────────────────
+    String caller = sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;
+    if (caller == null) {
+      return Response.status(Response.Status.UNAUTHORIZED).build();
+    }
+
+    // ── existence check ────────────────────────────────────────────────────
+    // EntityIdResolver throws NotFoundException when the appId is unknown.
+    try {
+      entityIdResolver.resolveLong(appId);
+    } catch (NotFoundException nfe) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+
+    // ── permission check ───────────────────────────────────────────────────
+    // DataObjects have no own :Permissions node; access is inherited from the
+    // parent Collection. The helper walks DO → Collection via Cypher.
+    if (!permissionsService.isAccessAllowedForDataObjectAppId(appId, AccessType.Read, caller)) {
+      return Response.status(Response.Status.FORBIDDEN).build();
+    }
+
+    // ── fetch annotations & build Turtle ──────────────────────────────────
+    List<SemanticAnnotation> annotations = annotationDAO.findBySubjectAppId(appId);
+    String turtle = buildTurtleDocument(appId, annotations);
+
+    return Response.ok(turtle, "text/turtle").build();
+  }
+
+  // ─── Turtle serialisation helpers ────────────────────────────────────────
+
+  /**
+   * Builds a complete Turtle document for all annotations on the given DataObject.
+   *
+   * <p>Emits shared prefix declarations once, then one block per annotation.
+   * An empty annotation list yields a valid prefix-only document.
+   *
+   * <p>Uses the same §3.3 OA-frame shape as
+   * {@link de.dlr.shepard.v2.annotations.resources.SemanticAnnotationV2Rest#buildTurtle}.
+   */
+  static String buildTurtleDocument(String dataObjectAppId, List<SemanticAnnotation> annotations) {
+    StringBuilder sb = new StringBuilder();
+
+    // Shared prefix declarations
+    sb.append("@prefix oa: <http://www.w3.org/ns/oa#> .\n");
+    sb.append("@prefix prov: <http://www.w3.org/ns/prov#> .\n");
+    sb.append("@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n");
+    sb.append("@prefix sh: <http://www.w3.org/ns/shacl#> .\n");
+    sb.append("@prefix shepard: <https://shepard.dlr.de/v2/> .\n");
+
+    if (annotations == null || annotations.isEmpty()) {
+      return sb.toString();
+    }
+
+    sb.append("\n");
+
+    for (SemanticAnnotation a : annotations) {
+      sb.append(buildAnnotationBlock(a));
+      sb.append("\n");
+    }
+
+    return sb.toString();
+  }
+
+  /**
+   * Renders one annotation as a pair of Turtle stanzas (flat triple + OA frame).
+   *
+   * <p>Mirrors the private {@code buildTurtle(SemanticAnnotation)} helper in
+   * {@link de.dlr.shepard.v2.annotations.resources.SemanticAnnotationV2Rest},
+   * but without the per-annotation prefix block (those are emitted once by
+   * {@link #buildTurtleDocument}).
+   */
+  static String buildAnnotationBlock(SemanticAnnotation a) {
+    String subjectIri = shepardIri(a.getSubjectKind(), a.getSubjectAppId());
+    String predicateIri = nvl(a.getPropertyIRI(), "http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate");
+    String annotationIri = "shepard:Annotation/" + nvl(a.getAppId(), "unknown");
+    String activityIri = blank(a.getSourceActivityAppId())
+        ? null
+        : "shepard:Activity/" + a.getSourceActivityAppId();
+
+    // object value — IRI or literal
+    String objectValue = a.getValueIRI() != null
+        ? "<" + a.getValueIRI() + ">"
+        : "\"" + escapeTurtleLiteral(nvl(a.getValueName(), "")) + "\"";
+
+    StringBuilder sb = new StringBuilder();
+
+    // Flat triple (§3.3 line 1)
+    sb.append("<").append(subjectIri).append("> <").append(predicateIri).append("> ")
+        .append(objectValue).append(" .\n");
+    sb.append("\n");
+
+    // OA-shaped annotation (§3.3 lines 2-5)
+    sb.append("<").append(annotationIri).append("> a oa:Annotation ;\n");
+    sb.append("    oa:hasTarget <").append(subjectIri).append("> ;\n");
+    sb.append("    oa:hasBody [ rdf:value ").append(objectValue)
+        .append(" ; sh:path <").append(predicateIri).append("> ]");
+
+    if (activityIri != null) {
+      sb.append(" ;\n    prov:wasGeneratedBy <").append(activityIri).append(">");
+    }
+    sb.append(" .\n");
+
+    return sb.toString();
+  }
+
+  // ── tiny helpers — package-private so tests can reach them ────────────────
+
+  static String shepardIri(String kind, String appId) {
+    if (blank(kind) || blank(appId)) {
+      return "https://shepard.dlr.de/v2/entities/" + nvl(appId, "unknown");
+    }
+    return "https://shepard.dlr.de/v2/" + kind.toLowerCase() + "s/" + appId;
+  }
+
+  static String escapeTurtleLiteral(String s) {
+    return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r");
+  }
+
+  private static boolean blank(String s) {
+    return s == null || s.isBlank();
+  }
+
+  private static String nvl(String s, String fallback) {
+    return s == null || s.isBlank() ? fallback : s;
+  }
+}

--- a/backend/src/test/java/de/dlr/shepard/v2/dataobject/resources/DataObjectRdfRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/dataobject/resources/DataObjectRdfRestTest.java
@@ -1,0 +1,268 @@
+package de.dlr.shepard.v2.dataobject.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.dlr.shepard.auth.permission.services.PermissionsService;
+import de.dlr.shepard.common.identifier.EntityIdResolver;
+import de.dlr.shepard.common.util.AccessType;
+import de.dlr.shepard.context.semantic.entities.SemanticAnnotation;
+import de.dlr.shepard.v2.annotations.daos.SemanticAnnotationV2DAO;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import java.security.Principal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * SHAPES-V-PREFILL-2 — unit tests for {@link DataObjectRdfRest}.
+ *
+ * <p>All tests use Mockito field injection. No CDI context is started.
+ *
+ * <p>Covers the five required acceptance criteria:
+ * <ol>
+ *   <li>200 OK with valid Turtle when annotations exist</li>
+ *   <li>200 OK with empty-but-valid Turtle when no annotations</li>
+ *   <li>404 when DataObject appId does not exist</li>
+ *   <li>401/403 when caller lacks read permission</li>
+ *   <li>Response {@code Content-Type} is {@code text/turtle}</li>
+ * </ol>
+ */
+class DataObjectRdfRestTest {
+
+  static final String DO_APP_ID = "018f9c5a-7e26-7000-a000-000000000042";
+  static final long DO_OGM_ID = 99L;
+  static final String CALLER = "alice";
+
+  @Mock
+  SemanticAnnotationV2DAO annotationDAO;
+
+  @Mock
+  PermissionsService permissionsService;
+
+  @Mock
+  EntityIdResolver entityIdResolver;
+
+  @Mock
+  SecurityContext securityContext;
+
+  @Mock
+  Principal principal;
+
+  DataObjectRdfRest resource;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    resource = new DataObjectRdfRest();
+    resource.annotationDAO = annotationDAO;
+    resource.permissionsService = permissionsService;
+    resource.entityIdResolver = entityIdResolver;
+
+    when(securityContext.getUserPrincipal()).thenReturn(principal);
+    when(principal.getName()).thenReturn(CALLER);
+
+    // Default: DataObject exists
+    when(entityIdResolver.resolveLong(DO_APP_ID)).thenReturn(DO_OGM_ID);
+
+    // Default: caller has Read permission
+    when(permissionsService.isAccessAllowedForDataObjectAppId(eq(DO_APP_ID), eq(AccessType.Read), eq(CALLER)))
+        .thenReturn(true);
+
+    // Default: no annotations
+    when(annotationDAO.findBySubjectAppId(DO_APP_ID)).thenReturn(List.of());
+  }
+
+  // ── test 1: 200 OK with valid Turtle when annotations exist ─────────────
+
+  @Test
+  void returns200WithTurtleWhenAnnotationsExist() {
+    SemanticAnnotation ann = makeAnnotation(
+        "ann-001",
+        DO_APP_ID,
+        "DataObject",
+        "http://purl.org/dc/terms/title",
+        "Hot-fire TR-004"
+    );
+    when(annotationDAO.findBySubjectAppId(DO_APP_ID)).thenReturn(List.of(ann));
+
+    Response r = resource.getDataObjectRdf(DO_APP_ID, securityContext);
+
+    assertEquals(200, r.getStatus());
+    String body = (String) r.getEntity();
+    assertNotNull(body);
+    assertTrue(body.contains("@prefix oa:"), "Expected oa: prefix");
+    assertTrue(body.contains("@prefix shepard:"), "Expected shepard: prefix");
+    // Flat triple: subject IRI
+    assertTrue(body.contains("https://shepard.dlr.de/v2/dataobjects/" + DO_APP_ID),
+        "Expected subject IRI in flat triple");
+    // Object literal value
+    assertTrue(body.contains("Hot-fire TR-004"), "Expected annotation literal in Turtle");
+    // OA annotation block
+    assertTrue(body.contains("oa:Annotation"), "Expected oa:Annotation type in Turtle");
+    assertTrue(body.contains("oa:hasTarget"), "Expected oa:hasTarget in Turtle");
+  }
+
+  // ── test 2: 200 OK with empty-but-valid Turtle when no annotations ────
+
+  @Test
+  void returns200WithPrefixOnlyTurtleWhenNoAnnotations() {
+    // annotationDAO returns empty list (default stub)
+    Response r = resource.getDataObjectRdf(DO_APP_ID, securityContext);
+
+    assertEquals(200, r.getStatus());
+    String body = (String) r.getEntity();
+    assertNotNull(body);
+    // Prefixes must be present even when there are no triples
+    assertTrue(body.contains("@prefix oa:"), "Expected oa: prefix in empty document");
+    assertTrue(body.contains("@prefix prov:"), "Expected prov: prefix in empty document");
+    assertTrue(body.contains("@prefix rdf:"), "Expected rdf: prefix in empty document");
+    assertTrue(body.contains("@prefix sh:"), "Expected sh: prefix in empty document");
+    assertTrue(body.contains("@prefix shepard:"), "Expected shepard: prefix in empty document");
+    // No triple content beyond prefixes
+    assertTrue(!body.contains("oa:Annotation"),
+        "Annotation block should be absent when annotation list is empty");
+  }
+
+  // ── test 3: 404 when DataObject appId does not exist ─────────────────
+
+  @Test
+  void returns404WhenDataObjectNotFound() {
+    String unknownId = "018f-unknown-appid";
+    when(entityIdResolver.resolveLong(unknownId)).thenThrow(new NotFoundException());
+
+    Response r = resource.getDataObjectRdf(unknownId, securityContext);
+
+    assertEquals(404, r.getStatus());
+    verify(permissionsService, never()).isAccessAllowedForDataObjectAppId(any(), any(), any());
+    verify(annotationDAO, never()).findBySubjectAppId(any());
+  }
+
+  // ── test 4a: 401 when caller is not authenticated ────────────────────
+
+  @Test
+  void returns401WhenUnauthenticated() {
+    when(securityContext.getUserPrincipal()).thenReturn(null);
+
+    Response r = resource.getDataObjectRdf(DO_APP_ID, securityContext);
+
+    assertEquals(401, r.getStatus());
+    verify(entityIdResolver, never()).resolveLong(any());
+    verify(annotationDAO, never()).findBySubjectAppId(any());
+  }
+
+  // ── test 4b: 403 when caller lacks Read permission ────────────────────
+
+  @Test
+  void returns403WhenCallerLacksReadPermission() {
+    when(permissionsService.isAccessAllowedForDataObjectAppId(eq(DO_APP_ID), eq(AccessType.Read), eq(CALLER)))
+        .thenReturn(false);
+
+    Response r = resource.getDataObjectRdf(DO_APP_ID, securityContext);
+
+    assertEquals(403, r.getStatus());
+    verify(annotationDAO, never()).findBySubjectAppId(any());
+  }
+
+  // ── test 5: Content-Type is text/turtle ──────────────────────────────
+
+  @Test
+  void responseContentTypeIsTextTurtle() {
+    Response r = resource.getDataObjectRdf(DO_APP_ID, securityContext);
+
+    assertEquals(200, r.getStatus());
+    // The JAX-RS runtime populates Content-Type from @Produces when
+    // Response.ok(entity, mediaType) is used — check the entity type header
+    // set in the Response builder.
+    String contentType = r.getMediaType() != null ? r.getMediaType().toString() : "";
+    // When entity is a String the mediaType comes from the second arg to Response.ok(...)
+    assertTrue(contentType.startsWith("text/turtle"),
+        "Expected Content-Type text/turtle but got: " + contentType);
+  }
+
+  // ── test 6: multiple annotations produce multiple blocks ─────────────
+
+  @Test
+  void multipleAnnotationsProduceMultipleBlocks() {
+    SemanticAnnotation ann1 = makeAnnotation(
+        "ann-001", DO_APP_ID, "DataObject",
+        "http://purl.org/dc/terms/title", "Run TR-004"
+    );
+    SemanticAnnotation ann2 = makeAnnotation(
+        "ann-002", DO_APP_ID, "DataObject",
+        "http://purl.org/dc/terms/subject", "LOX/LH2"
+    );
+    when(annotationDAO.findBySubjectAppId(DO_APP_ID)).thenReturn(List.of(ann1, ann2));
+
+    Response r = resource.getDataObjectRdf(DO_APP_ID, securityContext);
+
+    assertEquals(200, r.getStatus());
+    String body = (String) r.getEntity();
+    // Both literal values must appear
+    assertTrue(body.contains("Run TR-004"), "Expected first annotation literal");
+    assertTrue(body.contains("LOX/LH2"), "Expected second annotation literal");
+    // Two oa:Annotation blocks
+    int count = countOccurrences(body, "oa:Annotation");
+    assertEquals(2, count, "Expected 2 oa:Annotation blocks");
+  }
+
+  // ── test 7: IRI-valued annotation produces IRI object ─────────────────
+
+  @Test
+  void iriValuedAnnotationProducesIriObject() {
+    SemanticAnnotation ann = new SemanticAnnotation();
+    ann.setAppId("ann-iri-01");
+    ann.setSubjectAppId(DO_APP_ID);
+    ann.setSubjectKind("DataObject");
+    ann.setPropertyIRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+    // valueIRI is set — no valueName
+    ann.setValueIRI("http://qudt.org/vocab/unit/M-PER-SEC");
+    ann.setValueName(null);
+
+    when(annotationDAO.findBySubjectAppId(DO_APP_ID)).thenReturn(List.of(ann));
+
+    Response r = resource.getDataObjectRdf(DO_APP_ID, securityContext);
+
+    assertEquals(200, r.getStatus());
+    String body = (String) r.getEntity();
+    assertTrue(body.contains("<http://qudt.org/vocab/unit/M-PER-SEC>"),
+        "Expected IRI-form object for IRI-valued annotation");
+  }
+
+  // ── helper ────────────────────────────────────────────────────────────────
+
+  static SemanticAnnotation makeAnnotation(
+      String annAppId,
+      String subjectAppId,
+      String subjectKind,
+      String predicateIri,
+      String valueName) {
+    SemanticAnnotation a = new SemanticAnnotation();
+    a.setAppId(annAppId);
+    a.setSubjectAppId(subjectAppId);
+    a.setSubjectKind(subjectKind);
+    a.setPropertyIRI(predicateIri);
+    a.setValueName(valueName);
+    return a;
+  }
+
+  static int countOccurrences(String haystack, String needle) {
+    int count = 0;
+    int idx = 0;
+    while ((idx = haystack.indexOf(needle, idx)) != -1) {
+      count++;
+      idx += needle.length();
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /v2/data-objects/{appId}/rdf` — returns all `SemanticAnnotation` triples for a DataObject as an OA-framed Turtle document
- Closes the missing backend half of backlog row **SHAPES-V-PREFILL-2**: the `validate.vue` frontend page already calls this endpoint when `?focusAppId=` is present
- Adds `SemanticAnnotationV2DAO.findBySubjectAppId()` — unbounded subject-scoped annotation lookup (distinct from `findFiltered()` which is paginated)

## Endpoint details

```
GET /v2/data-objects/{appId}/rdf
Accept: text/turtle
```

- **200** — valid Turtle with one flat triple + one `oa:Annotation` block per annotation (§3.3 of `aidocs/semantics/100`); prefix-only document when annotation set is empty
- **404** — unknown `appId`
- **401** — unauthenticated
- **403** — caller lacks Read on parent Collection
- **Content-Type** — `text/turtle`

Follows the flat-path pattern of `DataObjectBatchV2Rest` (`/v2/data-objects/batch`), NOT the collection-scoped pattern (`/v2/collections/{cId}/data-objects`), since the caller only has the DataObject `appId`.

## API-version policy

`/v2/` only. Never touches `/shepard/api/` compat surface.

## Test coverage

8 unit tests in `DataObjectRdfRestTest`:
1. 200 with valid Turtle when annotations exist (checks prefixes, subject IRI, literal, `oa:Annotation`)
2. 200 with prefix-only Turtle when no annotations
3. 404 when `appId` unknown
4. 401 when unauthenticated
5. 403 when caller lacks Read permission
6. `Content-Type: text/turtle` on the response
7. Multiple annotations produce multiple `oa:Annotation` blocks
8. IRI-valued annotation produces IRI-form object (`<uri>` not `"literal"`)

All 8 pass. Pre-existing failures in `DataObjectServiceTest`, `AnomalyDetectionServiceTest`, etc. are unrelated to these changes (confirmed by `git diff`).

## Backlog row

Implements **SHAPES-V-PREFILL-2-RDF-ENDPOINT** in `aidocs/16-dispatcher-backlog.md`.

https://claude.ai/code/session_01U7YFDvnZezK3wuQ2dVahTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7YFDvnZezK3wuQ2dVahTM)_