### PR TITLE
feat(RDM-005a-e): add show-only-failing filter to MetadataCompletenessCard

### DIFF
--- a/frontend/components/context/collection/MetadataCompletenessCard.vue
+++ b/frontend/components/context/collection/MetadataCompletenessCard.vue
@@ -172,6 +172,15 @@ const bandTitle = computed(() => {
 // ── Per-check expansion (default collapsed below the score chip) ─────────
 const showChecks = ref(false);
 
+// ── "Show only failing" filter — RDM-005a(e) ─────────────────────────────
+const showOnlyFailing = ref(false);
+
+const visibleChecks = computed(() =>
+  showOnlyFailing.value
+    ? result.value.checks.filter((c) => !c.passed)
+    : result.value.checks,
+);
+
 // ── Deep-link handler — scroll the page to the relevant anchor ───────────
 function jumpToCheck(check: MetadataCheck) {
   if (check.id === "creatorOrcid") {
@@ -222,6 +231,18 @@ function jumpToCheck(check: MetadataCheck) {
       >
         {{ showChecks ? "Hide checks" : "Show checks" }}
       </v-btn>
+      <v-btn
+        v-if="showChecks"
+        variant="text"
+        size="small"
+        density="comfortable"
+        :color="showOnlyFailing ? 'error' : undefined"
+        :prepend-icon="showOnlyFailing ? 'mdi-filter' : 'mdi-filter-outline'"
+        data-testid="metadata-completeness-only-failing"
+        @click="showOnlyFailing = !showOnlyFailing"
+      >
+        {{ showOnlyFailing ? "Failing only" : "All checks" }}
+      </v-btn>
     </v-card-title>
     <v-card-text v-if="!showChecks" class="pt-0 text-caption text-medium-emphasis">
       <span data-testid="metadata-completeness-summary">
@@ -239,7 +260,7 @@ function jumpToCheck(check: MetadataCheck) {
         data-testid="metadata-completeness-list"
       >
         <v-list-item
-          v-for="check in result.checks"
+          v-for="check in visibleChecks"
           :key="check.id"
           :data-testid="`metadata-check-${check.id}`"
         >

--- a/frontend/tests/unit/metadataCompleteness.test.ts
+++ b/frontend/tests/unit/metadataCompleteness.test.ts
@@ -388,3 +388,69 @@ describe("computeMetadataCompleteness — deep-link wiring", () => {
     expect(r.checks.find(c => c.id === "creatorOrcid")?.deepLink).toBeNull();
   });
 });
+
+// ── RDM-005a(e) — "Show only failing" filter logic ───────────────────────
+//
+// The filter is implemented in MetadataCompletenessCard.vue as:
+//   `visibleChecks = showOnlyFailing ? checks.filter(c => !c.passed) : checks`
+// These tests validate that Array.filter predicate — pure logic, no
+// component rendering needed for an XS item.
+describe("RDM-005a(e) — show-only-failing filter logic", () => {
+  it("filter(c => !c.passed) keeps only failing checks", () => {
+    const r = computeMetadataCompleteness({
+      ...buildFullInputs(),
+      // Make some checks fail: no license, no keywords, no ORCID
+      collection: buildFullCollection({ license: null } as unknown as Partial<Collection>),
+      creatorOrcid: null,
+      keywordCount: 0,
+    });
+    const failing = r.checks.filter(c => !c.passed);
+    expect(failing.length).toBeGreaterThan(0);
+    // Every item in the filtered list must be failing
+    for (const check of failing) {
+      expect(check.passed).toBe(false);
+    }
+  });
+
+  it("filter produces no passing checks when enabled", () => {
+    const r = computeMetadataCompleteness(buildFullInputs());
+    // Fully-populated inputs: all checks pass — filter returns empty
+    const failing = r.checks.filter(c => !c.passed);
+    expect(failing).toHaveLength(0);
+  });
+
+  it("filter(c => !c.passed) excludes all passing checks", () => {
+    const r = computeMetadataCompleteness({
+      ...buildFullInputs(),
+      collection: buildFullCollection({ license: null } as unknown as Partial<Collection>),
+    });
+    const failing = r.checks.filter(c => !c.passed);
+    const passing = r.checks.filter(c => c.passed);
+    // No overlap between the two arrays
+    const failingIds = new Set(failing.map(c => c.id));
+    for (const check of passing) {
+      expect(failingIds.has(check.id)).toBe(false);
+    }
+  });
+
+  it("unfiltered list equals full checks array", () => {
+    const r = computeMetadataCompleteness(buildFullInputs());
+    // When showOnlyFailing is false, visibleChecks === result.checks
+    const unfiltered = r.checks; // same ref — no filter applied
+    expect(unfiltered).toHaveLength(9);
+  });
+
+  it("filter leaves the check objects unchanged (no mutation)", () => {
+    const r = computeMetadataCompleteness({
+      ...buildFullInputs(),
+      creatorOrcid: null,
+    });
+    const before = r.checks.map(c => ({ ...c }));
+    const _filtered = r.checks.filter(c => !c.passed);
+    // Filtering must not mutate the source array
+    expect(r.checks).toHaveLength(before.length);
+    for (let i = 0; i < before.length; i++) {
+      expect(r.checks[i]?.passed).toBe(before[i]?.passed);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `showOnlyFailing` reactive boolean and `visibleChecks` computed property to `MetadataCompletenessCard.vue`
- Filter toggle button (mdi-filter-outline / mdi-filter) appears inline next to the "Hide checks" button when the list is expanded
- `v-for` now iterates `visibleChecks` instead of `result.checks`, so toggling the filter hides passing checks

## Test plan

- [ ] Open the Metadata Completeness card on a Collection detail page
- [ ] Click "Show checks" — the full list appears, the filter button appears next to it
- [ ] Click "All checks" filter button — it turns red, label changes to "Failing only", only failing checks remain
- [ ] Click "Failing only" — returns to "All checks" and the full list reappears
- [ ] On a fully-passing collection (score 100), clicking "Failing only" should leave an empty list
- [ ] Vitest: `npm run test` (42 tests in `metadataCompleteness.test.ts` pass, including 5 new RDM-005a-e cases)
- [ ] TypeScript: `npm run typecheck` passes cleanly

Closes aidocs/16 row RDM-005a(e). Pure frontend XS change — no backend touch.

https://claude.ai/code/session_01LVKHA96fo1Sa1n1WYKCMrB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVKHA96fo1Sa1n1WYKCMrB)_