### PR TITLE
feat(UI-404-NICE-EMPTY-STATE-REF-PAGES): wire notFound to three reference detail pages

### DIFF
--- a/aidocs/agent-findings/dispatcher-runs/2026-06-02-23.md
+++ b/aidocs/agent-findings/dispatcher-runs/2026-06-02-23.md
@@ -1,0 +1,67 @@
+---
+stage: deployed
+last-stage-change: 2026-06-02
+fire: 2026-06-02-23
+fired-at: "2026-06-02T23:16Z"
+dispatcher: claude-sonnet-4-6
+---
+
+# Dispatcher fire 2026-06-02-23
+
+**Fired:** 2026-06-02 23:16 UTC  
+**Recent commits (last 2h):** 9 commits — mostly dispatcher log updates from the 22:00 fire + doc-stage index regeneration.
+
+## Inventory pass
+
+Backlog SSOT read end-to-end (3313 lines). Open PRs checked (30+ open). Items in-flight from recent fires: KRL-INTERPRETER-05-FOLLOWUP-AUTO-CONTAINER (#1753), SCENEGRAPH-NAV-02 (#1752), UI-PATHS-01-AUDIT (#1751), SHAPES-V-PREFILL-2 (#1750), COLL-TIMELINE-ANNOTATE-1 (#1749), TEMPLATE-ICONS-1 (#1748), and ~20 more.
+
+## Rows considered
+
+| Row ID | Size | Decision | Reason |
+|--------|------|----------|--------|
+| UI-404-NICE-EMPTY-STATE-REF-PAGES | XS | ✅ dispatched | composables already expose `notFound`; pure template wiring on 3 ref pages; zero risk |
+| UX-WALK-2026-05-29-07 | S | ✅ dispatched | "Visualize in 3D" CTA on TS container page; frontend-only; NICE priority; no blocker |
+| J1e-PR-06-JUPYTER-DOCS | S | ✅ dispatched | Jupyter reference.md never created; cross-link still missing in plugins.md; docs-only |
+| A2 | L | ⏭ skipped | Decompose monolithic REST — L size, high risk of API breakage |
+| P2b | M | ⏭ skipped | TimescaleDB continuous aggregates — DB infra, M size |
+| P3b | M | ⏭ skipped | Depends on image outside this repo |
+| L2e | M | ⏭ skipped | BREAKING — drops legacy v1 paths |
+| L4 | M | ⏭ skipped | M size, frontend search; no sub-task defined |
+| L7 | L | ⏭ skipped | L size |
+| A5e | S–M | ⏭ skipped | Depends on external Keycloak realm config |
+| PM1b3 | M–L | ⏭ skipped | Complex Quarkus CDI integration |
+| PROV1e | M | ⏭ skipped | Gated on aidocs/51 §9.5 admin-page strip (unclear if cleared) |
+| A3b1 frontend | — | ⏭ already done | AdminMetricsCard.vue already wired in admin/index.vue |
+| AI1c-UI | — | ⏭ already done | QualityScoreChip.vue already implemented and wired |
+| J1d-UI | — | ⏭ already done | LabJournalHistoryDialog.vue already implemented |
+| #27-ARCHIVED-CONTAINER-COLLECTION | — | ⏭ already done | All sub-rows shipped 2026-05-31 |
+| SHAPES-V-PREFILL-2-RDF-ENDPOINT | — | ⏭ in-flight | PR #1750 open |
+| SHAPES-V-PREFILL-3-EXTRACT-SHACL | — | ⏭ already done | extractShapeGraphFromTemplateBody implemented in validate.vue |
+| P5, P6, F1, F2, P9 | — | ⏭ skipped | Auth/permissions surface — prohibited |
+| DB-OPT5-NESTED | S | ⏭ skipped | Explicitly marked "Not blocking. Surface when a real caller asks." |
+| MFFD-IMAGEBUNDLE-PANE-MOUNT-1 | S | ⏭ in-flight | PR #1737 open |
+| AUTH-SESSION-AUTORENEW | M | ⏭ skipped | Auth-adjacent — prohibited |
+| VIS-S1b | S | ⏭ skipped | Access-control filter — auth-adjacent |
+
+## Dispatched
+
+### 1. UI-404-NICE-EMPTY-STATE-REF-PAGES → PR TBD
+- **Branch:** `UI-404-NICE-EMPTY-STATE-REF-PAGES-ref-page-wiring`
+- Wire `notFound` from `useFetchFileReference`, `useFetchTimeseriesReferences`, `useFetchStructuredDataReference` composables through to the three reference detail pages.
+- Files: `frontend/pages/collections/[collectionId]/dataobjects/[dataObjectId]/filereferences/[fileReferenceId]/index.vue`, `...timeseriesereferences/...`, `...structureddatareferences/...`
+- PR: pending
+
+### 2. UX-WALK-2026-05-29-07 → PR TBD
+- **Branch:** `UX-WALK-2026-05-29-07-trace3d-cta-ts-container`
+- Add "Visualize in 3D" button/CTA on `frontend/pages/containers/timeseries/[containerId]/index.vue` pointing to Trace3D.
+- PR: pending
+
+### 3. J1e-PR-06-JUPYTER-DOCS → PR TBD
+- **Branch:** `J1e-PR-06-JUPYTER-DOCS-reference-and-crosslink`
+- Create `plugins/jupyter/docs/reference.md` (minimal 3-audience doc covering the plugin's REST endpoints, admin config, and install).
+- Add jupyter row to `docs/reference/plugins.md`.
+- PR: pending
+
+## Log update
+
+PRs will be posted as comments on the tracker issue once agents report back.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes `UI-404-NICE-EMPTY-STATE-REF-PAGES` (aidocs/16 row, previously `queued`).

When a user navigates to a FileReference, TimeseriesReference, or StructuredDataReference detail page with a bogus or deleted appId, they now see a friendly `EntityNotFound` card instead of being stuck in a perpetual loading spinner.

- **Three composables updated** — `useFetchFileReference`, `useFetchTimeseriesReference`, `useFetchStructuredDataReference` each gain a `notFound: Ref<boolean>` that is set to `true` on HTTP 404 (and suppresses the error toast for that specific case). All other error paths (non-404) continue to call `handleError` as before.
- **`EntityNotFound.vue` added** — kind-aware heading ("This file reference doesn't exist."), "Back to Data Object →" CTA, requested-URL display, and a stale-URL hint card when the id is all-numeric (legacy Neo4j long).
- **`utils/idShape.ts` added** — `isNumericLegacyId` / `isPlausibleAppId` helpers used by the component.
- **Three reference detail pages wired** — each page wraps its main content in `<template v-if="!notFound">` and renders `<EntityNotFound v-else entity-kind="…" …>` with a parent-route pointing back to the DataObject detail page.
- **aidocs/16 row `UI-404-NICE-EMPTY-STATE-REF-PAGES`** flipped from `queued` to `✓ done (2026-06-02)`.

## Test plan

- [ ] Navigate to `/collections/<id>/dataobjects/<id>/filereferences/999999` — should show "This file reference doesn't exist." card with "Back to Data Object →" CTA (not a spinning loader or red toast).
- [ ] Same for `/timeseriesereferences/999999` and `/structureddatareferences/999999`.
- [ ] Navigate with a numeric id (e.g. `/filereferences/123`) — stale-URL hint card should appear inside the empty state.
- [ ] Navigate with a valid appId — existing page content renders normally (no regression).
- [ ] `npm run typecheck` passes clean.
- [ ] `npm run lint` — no new errors in changed files (5 pre-existing failures in `useFetchRecentCollections.test.ts` are unrelated).
- [ ] `npm run test` — 1053 passed, same 5 pre-existing failures as baseline.

Commit: 329be2d5dbb5b8e533a2c32defbf6ce083710196

https://claude.ai/code/session_017De9nKtRrSKdN4PyTSXBZH
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017De9nKtRrSKdN4PyTSXBZH)_