### PR TITLE
chore(PROJ-PLAYWRIGHT-1-AUTH-FIXTURE): env-backed Playwright auth credentials

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,49 @@
+# e2e — Playwright end-to-end test suite
+
+## Running the tests
+
+```bash
+cd e2e
+npm install
+npx playwright test
+```
+
+By default tests run against `https://shepard.nuclide.systems` (configured in
+`playwright.config.ts`).
+
+## Environment variables for live Keycloak auth
+
+Playwright specs that call `loginAs()` use these env vars:
+
+| Variable | Default | Description |
+|---|---|---|
+| `DEMO_USER` | `flodemo` | Keycloak username for test user |
+| `DEMO_PASSWORD` | `flo-demo` | Keycloak password for test user |
+
+Set them to match a provisioned user on your target Keycloak realm:
+
+```bash
+export DEMO_USER=alice
+export DEMO_PASSWORD=alice-demo
+npx playwright test
+```
+
+The live `shepard-auth.nuclide.systems` realm currently provisions `alice`/`alice-demo`
+(user role). If `flodemo` is not provisioned on your realm, set these variables
+before running.
+
+Both constants are exported from `tests/helpers/auth.ts` so spec files import
+them instead of duplicating the `process.env` fallback pattern:
+
+```ts
+import { loginAs, DEMO_USER, DEMO_PASSWORD } from "./helpers/auth";
+
+await loginAs(page, DEMO_USER, DEMO_PASSWORD);
+```
+
+## Other environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `KEYCLOAK_HOST` | `https://shepard-auth.nuclide.systems` | Keycloak base URL |
+| `BACKEND_URL` | `https://shepard-api.nuclide.systems` | Shepard backend API URL |

--- a/e2e/tests/header-search.spec.ts
+++ b/e2e/tests/header-search.spec.ts
@@ -11,14 +11,11 @@
  * `examples/lumen-showcase/seed.py` is the data source; TR-004 is present.
  */
 import { test, expect } from "@playwright/test";
-import { loginAs } from "./helpers/auth";
-
-const USER = process.env.DEMO_USER || "flodemo";
-const PASSWORD = process.env.DEMO_PASSWORD || "flo-demo";
+import { loginAs, DEMO_USER, DEMO_PASSWORD } from "./helpers/auth";
 
 test.describe("Header search dropdown (UI-002)", () => {
   test.beforeEach(async ({ page }) => {
-    await loginAs(page, USER, PASSWORD);
+    await loginAs(page, DEMO_USER, DEMO_PASSWORD);
   });
 
   test("typing a known DataObject name produces a matching dataobject row", async ({ page }) => {

--- a/e2e/tests/helpers/auth.ts
+++ b/e2e/tests/helpers/auth.ts
@@ -7,6 +7,16 @@ const KC = process.env.KEYCLOAK_HOST || "https://shepard-auth.nuclide.systems";
 const REALM = "shepard-demo";
 
 /**
+ * Demo Keycloak credentials.  Set DEMO_USER / DEMO_PASSWORD in your shell
+ * (or .env.local) to match the provisioned user on your target realm.
+ * The live shepard-auth.nuclide.systems realm provisions `alice`/`alice-demo`
+ * (user role).  If `flodemo` is not present on your realm, export these vars
+ * before running Playwright.  See e2e/README.md for details.
+ */
+export const DEMO_USER = process.env.DEMO_USER ?? "flodemo";
+export const DEMO_PASSWORD = process.env.DEMO_PASSWORD ?? "flo-demo";
+
+/**
  * Tolerant OIDC browser login. Returns when the app's home page is loaded
  * with the user signed in (SIGN OUT visible).
  *

--- a/e2e/tests/home-polish.spec.ts
+++ b/e2e/tests/home-polish.spec.ts
@@ -18,14 +18,11 @@
  * AI Exchange collection has `<p>Collection to exchange data</p>` literal HTML.
  */
 import { test, expect } from "@playwright/test";
-import { loginAs } from "./helpers/auth";
-
-const USER = process.env.DEMO_USER || "flodemo";
-const PASSWORD = process.env.DEMO_PASSWORD || "flo-demo";
+import { loginAs, DEMO_USER, DEMO_PASSWORD } from "./helpers/auth";
 
 test.describe("Home + file-row polish (UI-006/007/009/015)", () => {
   test.beforeEach(async ({ page }) => {
-    await loginAs(page, USER, PASSWORD);
+    await loginAs(page, DEMO_USER, DEMO_PASSWORD);
   });
 
   test("UI-006: LUMEN card description renders markdown — no literal **", async ({

--- a/e2e/tests/recent-features.spec.ts
+++ b/e2e/tests/recent-features.spec.ts
@@ -20,7 +20,7 @@
  *   flodemo / flo-demo   (has the `orcid` user attribute pre-seeded)
  */
 import { test, expect } from "@playwright/test";
-import { loginAs } from "./helpers/auth";
+import { loginAs, DEMO_USER, DEMO_PASSWORD } from "./helpers/auth";
 
 const BACKEND =
   process.env.BACKEND_URL || "https://shepard-api.nuclide.systems";
@@ -94,7 +94,7 @@ test.describe("User profile — appId, avatar GET, ORCID auto-sync", () => {
   test("flo logs in; /shepard/api/users response includes appId + auto-synced orcid", async ({
     page,
   }) => {
-    await loginAs(page, "flodemo", "flo-demo");
+    await loginAs(page, DEMO_USER, DEMO_PASSWORD);
     // Bearer flow: pull the access token from the Nuxt auth session
     // (sidebase/nuxt-auth exposes the token at /api/auth/session) and
     // call the API directly. Cross-origin `credentials: include` won't
@@ -125,7 +125,7 @@ test.describe("User profile — appId, avatar GET, ORCID auto-sync", () => {
   }) => {
     // Get an appId via the logged-in page, then probe the avatar GET
     // anonymously to confirm the public-endpoint path.
-    await loginAs(page, "flodemo", "flo-demo");
+    await loginAs(page, DEMO_USER, DEMO_PASSWORD);
     const appId = await page.evaluate(async (backend) => {
       const sess = await fetch("/api/auth/session", {
         credentials: "include",
@@ -160,7 +160,7 @@ test.describe("User profile — appId, avatar GET, ORCID auto-sync", () => {
 
 test.describe("Profile page UI", () => {
   test("profile page renders with user details visible", async ({ page }) => {
-    await loginAs(page, "flodemo", "flo-demo");
+    await loginAs(page, DEMO_USER, DEMO_PASSWORD);
     await page.goto("/me");
     await page.waitForLoadState("networkidle");
     // U1b's effective display name MUST render; it's the canonical "I am
@@ -182,7 +182,7 @@ test.describe("Profile page UI", () => {
     // class-coupled and flaky to drive. The behavior we care about is
     // "PATCH /v2/users/me/preferences with ui.advancedMode succeeds 200,
     // and a subsequent GET returns the new value." We hit that directly.
-    await loginAs(page, "flodemo", "flo-demo");
+    await loginAs(page, DEMO_USER, DEMO_PASSWORD);
     const tokenJson = await page.evaluate(async () => {
       const r = await fetch("/api/auth/session", { credentials: "include" });
       return r.json();

--- a/e2e/tests/ui-013-help-search-anchors.spec.ts
+++ b/e2e/tests/ui-013-help-search-anchors.spec.ts
@@ -12,10 +12,7 @@
  * heading/anchor generation in `frontend/utils/helpMarkdown.ts`.
  */
 import { test, expect } from "@playwright/test";
-import { loginAs } from "./helpers/auth";
-
-const USER = process.env.DEMO_USER || "flodemo";
-const PASSWORD = process.env.DEMO_PASSWORD || "flo-demo";
+import { loginAs, DEMO_USER, DEMO_PASSWORD } from "./helpers/auth";
 
 // The shared loginAs() helper defaults KEYCLOAK_HOST to a stale internal IP.
 // Newer specs override via env at run time; document the convention here.
@@ -25,7 +22,7 @@ if (!process.env.KEYCLOAK_HOST) {
 
 test.describe("Help page search + anchors (UI-013)", () => {
   test.beforeEach(async ({ page }) => {
-    await loginAs(page, USER, PASSWORD);
+    await loginAs(page, DEMO_USER, DEMO_PASSWORD);
   });
 
   test("search box filters sections on the current help page", async ({ page }) => {

--- a/e2e/tests/ui-016-017-cosmetic-polish.spec.ts
+++ b/e2e/tests/ui-016-017-cosmetic-polish.spec.ts
@@ -19,14 +19,11 @@
  * known LUMEN data object.
  */
 import { test, expect } from "@playwright/test";
-import { loginAs } from "./helpers/auth";
-
-const USER = process.env.DEMO_USER || "flodemo";
-const PASSWORD = process.env.DEMO_PASSWORD || "flo-demo";
+import { loginAs, DEMO_USER, DEMO_PASSWORD } from "./helpers/auth";
 
 test.describe("UI-016 + UI-017 cosmetic polish", () => {
   test.beforeEach(async ({ page }) => {
-    await loginAs(page, USER, PASSWORD);
+    await loginAs(page, DEMO_USER, DEMO_PASSWORD);
   });
 
   test("UI-016: SD container Referenced-by rows expose +N more when >3 annotations", async ({

--- a/e2e/tests/ux-polish-2026-05-24.spec.ts
+++ b/e2e/tests/ux-polish-2026-05-24.spec.ts
@@ -19,10 +19,7 @@
  *   through `?q=<query>`.
  */
 import { test, expect } from "@playwright/test";
-import { loginAs } from "./helpers/auth";
-
-const USERNAME = process.env.DEMO_USER || "flodemo";
-const PASSWORD = process.env.DEMO_PASSWORD || "flo-demo";
+import { loginAs, DEMO_USER, DEMO_PASSWORD } from "./helpers/auth";
 
 const LUMEN_ID = 42;
 const SECOND_COLLECTION_ID = Number(
@@ -35,7 +32,7 @@ const SECOND_COLLECTION_ID = Number(
 
 test.describe("UX polish bundle 2026-05-24", () => {
   test.beforeEach(async ({ page }) => {
-    await loginAs(page, USERNAME, PASSWORD);
+    await loginAs(page, DEMO_USER, DEMO_PASSWORD);
   });
 
   test("Pattern A: no red error toast flashes on cold load of /collections/42", async ({ page }) => {

--- a/e2e/tests/ux-survey-2026-05-24.spec.ts
+++ b/e2e/tests/ux-survey-2026-05-24.spec.ts
@@ -38,8 +38,8 @@ async function loginLocal(page: Page, username: string, password: string): Promi
   throw new Error("loginLocal failed after 3 retries");
 }
 
-const USERNAME = process.env.KC_USERNAME || "flodemo";
-const PASSWORD = process.env.KC_PASSWORD || "flo-demo";
+const USERNAME = process.env.DEMO_USER || "flodemo";
+const PASSWORD = process.env.DEMO_PASSWORD || "flo-demo";
 const SHOT_DIR = "/opt/shepard/aidocs/agent-findings/screenshots-ux-survey-2026-05-24";
 const STORAGE_FILE = path.join(SHOT_DIR, "_storageState.json");
 

--- a/e2e/tests/ux-walk-2026-05-29.spec.ts
+++ b/e2e/tests/ux-walk-2026-05-29.spec.ts
@@ -19,7 +19,7 @@
  * renamed 2026-05-29 per ROLE-GRANT-DEMO-FLO-DISAMBIGUATE).
  */
 import { test } from "@playwright/test";
-import { loginAs } from "./helpers/auth";
+import { loginAs, DEMO_USER, DEMO_PASSWORD } from "./helpers/auth";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -30,8 +30,11 @@ const MICROSECTIONS_DO_APPID_PH2940_07 = "019e7244-06d0-7051-9add-f3f87fcf0f3b";
 const VP_4K = { width: 3840, height: 2160 };
 const VP_NARROW = { width: 1440, height: 900 };
 
+// Primary credentials come from env (DEMO_USER / DEMO_PASSWORD); fallback
+// list tries additional realm users so the walk succeeds even when the
+// primary account is not provisioned on the target realm.
 const CREDS: ReadonlyArray<readonly [string, string]> = [
-  ["flodemo", "flo-demo"],
+  [DEMO_USER, DEMO_PASSWORD],
   ["bob", "bob-demo"],
   ["alice", "alice-demo"],
 ];


### PR DESCRIPTION
## Summary

- Exports `DEMO_USER` and `DEMO_PASSWORD` constants from `e2e/tests/helpers/auth.ts`, backed by `process.env.DEMO_USER ?? "flodemo"` and `process.env.DEMO_PASSWORD ?? "flo-demo"`.
- Updates 8 spec files to import from the shared helper and removes per-file duplicate `const USER = process.env.DEMO_USER || "flodemo"` patterns.
- Standardises `ux-survey-2026-05-24.spec.ts` from `KC_USERNAME`/`KC_PASSWORD` to `DEMO_USER`/`DEMO_PASSWORD`.
- Creates `e2e/README.md` documenting the env vars so operators targeting a realm where `flodemo` is not provisioned know to set these before running.

**Root cause fixed:** Keycloak rejected `flodemo`/`flo-demo` on the live `shepard-auth.nuclide.systems` realm. By exporting env-backed defaults from the shared helper, any realm can be targeted by exporting `DEMO_USER=alice DEMO_PASSWORD=alice-demo` — no spec edits needed.

## Files changed

- `e2e/tests/helpers/auth.ts` — added `DEMO_USER` / `DEMO_PASSWORD` exports
- `e2e/tests/recent-features.spec.ts` — 4 hardcoded `loginAs(page, "flodemo", "flo-demo")` calls replaced
- `e2e/tests/ui-013-help-search-anchors.spec.ts` — local const removed, imports from helper
- `e2e/tests/ui-016-017-cosmetic-polish.spec.ts` — local const removed, imports from helper
- `e2e/tests/ux-polish-2026-05-24.spec.ts` — local const removed, imports from helper
- `e2e/tests/header-search.spec.ts` — local const removed, imports from helper
- `e2e/tests/home-polish.spec.ts` — local const removed, imports from helper
- `e2e/tests/ux-walk-2026-05-29.spec.ts` — first CREDS entry uses `[DEMO_USER, DEMO_PASSWORD]`
- `e2e/tests/ux-survey-2026-05-24.spec.ts` — env vars renamed from `KC_USERNAME`/`KC_PASSWORD`
- `e2e/README.md` — created, documents all auth env vars

## Test plan

- [ ] Set `DEMO_USER=alice DEMO_PASSWORD=alice-demo` and run `npx playwright test` against live — no spec should hardcode a credential that requires `flodemo` to be provisioned
- [ ] Without any env vars, default behaviour (`flodemo`/`flo-demo`) is unchanged for realms that have `flodemo`
- [ ] `git diff --stat` confirms only `e2e/` files were modified — no production code, no backend, no frontend source

https://claude.ai/code/session_01LerDfTVs6ifpgvRKKN7ysk

---
_Generated by [Claude Code](https://claude.ai/code/session_01LerDfTVs6ifpgvRKKN7ysk)_