### PR TITLE
feat(MFFD-PLUGIN-SVDX-SEMANTIC-1): Beckhoff channel → urn:shepard:phys:* classifier

### DIFF
--- a/plugins/fileformat-svdx/pom.xml
+++ b/plugins/fileformat-svdx/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  shepard-plugin-fileformat-svdx — Beckhoff TwinCAT Scope (.svdx) tier-1 manifest parser
+
+  STANDALONE MODULE. This pom is deliberately NOT wired into the main
+  aggregator build — the Quarkus/Jandex CompositeIndex hang documented
+  in the fileformat-robotics pom still applies. See MFFD-PARSER-01 for
+  the wire-up follow-up row.
+
+  Build:
+    cd plugins/fileformat-svdx && mvn verify
+
+  Scope (MFFD-PLUGIN-SVDX-1 + MFFD-PLUGIN-SVDX-SEMANTIC-1):
+    - Parse the channel-name manifest from a .svdx header (XML prefix
+      that Beckhoff TwinCAT Scope embeds before the binary payload).
+    - Emit urn:shepard:svdx:* annotations on the FileReference:
+      channelName, symbolName, sampleRate, unit, processType, seamId.
+    - Emit urn:shepard:phys:* physical-quantity annotations derived
+      from Beckhoff channel-name conventions (MFFD-PLUGIN-SVDX-SEMANTIC-1):
+      temperature, position, torque, force, ultrasonic-power, pressure,
+      velocity.
+    - NO TimescaleDB ingest (tier-2, gated on MFFD-PARSER-01 +
+      MFFD-NDRIVE-01 being resolved).
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>de.dlr.shepard.plugins</groupId>
+  <artifactId>shepard-plugin-fileformat-svdx</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>shepard plugin — fileformat svdx (Beckhoff TwinCAT Scope tier-1)</name>
+  <description>
+    Tier-1 manifest parser for Beckhoff TwinCAT Scope files (.svdx) from
+    the MFFD stringer continuous resistance welding (CRW) and spot-welding
+    cells at DLR ZLP Augsburg. Reads the XML channel-manifest prefix that
+    precedes the binary payload, emits urn:shepard:svdx:* annotations
+    (channelName, symbolName, sampleRate, unit, processType, seamId) and
+    urn:shepard:phys:* physical-quantity annotations derived from Beckhoff
+    naming conventions (temperature, position, torque, force,
+    ultrasonic-power, pressure, velocity). No TimescaleDB ingest (tier-2).
+  </description>
+
+  <organization>
+    <name>DLR e.V.</name>
+    <url>https://www.dlr.de</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <compiler-plugin.version>3.13.0</compiler-plugin.version>
+    <surefire-plugin.version>3.5.2</surefire-plugin.version>
+    <jacoco-plugin.version>0.8.12</jacoco-plugin.version>
+
+    <junit.version>5.11.4</junit.version>
+    <assertj.version>3.27.3</assertj.version>
+  </properties>
+
+  <dependencies>
+    <!-- No runtime deps beyond the JDK: javax.xml.parsers handles the
+         XML manifest prefix; java.util handles the classifier. -->
+
+    <!-- test scope only -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>shepard-plugin-fileformat-svdx-${project.version}</finalName>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals><goal>prepare-agent</goal></goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals><goal>report</goal></goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugins/fileformat-svdx/src/main/java/de/dlr/shepard/plugin/fileformat/svdx/FileParserPlugin.java
+++ b/plugins/fileformat-svdx/src/main/java/de/dlr/shepard/plugin/fileformat/svdx/FileParserPlugin.java
@@ -1,0 +1,68 @@
+package de.dlr.shepard.plugin.fileformat.svdx;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Local SPI shim for the {@code FileParserPlugin} interface sketched in
+ * aidocs/integrations/110 §3.
+ *
+ * <p>Mirrors the shim in {@code plugins/fileformat-robotics/} verbatim
+ * (same shape, same note about the Quarkus/Jandex hang preventing a
+ * direct backend dependency). When the Jandex hang clears, replace this
+ * file with {@code @Override} bindings against the real
+ * {@code de.dlr.shepard.spi.fileparser.FileParserPlugin} interface.
+ *
+ * @see SvdxManifestParser
+ */
+public interface FileParserPlugin {
+
+    /**
+     * Cheap reject: does this plugin handle the file described by the
+     * given MIME type and filename? Heavy work is left for
+     * {@link #parse(ParseContext)}.
+     */
+    boolean accepts(String mimeType, String filename);
+
+    /**
+     * Parse the file and emit annotations via
+     * {@link ParseContext#annotations()}.
+     *
+     * @param ctx per-invocation context — bytes + write target
+     * @return the number of annotations emitted (informational)
+     */
+    int parse(ParseContext ctx);
+
+    /**
+     * Minimum {@code ParseContext} needed by tier-1 parsers.
+     */
+    interface ParseContext {
+        byte[] bytes();
+        String filename();
+        Optional<String> parentDataObjectAppId();
+        Optional<String> fileReferenceAppId();
+
+        /** Other files in the same container; default empty. */
+        default List<SiblingFile> siblingFiles() { return List.of(); }
+
+        AnnotationWriter annotations();
+    }
+
+    /** A sibling file in the same {@code FileContainer}. */
+    record SiblingFile(String filename, String fileReferenceAppId) {}
+
+    /**
+     * Receive an emitted semantic annotation. The real backend
+     * implementation persists each call as a {@code :SemanticAnnotation}
+     * Neo4j node anchored to the {@code subjectAppId}.
+     */
+    @FunctionalInterface
+    interface AnnotationWriter {
+        /**
+         * @param subjectAppId appId of the annotation subject
+         * @param predicate    IRI (e.g. {@code urn:shepard:svdx:channelName})
+         * @param value        literal string value
+         */
+        void write(String subjectAppId, String predicate, String value);
+    }
+}

--- a/plugins/fileformat-svdx/src/main/java/de/dlr/shepard/plugin/fileformat/svdx/SvdxAnnotations.java
+++ b/plugins/fileformat-svdx/src/main/java/de/dlr/shepard/plugin/fileformat/svdx/SvdxAnnotations.java
@@ -1,0 +1,101 @@
+package de.dlr.shepard.plugin.fileformat.svdx;
+
+/**
+ * Canonical predicate IRIs emitted by the Beckhoff TwinCAT Scope
+ * ({@code .svdx}) tier-1 manifest parser. Follows the
+ * {@code urn:shepard:<domain>:<role>} namespace convention; this module
+ * owns {@code urn:shepard:svdx:*} and borrows the cross-cutting
+ * {@code urn:shepard:phys:*} physical-quantity namespace.
+ *
+ * <p>The {@code svdx:*} predicates capture channel metadata extracted from
+ * the XML manifest prefix that Beckhoff TwinCAT Scope embeds before the
+ * binary payload. The {@code phys:*} predicates are <em>derived</em> —
+ * inferred from Beckhoff channel-name conventions (see
+ * {@link SvdxManifestParser#classifyChannelPhysics(String)}) and assert the
+ * physical quantity a channel measures, independent of the raw channel name.
+ *
+ * <p>Reference: aidocs/integrations/110 §4.2,
+ * aidocs/16-dispatcher-backlog.md MFFD-PLUGIN-SVDX-1 +
+ * MFFD-PLUGIN-SVDX-SEMANTIC-1.
+ */
+public final class SvdxAnnotations {
+
+    private SvdxAnnotations() {
+        // utility class — no instances
+    }
+
+    // ── SVDX channel-metadata predicates (urn:shepard:svdx:*) ────────────
+
+    /** Prefix shared by every svdx-domain predicate. */
+    public static final String SVDX_PREDICATE_PREFIX = "urn:shepard:svdx:";
+
+    /**
+     * Raw channel name from the SVDX manifest
+     * (e.g. {@code "aTemperatureAnalogInput1"}). Multi-valued — emitted
+     * once per channel present in the file.
+     */
+    public static final String CHANNEL_NAME = SVDX_PREDICATE_PREFIX + "channelName";
+
+    /**
+     * Symbolic name (human-readable alias) from the SVDX manifest
+     * (e.g. {@code "TC Head 01"}). Multi-valued — one per channel; absent
+     * channels that carry no symbolic name.
+     */
+    public static final String SYMBOL_NAME = SVDX_PREDICATE_PREFIX + "symbolName";
+
+    /**
+     * Sample rate declared in the SVDX manifest header
+     * (e.g. {@code "1000 Hz"}). Single-valued per file.
+     */
+    public static final String SAMPLE_RATE = SVDX_PREDICATE_PREFIX + "sampleRate";
+
+    /**
+     * Engineering unit of a channel as declared in the manifest
+     * (e.g. {@code "°C"}, {@code "N"}, {@code "mm"}). Multi-valued —
+     * one per channel.
+     */
+    public static final String UNIT = SVDX_PREDICATE_PREFIX + "unit";
+
+    /**
+     * Process type derived from the filename or manifest comment
+     * (e.g. {@code "welding"}, {@code "afp-consolidation"}). Single-valued.
+     */
+    public static final String PROCESS_TYPE = SVDX_PREDICATE_PREFIX + "processType";
+
+    /**
+     * Weld seam or pass identifier derived from the filename
+     * (e.g. {@code "P08_2teBahn"}, {@code "TG258_spot_001"}). Single-valued.
+     */
+    public static final String SEAM_ID = SVDX_PREDICATE_PREFIX + "seamId";
+
+    // ── Physical-quantity predicates (urn:shepard:phys:*) ─────────────────
+    //
+    // Derived from Beckhoff TwinCAT Scope channel-name conventions.
+    // Value "true" is used (presence = quantity asserted). These predicates
+    // are cross-cutting — they may be emitted by other parsers in future
+    // (e.g. the Spatial Analyzer parser for force/torque channels).
+
+    /** Prefix shared by every phys-domain predicate. */
+    public static final String PHYS_PREDICATE_PREFIX = "urn:shepard:phys:";
+
+    /** {@code urn:shepard:phys:temperature} — channel measures temperature (°C). */
+    public static final String PHYS_TEMPERATURE = PHYS_PREDICATE_PREFIX + "temperature";
+
+    /** {@code urn:shepard:phys:position} — channel measures position or angle. */
+    public static final String PHYS_POSITION = PHYS_PREDICATE_PREFIX + "position";
+
+    /** {@code urn:shepard:phys:torque} — channel measures torque (N·m). */
+    public static final String PHYS_TORQUE = PHYS_PREDICATE_PREFIX + "torque";
+
+    /** {@code urn:shepard:phys:force} — channel measures force (N). */
+    public static final String PHYS_FORCE = PHYS_PREDICATE_PREFIX + "force";
+
+    /** {@code urn:shepard:phys:ultrasonic-power} — channel is an ultrasonic actuator signal. */
+    public static final String PHYS_ULTRASONIC_POWER = PHYS_PREDICATE_PREFIX + "ultrasonic-power";
+
+    /** {@code urn:shepard:phys:pressure} — channel measures pressure (Pa or bar). */
+    public static final String PHYS_PRESSURE = PHYS_PREDICATE_PREFIX + "pressure";
+
+    /** {@code urn:shepard:phys:velocity} — channel measures velocity or speed. */
+    public static final String PHYS_VELOCITY = PHYS_PREDICATE_PREFIX + "velocity";
+}

--- a/plugins/fileformat-svdx/src/main/java/de/dlr/shepard/plugin/fileformat/svdx/SvdxManifestParser.java
+++ b/plugins/fileformat-svdx/src/main/java/de/dlr/shepard/plugin/fileformat/svdx/SvdxManifestParser.java
@@ -1,0 +1,458 @@
+package de.dlr.shepard.plugin.fileformat.svdx;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Tier-1 parser for Beckhoff TwinCAT Scope files ({@code .svdx}).
+ *
+ * <p><b>Scope (tier-1, MFFD-PLUGIN-SVDX-1 + MFFD-PLUGIN-SVDX-SEMANTIC-1).</b>
+ * Reads the XML channel-manifest prefix that Beckhoff TwinCAT Scope v2
+ * embeds before the binary data payload. Emits two annotation families on
+ * the parent {@code FileReference}:
+ *
+ * <ul>
+ *   <li><b>{@code urn:shepard:svdx:*}</b> — raw manifest metadata:
+ *       channel name, symbolic name, sample rate, unit, process type,
+ *       seam id (from filename).</li>
+ *   <li><b>{@code urn:shepard:phys:*}</b> — physical-quantity tags inferred
+ *       from Beckhoff channel-name conventions via
+ *       {@link #classifyChannelPhysics(String)} (MFFD-PLUGIN-SVDX-SEMANTIC-1).
+ *       Value {@code "true"} signals presence.</li>
+ * </ul>
+ *
+ * <p><b>Format background.</b> A {@code .svdx} file begins with a UTF-8
+ * XML document (the "scope manifest") immediately followed by a binary
+ * payload containing the sampled data. The XML section ends at the first
+ * {@code </TcScope>} closing tag. This parser extracts only the XML
+ * portion via a SAX scan that stops as soon as the manifest is consumed
+ * (or the binary boundary is reached).
+ *
+ * <p><b>Beckhoff naming conventions (MFFD-PLUGIN-SVDX-SEMANTIC-1).</b>
+ * TwinCAT PLC variable names follow a systematic convention:
+ * <ul>
+ *   <li>Prefix character encodes data type: {@code a} = analog input,
+ *       {@code r} = real (float), {@code b} = boolean, {@code n} = integer.</li>
+ *   <li>The name root encodes the physical quantity:
+ *       {@code Temperature/Temp} → temperature, {@code RoboPos} → position,
+ *       {@code Torque} → torque, {@code Force} → force,
+ *       {@code Branson} → ultrasonic actuator, {@code Pressure} → pressure,
+ *       {@code Velocity} → velocity.</li>
+ * </ul>
+ * The classifier {@link #classifyChannelPhysics(String)} implements this
+ * mapping and is package-visible for direct unit testing.
+ *
+ * <p><b>Out of scope (tier-2, MFFD-PARSER-SVDX1).</b> Binary payload
+ * ingest into TimescaleDB requires the full SVDX binary decoder (gated on
+ * MFFD-PARSER-01 + MFFD-NDRIVE-01). This parser is best-effort: any
+ * failure yields zero or partial annotations and never throws.
+ *
+ * <p><b>Seam ID derivation.</b> The filename basename (without extension)
+ * is used as the seam identifier; e.g. {@code "P08_2teBahn.svdx"} →
+ * {@code seamId = "P08_2teBahn"}.
+ *
+ * <p><b>Error policy.</b> Any parse failure (malformed XML, binary
+ * boundary before end tag, null context) results in zero or partial
+ * annotations but no thrown exception — tier-1 is a best-effort
+ * enrichment hook, never the cause of an upload failure.
+ */
+public final class SvdxManifestParser implements FileParserPlugin {
+
+    /** Accepted extension (case-insensitive). */
+    public static final String EXTENSION = ".svdx";
+
+    /** Literal value emitted for physical-quantity predicates (presence = asserted). */
+    public static final String PHYS_VALUE_TRUE = "true";
+
+    private static final Logger LOG =
+            Logger.getLogger(SvdxManifestParser.class.getName());
+
+    @Override
+    public boolean accepts(String mimeType, String filename) {
+        if (filename == null) return false;
+        return filename.toLowerCase(Locale.ROOT).endsWith(EXTENSION);
+    }
+
+    @Override
+    public int parse(ParseContext ctx) {
+        if (ctx == null || ctx.bytes() == null || ctx.bytes().length == 0) {
+            return 0;
+        }
+        String subject = ctx.fileReferenceAppId()
+                .or(ctx::parentDataObjectAppId)
+                .orElse(null);
+        if (subject == null) {
+            return 0;
+        }
+
+        // ── Seam ID from filename ──
+        int emitted = 0;
+        String seamId = extractSeamId(ctx.filename());
+        if (seamId != null && !seamId.isEmpty()) {
+            ctx.annotations().write(subject, SvdxAnnotations.SEAM_ID, seamId);
+            emitted++;
+        }
+
+        // ── Parse XML manifest prefix ──
+        List<ChannelEntry> channels;
+        try {
+            channels = parseManifest(ctx.bytes());
+        } catch (Exception e) {
+            LOG.log(Level.WARNING,
+                    "SvdxManifestParser: failed to parse manifest from {0}: {1}",
+                    new Object[]{ctx.filename(), e.getMessage()});
+            return emitted;
+        }
+
+        // ── Emit per-channel annotations ──
+        for (ChannelEntry ch : channels) {
+            if (ch.name() != null && !ch.name().isBlank()) {
+                ctx.annotations().write(subject, SvdxAnnotations.CHANNEL_NAME, ch.name());
+                emitted++;
+            }
+            if (ch.symbolName() != null && !ch.symbolName().isBlank()) {
+                ctx.annotations().write(subject, SvdxAnnotations.SYMBOL_NAME, ch.symbolName());
+                emitted++;
+            }
+            if (ch.unit() != null && !ch.unit().isBlank()) {
+                ctx.annotations().write(subject, SvdxAnnotations.UNIT, ch.unit());
+                emitted++;
+            }
+
+            // ── Physical-quantity classifier (MFFD-PLUGIN-SVDX-SEMANTIC-1) ──
+            Optional<String> physPredicate = classifyChannelPhysics(ch.name());
+            if (physPredicate.isPresent()) {
+                ctx.annotations().write(subject, physPredicate.get(), PHYS_VALUE_TRUE);
+                emitted++;
+            }
+        }
+
+        // ── Sample rate (file-level, from first channel or manifest root) ──
+        channels.stream()
+                .filter(ch -> ch.sampleRate() != null && !ch.sampleRate().isBlank())
+                .findFirst()
+                .ifPresent(ch -> {
+                    ctx.annotations().write(subject, SvdxAnnotations.SAMPLE_RATE, ch.sampleRate());
+                });
+        if (channels.stream().anyMatch(ch -> ch.sampleRate() != null && !ch.sampleRate().isBlank())) {
+            emitted++;
+        }
+
+        return emitted;
+    }
+
+    // ─── Physical-quantity classifier ──────────────────────────────────────
+
+    /**
+     * Classify a Beckhoff TwinCAT channel name to a
+     * {@code urn:shepard:phys:*} predicate using the naming conventions
+     * observed in MFFD CRW and spot-welding scope files.
+     *
+     * <p>The matching is case-insensitive. Patterns (in priority order):
+     *
+     * <ol>
+     *   <li>Starts with {@code aTemperatureAnalog} or contains {@code Temp}
+     *       → {@link SvdxAnnotations#PHYS_TEMPERATURE}</li>
+     *   <li>Starts with {@code rRoboPos} or contains {@code RoboPos}
+     *       → {@link SvdxAnnotations#PHYS_POSITION}</li>
+     *   <li>Contains {@code Torque} or starts with {@code rTorque}
+     *       → {@link SvdxAnnotations#PHYS_TORQUE}</li>
+     *   <li>Contains {@code Force} or starts with {@code rForce}
+     *       → {@link SvdxAnnotations#PHYS_FORCE}</li>
+     *   <li>Starts with {@code aBranson} or contains {@code Branson}
+     *       → {@link SvdxAnnotations#PHYS_ULTRASONIC_POWER}</li>
+     *   <li>Contains {@code Pressure} or starts with {@code aPressure}
+     *       → {@link SvdxAnnotations#PHYS_PRESSURE}</li>
+     *   <li>Contains {@code Velocity} or starts with {@code rVelocity}
+     *       → {@link SvdxAnnotations#PHYS_VELOCITY}</li>
+     * </ol>
+     *
+     * @param channelName the raw Beckhoff channel name; may be {@code null}
+     * @return the first matching {@code urn:shepard:phys:*} predicate IRI,
+     *         or {@link Optional#empty()} when no pattern matches or the
+     *         input is {@code null}
+     */
+    static Optional<String> classifyChannelPhysics(String channelName) {
+        if (channelName == null) {
+            return Optional.empty();
+        }
+        // Normalise once — all comparisons are case-insensitive
+        String lower = channelName.toLowerCase(Locale.ROOT);
+
+        // 1. Temperature: aTemperatureAnalog* or contains "temp"
+        if (lower.startsWith("atemperatureanalog") || lower.contains("temp")) {
+            return Optional.of(SvdxAnnotations.PHYS_TEMPERATURE);
+        }
+        // 2. Position: rRoboPos* or contains "robopos"
+        if (lower.startsWith("rrobopos") || lower.contains("robopos")) {
+            return Optional.of(SvdxAnnotations.PHYS_POSITION);
+        }
+        // 3. Torque: rTorque* or contains "torque"
+        if (lower.startsWith("rtorque") || lower.contains("torque")) {
+            return Optional.of(SvdxAnnotations.PHYS_TORQUE);
+        }
+        // 4. Force: rForce* or contains "force"
+        if (lower.startsWith("rforce") || lower.contains("force")) {
+            return Optional.of(SvdxAnnotations.PHYS_FORCE);
+        }
+        // 5. Ultrasonic: aBranson* or contains "branson"
+        if (lower.startsWith("abranson") || lower.contains("branson")) {
+            return Optional.of(SvdxAnnotations.PHYS_ULTRASONIC_POWER);
+        }
+        // 6. Pressure: aPressure* or contains "pressure"
+        if (lower.startsWith("apressure") || lower.contains("pressure")) {
+            return Optional.of(SvdxAnnotations.PHYS_PRESSURE);
+        }
+        // 7. Velocity: rVelocity* or contains "velocity"
+        if (lower.startsWith("rvelocity") || lower.contains("velocity")) {
+            return Optional.of(SvdxAnnotations.PHYS_VELOCITY);
+        }
+
+        return Optional.empty();
+    }
+
+    // ─── Manifest XML parser ────────────────────────────────────────────────
+
+    /**
+     * Parse the XML manifest prefix out of the raw {@code .svdx} bytes.
+     *
+     * <p>The manifest is a UTF-8 XML document that Beckhoff TwinCAT Scope v2
+     * embeds at the start of the file before the binary payload. We scan for
+     * the closing {@code </TcScope>} tag to bound the XML region, then parse
+     * that region with a SAX handler. If no XML boundary is found, we
+     * attempt to parse the whole buffer (handles pure-XML test fixtures).
+     *
+     * @return list of channel entries extracted from the manifest;
+     *         empty list if none found
+     */
+    static List<ChannelEntry> parseManifest(byte[] bytes) {
+        // ── Find the XML boundary ──
+        // Scan for "</TcScope>" in the byte array (UTF-8 encoded).
+        byte[] endTag = "</TcScope>".getBytes(StandardCharsets.UTF_8);
+        int xmlEnd = indexOf(bytes, endTag);
+        int xmlLength = (xmlEnd >= 0) ? xmlEnd + endTag.length : bytes.length;
+
+        // ── SAX parse of the XML region ──
+        SvdxSaxHandler handler = new SvdxSaxHandler();
+        try {
+            SAXParserFactory factory = SAXParserFactory.newInstance();
+            // Hardened against XXE — no external entity resolution
+            factory.setFeature(
+                    "http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature(
+                    "http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature(
+                    "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            SAXParser saxParser = factory.newSAXParser();
+            saxParser.parse(
+                    new ByteArrayInputStream(bytes, 0, xmlLength), handler);
+        } catch (SAXException e) {
+            // Partial parse OK — the binary tail will cause a SAX error; we
+            // accept partial results already collected by the handler.
+            LOG.log(Level.FINE,
+                    "SvdxManifestParser: SAX stopped early (binary boundary or malformed XML): {0}",
+                    e.getMessage());
+        } catch (Exception e) {
+            LOG.log(Level.WARNING,
+                    "SvdxManifestParser: XML manifest parse failed: {0}",
+                    e.getMessage());
+        }
+        return handler.channels();
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    /**
+     * Extract the seam/pass identifier from the filename: the basename
+     * without its {@code .svdx} extension.
+     * {@code "P08_2teBahn.svdx"} → {@code "P08_2teBahn"}.
+     */
+    static String extractSeamId(String filename) {
+        if (filename == null) return null;
+        String base = basename(filename);
+        if (base.toLowerCase(Locale.ROOT).endsWith(EXTENSION)) {
+            return base.substring(0, base.length() - EXTENSION.length());
+        }
+        return base;
+    }
+
+    private static String basename(String path) {
+        int slash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+        return slash >= 0 ? path.substring(slash + 1) : path;
+    }
+
+    /**
+     * Find the first occurrence of {@code needle} in {@code haystack},
+     * returning the byte offset or {@code -1} if not found.
+     */
+    private static int indexOf(byte[] haystack, byte[] needle) {
+        outer:
+        for (int i = 0; i <= haystack.length - needle.length; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) continue outer;
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    // ─── SAX handler ────────────────────────────────────────────────────────
+
+    /**
+     * SAX handler that extracts channel entries from a TwinCAT Scope
+     * manifest. The expected element hierarchy (simplified):
+     *
+     * <pre>{@code
+     * <TcScope>
+     *   <SampleTime>1000000</SampleTime>   <!-- ns → Hz derivable -->
+     *   <Channel>
+     *     <Name>aTemperatureAnalogInput1</Name>
+     *     <SymbolBased>
+     *       <Symbol>MAIN.aTemperatureAnalogInput1</Symbol>
+     *     </SymbolBased>
+     *     <YAxis>
+     *       <Unit>°C</Unit>
+     *     </YAxis>
+     *   </Channel>
+     *   ...
+     * </TcScope>
+     * }</pre>
+     *
+     * <p>The handler is defensive: unknown element names and missing
+     * optional fields are silently skipped.
+     */
+    private static final class SvdxSaxHandler extends DefaultHandler {
+
+        private final List<ChannelEntry> channels = new ArrayList<>();
+        private final StringBuilder text = new StringBuilder();
+
+        // State for the channel being built
+        private String currentName;
+        private String currentSymbol;
+        private String currentUnit;
+        private String currentSampleTime; // nanoseconds string
+        private boolean inChannel;
+        private boolean inSymbolBased;
+        private boolean inYAxis;
+
+        List<ChannelEntry> channels() { return List.copyOf(channels); }
+
+        @Override
+        public void startElement(String uri, String localName,
+                                 String qName, Attributes attributes) {
+            text.setLength(0);
+            switch (qName) {
+                case "Channel" -> {
+                    inChannel = true;
+                    currentName = null;
+                    currentSymbol = null;
+                    currentUnit = null;
+                }
+                case "SymbolBased" -> inSymbolBased = true;
+                case "YAxis" -> inYAxis = true;
+                default -> { /* ignore */ }
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName) {
+            String value = text.toString().trim();
+            switch (qName) {
+                case "Name" -> {
+                    if (inChannel && !inSymbolBased && !inYAxis) {
+                        currentName = value;
+                    }
+                }
+                case "Symbol" -> {
+                    if (inChannel && inSymbolBased) {
+                        // Full PLC symbol path; strip the leading "MAIN." prefix
+                        // to recover the short channel name when Name is absent.
+                        if (currentSymbol == null) {
+                            currentSymbol = stripPlcPrefix(value);
+                        }
+                    }
+                }
+                case "Unit" -> {
+                    if (inChannel && inYAxis) {
+                        currentUnit = value;
+                    }
+                }
+                case "SampleTime" -> currentSampleTime = value; // ns
+                case "SymbolBased" -> inSymbolBased = false;
+                case "YAxis" -> inYAxis = false;
+                case "Channel" -> {
+                    inChannel = false;
+                    // Resolve effective name: prefer <Name>, fall back to
+                    // symbol short name derived from <Symbol>.
+                    String effectiveName = (currentName != null && !currentName.isBlank())
+                            ? currentName : currentSymbol;
+                    channels.add(new ChannelEntry(
+                            effectiveName,
+                            currentSymbol,
+                            sampleRateHz(currentSampleTime),
+                            currentUnit));
+                    currentName = null;
+                    currentSymbol = null;
+                    currentUnit = null;
+                }
+                default -> { /* ignore */ }
+            }
+            text.setLength(0);
+        }
+
+        @Override
+        public void characters(char[] ch, int start, int length) {
+            text.append(ch, start, length);
+        }
+
+        /** Convert a PLC symbol path {@code "MAIN.rRoboPos_X"} → {@code "rRoboPos_X"}. */
+        private static String stripPlcPrefix(String symbol) {
+            int dot = symbol.lastIndexOf('.');
+            return dot >= 0 ? symbol.substring(dot + 1) : symbol;
+        }
+
+        /**
+         * Convert a TwinCAT sample time in nanoseconds to a human-readable
+         * Hz string, e.g. {@code "1000000"} → {@code "1000 Hz"}.
+         * Returns {@code null} if the sample time is absent or unparseable.
+         */
+        private static String sampleRateHz(String sampleTimeNs) {
+            if (sampleTimeNs == null || sampleTimeNs.isBlank()) return null;
+            try {
+                long ns = Long.parseLong(sampleTimeNs.trim());
+                if (ns <= 0) return null;
+                long hz = 1_000_000_000L / ns;
+                return hz + " Hz";
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+    }
+
+    // ─── ChannelEntry record ─────────────────────────────────────────────────
+
+    /**
+     * Immutable snapshot of a single channel entry from the SVDX manifest.
+     *
+     * @param name       raw channel name (Beckhoff PLC variable name),
+     *                   e.g. {@code "aTemperatureAnalogInput1"}
+     * @param symbolName human-readable alias or PLC short symbol,
+     *                   e.g. {@code "TC Head 01"} or {@code "rRoboPos_X"}
+     * @param sampleRate sample rate as a human-readable string,
+     *                   e.g. {@code "1000 Hz"}; {@code null} if absent
+     * @param unit       engineering unit, e.g. {@code "°C"}; {@code null} if absent
+     */
+    record ChannelEntry(String name, String symbolName,
+                        String sampleRate, String unit) {}
+}

--- a/plugins/fileformat-svdx/src/test/java/de/dlr/shepard/plugin/fileformat/svdx/SvdxManifestParserTest.java
+++ b/plugins/fileformat-svdx/src/test/java/de/dlr/shepard/plugin/fileformat/svdx/SvdxManifestParserTest.java
@@ -1,0 +1,409 @@
+package de.dlr.shepard.plugin.fileformat.svdx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SvdxManifestParser}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>{@code classifyChannelPhysics} — all seven pattern families +
+ *       null + no-match</li>
+ *   <li>{@code accepts} — extension matching</li>
+ *   <li>{@code extractSeamId} — filename basename stripping</li>
+ *   <li>Integration: full XML manifest → annotation emission including
+ *       physical-quantity predicates</li>
+ * </ul>
+ */
+class SvdxManifestParserTest {
+
+    // ─── RecordingWriter helper ──────────────────────────────────────────────
+
+    static final class RecordingWriter implements FileParserPlugin.AnnotationWriter {
+        record Entry(String subject, String predicate, String value) {}
+
+        final List<Entry> entries = new ArrayList<>();
+        /** Last value per predicate (for single-valued assertions). */
+        final Map<String, String> singleByPredicate = new LinkedHashMap<>();
+        /** All values per predicate (for multi-valued ones). */
+        final Map<String, List<String>> allByPredicate = new LinkedHashMap<>();
+
+        @Override
+        public void write(String subjectAppId, String predicate, String value) {
+            entries.add(new Entry(subjectAppId, predicate, value));
+            singleByPredicate.put(predicate, value);
+            allByPredicate.computeIfAbsent(predicate, k -> new ArrayList<>()).add(value);
+        }
+    }
+
+    // ─── classifyChannelPhysics ──────────────────────────────────────────────
+
+    /** Beckhoff analog thermocouple channel → temperature. */
+    @Test
+    void classifyTemperatureByFullPrefix() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("aTemperatureAnalogInput1"))
+                .contains(SvdxAnnotations.PHYS_TEMPERATURE);
+    }
+
+    /** Channel name containing "Temp" in any case → temperature. */
+    @Test
+    void classifyTemperatureByContains() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("TC_TempSetpoint"))
+                .contains(SvdxAnnotations.PHYS_TEMPERATURE);
+    }
+
+    /** Beckhoff robot position channel → position. */
+    @Test
+    void classifyPositionByPrefix() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("rRoboPosA"))
+                .contains(SvdxAnnotations.PHYS_POSITION);
+    }
+
+    /** Channel name containing "RoboPos" → position. */
+    @Test
+    void classifyPositionByContains() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("Axis1_RoboPosActual"))
+                .contains(SvdxAnnotations.PHYS_POSITION);
+    }
+
+    /** Beckhoff torque channel → torque. */
+    @Test
+    void classifyTorqueByPrefix() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("rTorqueAxis1"))
+                .contains(SvdxAnnotations.PHYS_TORQUE);
+    }
+
+    /** Channel name containing "Torque" → torque. */
+    @Test
+    void classifyTorqueByContains() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("JointTorque_3"))
+                .contains(SvdxAnnotations.PHYS_TORQUE);
+    }
+
+    /** Beckhoff force channel → force. */
+    @Test
+    void classifyForceByPrefix() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("rForce_TCP"))
+                .contains(SvdxAnnotations.PHYS_FORCE);
+    }
+
+    /** Channel name containing "Force" → force. */
+    @Test
+    void classifyForceByContains() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("ConsolidationForce"))
+                .contains(SvdxAnnotations.PHYS_FORCE);
+    }
+
+    /** Beckhoff Branson ultrasonic channel → ultrasonic-power. */
+    @Test
+    void classifyUltrasonicByBransonPrefix() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("aBransonAmplitude"))
+                .contains(SvdxAnnotations.PHYS_ULTRASONIC_POWER);
+    }
+
+    /** Channel name containing "Branson" → ultrasonic-power. */
+    @Test
+    void classifyUltrasonicByBransonContains() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("US_BransonPower"))
+                .contains(SvdxAnnotations.PHYS_ULTRASONIC_POWER);
+    }
+
+    /** Beckhoff pressure channel → pressure. */
+    @Test
+    void classifyPressureByPrefix() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("aPressure_bar"))
+                .contains(SvdxAnnotations.PHYS_PRESSURE);
+    }
+
+    /** Channel name containing "Pressure" → pressure. */
+    @Test
+    void classifyPressureByContains() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("HydraulicPressure"))
+                .contains(SvdxAnnotations.PHYS_PRESSURE);
+    }
+
+    /** Beckhoff velocity channel → velocity. */
+    @Test
+    void classifyVelocityByPrefix() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("rVelocity_mm_s"))
+                .contains(SvdxAnnotations.PHYS_VELOCITY);
+    }
+
+    /** Channel name containing "Velocity" → velocity. */
+    @Test
+    void classifyVelocityByContains() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("TravelVelocity"))
+                .contains(SvdxAnnotations.PHYS_VELOCITY);
+    }
+
+    /** Unrecognised channel name → empty. */
+    @Test
+    void classifyUnknownChannelReturnsEmpty() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("unknownChannel"))
+                .isEmpty();
+    }
+
+    /** Null input → empty (no NPE). */
+    @Test
+    void classifyNullReturnsEmpty() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics(null))
+                .isEmpty();
+    }
+
+    /** Matching is case-insensitive. */
+    @Test
+    void classifyIsCaseInsensitive() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics("ATEMPERATUREANALOGI1"))
+                .contains(SvdxAnnotations.PHYS_TEMPERATURE);
+        assertThat(SvdxManifestParser.classifyChannelPhysics("RROBOPOS_X"))
+                .contains(SvdxAnnotations.PHYS_POSITION);
+    }
+
+    /** Empty string → empty (no match, no error). */
+    @Test
+    void classifyEmptyStringReturnsEmpty() {
+        assertThat(SvdxManifestParser.classifyChannelPhysics(""))
+                .isEmpty();
+    }
+
+    // ─── accepts() ──────────────────────────────────────────────────────────
+
+    @Test
+    void acceptsSvdxExtensionCaseInsensitively() {
+        SvdxManifestParser parser = new SvdxManifestParser();
+        assertThat(parser.accepts("application/octet-stream", "P08_2teBahn.svdx")).isTrue();
+        assertThat(parser.accepts(null, "scope.SVDX")).isTrue();
+        assertThat(parser.accepts(null, "data.SvDx")).isTrue();
+    }
+
+    @Test
+    void rejectsUnrelatedFiles() {
+        SvdxManifestParser parser = new SvdxManifestParser();
+        assertThat(parser.accepts("application/pdf", "report.pdf")).isFalse();
+        assertThat(parser.accepts(null, null)).isFalse();
+        assertThat(parser.accepts(null, "data.tdms")).isFalse();
+        assertThat(parser.accepts(null, "station.rdk")).isFalse();
+    }
+
+    // ─── extractSeamId() ────────────────────────────────────────────────────
+
+    @Test
+    void extractSeamIdStripsExtension() {
+        assertThat(SvdxManifestParser.extractSeamId("P08_2teBahn.svdx"))
+                .isEqualTo("P08_2teBahn");
+    }
+
+    @Test
+    void extractSeamIdHandlesPathSeparators() {
+        assertThat(SvdxManifestParser.extractSeamId("/mnt/data/TG258_spot_001.svdx"))
+                .isEqualTo("TG258_spot_001");
+        assertThat(SvdxManifestParser.extractSeamId("C:\\scans\\Seam42.svdx"))
+                .isEqualTo("Seam42");
+    }
+
+    @Test
+    void extractSeamIdHandlesNull() {
+        assertThat(SvdxManifestParser.extractSeamId(null)).isNull();
+    }
+
+    // ─── degenerate parse inputs ─────────────────────────────────────────────
+
+    @Test
+    void emptyBytesEmitNothing() {
+        RecordingWriter writer = new RecordingWriter();
+        int emitted = new SvdxManifestParser().parse(ctx(new byte[0], "x.svdx",
+                Optional.empty(), Optional.of("ref"), writer));
+        assertThat(emitted).isZero();
+        assertThat(writer.entries).isEmpty();
+    }
+
+    @Test
+    void garbledBytesDoNotThrow() {
+        byte[] garbage = "NOT XML AT ALL  ".getBytes(StandardCharsets.UTF_8);
+        RecordingWriter writer = new RecordingWriter();
+        // Should not throw; may emit seamId or nothing
+        new SvdxManifestParser().parse(ctx(garbage, "bad.svdx",
+                Optional.empty(), Optional.of("ref"), writer));
+        // No assertion on content — just confirming no exception
+    }
+
+    @Test
+    void emitsNothingWhenNoSubjectAvailable() {
+        byte[] xml = syntheticManifest(List.of());
+        RecordingWriter writer = new RecordingWriter();
+        int emitted = new SvdxManifestParser().parse(ctx(xml, "x.svdx",
+                Optional.empty(), Optional.empty(), writer));
+        assertThat(emitted).isZero();
+    }
+
+    @Test
+    void fallsBackToDataObjectSubjectWhenFileReferenceMissing() {
+        byte[] xml = syntheticManifest(List.of(
+                new ChannelDef("aTemperatureAnalogInput1", null, "1000000", "°C")));
+        RecordingWriter writer = new RecordingWriter();
+        new SvdxManifestParser().parse(ctx(xml, "x.svdx",
+                Optional.of("do-fallback"), Optional.empty(), writer));
+        for (RecordingWriter.Entry e : writer.entries) {
+            assertThat(e.subject()).isEqualTo("do-fallback");
+        }
+    }
+
+    // ─── Integration: XML manifest → annotations ────────────────────────────
+
+    /**
+     * Full happy-path: a synthetic manifest with known channels produces
+     * the expected {@code svdx:*} and {@code phys:*} annotations.
+     */
+    @Test
+    void emitsChannelNameAndPhysAnnotationsForTemperatureChannel() {
+        byte[] xml = syntheticManifest(List.of(
+                new ChannelDef("aTemperatureAnalogInput1", "TC Head 01", "1000000", "°C")));
+
+        RecordingWriter writer = new RecordingWriter();
+        new SvdxManifestParser().parse(ctx(xml, "Seam01.svdx",
+                Optional.empty(), Optional.of("ref-111"), writer));
+
+        assertThat(writer.allByPredicate.get(SvdxAnnotations.CHANNEL_NAME))
+                .contains("aTemperatureAnalogInput1");
+        assertThat(writer.allByPredicate.get(SvdxAnnotations.SYMBOL_NAME))
+                .contains("TC Head 01");
+        assertThat(writer.allByPredicate.get(SvdxAnnotations.UNIT))
+                .contains("°C");
+        assertThat(writer.singleByPredicate.get(SvdxAnnotations.SAMPLE_RATE))
+                .isEqualTo("1000 Hz");
+        // Physical-quantity classifier: temperature
+        assertThat(writer.singleByPredicate.get(SvdxAnnotations.PHYS_TEMPERATURE))
+                .isEqualTo(SvdxManifestParser.PHYS_VALUE_TRUE);
+        // Seam ID from filename
+        assertThat(writer.singleByPredicate.get(SvdxAnnotations.SEAM_ID))
+                .isEqualTo("Seam01");
+    }
+
+    @Test
+    void emitsPositionPhysAnnotationForRoboPosChannel() {
+        byte[] xml = syntheticManifest(List.of(
+                new ChannelDef("rRoboPos_X", null, null, "mm")));
+        RecordingWriter writer = new RecordingWriter();
+        new SvdxManifestParser().parse(ctx(xml, "pass.svdx",
+                Optional.empty(), Optional.of("ref-222"), writer));
+
+        assertThat(writer.singleByPredicate.get(SvdxAnnotations.PHYS_POSITION))
+                .isEqualTo(SvdxManifestParser.PHYS_VALUE_TRUE);
+        assertThat(writer.singleByPredicate).doesNotContainKey(SvdxAnnotations.PHYS_TEMPERATURE);
+    }
+
+    @Test
+    void emitsBransonUltrasonicPhysAnnotation() {
+        byte[] xml = syntheticManifest(List.of(
+                new ChannelDef("aBransonAmplitude", "US Amp", null, "%")));
+        RecordingWriter writer = new RecordingWriter();
+        new SvdxManifestParser().parse(ctx(xml, "us.svdx",
+                Optional.empty(), Optional.of("ref-333"), writer));
+
+        assertThat(writer.singleByPredicate.get(SvdxAnnotations.PHYS_ULTRASONIC_POWER))
+                .isEqualTo(SvdxManifestParser.PHYS_VALUE_TRUE);
+    }
+
+    @Test
+    void multiChannelManifestEmitsAnnotationsForEachChannel() {
+        byte[] xml = syntheticManifest(List.of(
+                new ChannelDef("aTemperatureAnalogInput1", "TC 01", "1000000", "°C"),
+                new ChannelDef("rRoboPos_X", null, null, "mm"),
+                new ChannelDef("rForce_N", null, null, "N"),
+                new ChannelDef("unknownStatus", null, null, null)));
+        RecordingWriter writer = new RecordingWriter();
+        new SvdxManifestParser().parse(ctx(xml, "P08.svdx",
+                Optional.empty(), Optional.of("ref-multi"), writer));
+
+        assertThat(writer.allByPredicate.get(SvdxAnnotations.CHANNEL_NAME))
+                .containsExactlyInAnyOrder(
+                        "aTemperatureAnalogInput1", "rRoboPos_X", "rForce_N", "unknownStatus");
+        assertThat(writer.allByPredicate.get(SvdxAnnotations.PHYS_TEMPERATURE))
+                .hasSize(1)
+                .contains(SvdxManifestParser.PHYS_VALUE_TRUE);
+        assertThat(writer.allByPredicate.get(SvdxAnnotations.PHYS_POSITION))
+                .hasSize(1);
+        assertThat(writer.allByPredicate.get(SvdxAnnotations.PHYS_FORCE))
+                .hasSize(1);
+        // unknownStatus has no phys predicate
+        assertThat(writer.allByPredicate)
+                .doesNotContainKey(SvdxAnnotations.PHYS_VELOCITY)
+                .doesNotContainKey(SvdxAnnotations.PHYS_TORQUE);
+    }
+
+    @Test
+    void channelWithNoPhysMatchEmitsNoPhysPredicate() {
+        byte[] xml = syntheticManifest(List.of(
+                new ChannelDef("bEmergencyStop", "E-Stop", null, null)));
+        RecordingWriter writer = new RecordingWriter();
+        new SvdxManifestParser().parse(ctx(xml, "x.svdx",
+                Optional.empty(), Optional.of("ref-444"), writer));
+
+        assertThat(writer.singleByPredicate).doesNotContainKey(SvdxAnnotations.PHYS_TEMPERATURE);
+        assertThat(writer.singleByPredicate).doesNotContainKey(SvdxAnnotations.PHYS_POSITION);
+        assertThat(writer.singleByPredicate).doesNotContainKey(SvdxAnnotations.PHYS_TORQUE);
+        assertThat(writer.singleByPredicate).doesNotContainKey(SvdxAnnotations.PHYS_FORCE);
+        assertThat(writer.singleByPredicate).doesNotContainKey(SvdxAnnotations.PHYS_ULTRASONIC_POWER);
+        assertThat(writer.singleByPredicate).doesNotContainKey(SvdxAnnotations.PHYS_PRESSURE);
+        assertThat(writer.singleByPredicate).doesNotContainKey(SvdxAnnotations.PHYS_VELOCITY);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    record ChannelDef(String name, String symbolName, String sampleTimeNs, String unit) {}
+
+    /**
+     * Build a minimal TwinCAT Scope XML manifest for testing.
+     * Produces valid XML that the SAX parser can consume.
+     */
+    static byte[] syntheticManifest(List<ChannelDef> channels) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
+        sb.append("<TcScope>\n");
+        for (ChannelDef ch : channels) {
+            sb.append("  <Channel>\n");
+            if (ch.name() != null) {
+                sb.append("    <Name>").append(xmlEscape(ch.name())).append("</Name>\n");
+            }
+            if (ch.symbolName() != null) {
+                sb.append("    <SymbolBased><Symbol>MAIN.")
+                  .append(xmlEscape(ch.symbolName())).append("</Symbol></SymbolBased>\n");
+            }
+            if (ch.sampleTimeNs() != null) {
+                sb.append("    <SampleTime>").append(ch.sampleTimeNs()).append("</SampleTime>\n");
+            }
+            if (ch.unit() != null) {
+                sb.append("    <YAxis><Unit>").append(xmlEscape(ch.unit()))
+                  .append("</Unit></YAxis>\n");
+            }
+            sb.append("  </Channel>\n");
+        }
+        sb.append("</TcScope>\n");
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String xmlEscape(String s) {
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    static FileParserPlugin.ParseContext ctx(
+            byte[] bytes, String filename,
+            Optional<String> doId, Optional<String> refId,
+            FileParserPlugin.AnnotationWriter writer) {
+        return new FileParserPlugin.ParseContext() {
+            @Override public byte[] bytes() { return bytes; }
+            @Override public String filename() { return filename; }
+            @Override public Optional<String> parentDataObjectAppId() { return doId; }
+            @Override public Optional<String> fileReferenceAppId() { return refId; }
+            @Override public FileParserPlugin.AnnotationWriter annotations() { return writer; }
+        };
+    }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Creates `plugins/fileformat-svdx/` — a new standalone tier-1 manifest parser for Beckhoff TwinCAT Scope (`.svdx`) files from the MFFD stringer CRW and spot-welding cells at DLR ZLP Augsburg.
- Implements `MFFD-PLUGIN-SVDX-SEMANTIC-1`: a `classifyChannelPhysics()` method that maps Beckhoff PLC channel-name conventions to `urn:shepard:phys:*` physical-quantity predicates, emitted as additional `SemanticAnnotation`s on the parent `FileReference`.
- Complements `MFFD-PLUGIN-SVDX-1` (base parser scaffold, included here since the plugin was not yet created).

## Mapping table (Beckhoff naming → urn:shepard:phys:*)

| Pattern (case-insensitive) | Predicate |
|---|---|
| starts with `aTemperatureAnalog` or contains `Temp` | `urn:shepard:phys:temperature` |
| starts with `rRoboPos` or contains `RoboPos` | `urn:shepard:phys:position` |
| contains `Torque` or starts with `rTorque` | `urn:shepard:phys:torque` |
| contains `Force` or starts with `rForce` | `urn:shepard:phys:force` |
| starts with `aBranson` or contains `Branson` | `urn:shepard:phys:ultrasonic-power` |
| contains `Pressure` or starts with `aPressure` | `urn:shepard:phys:pressure` |
| contains `Velocity` or starts with `rVelocity` | `urn:shepard:phys:velocity` |

## Files added

- `plugins/fileformat-svdx/pom.xml` — standalone Maven module (same pattern as `fileformat-robotics`)
- `SvdxAnnotations.java` — IRI catalogue for `urn:shepard:svdx:*` + `urn:shepard:phys:*`
- `SvdxManifestParser.java` — SAX-based XML manifest parser + `classifyChannelPhysics()` classifier
- `FileParserPlugin.java` — local SPI shim (mirrors the robotics plugin shim)
- `SvdxManifestParserTest.java` — 32 unit tests

## Test plan

- [x] `cd plugins/fileformat-svdx && mvn verify` — 32/32 tests pass, BUILD SUCCESS
- [x] `classifyChannelPhysics` tested for all 7 pattern families (temperature, position, torque, force, ultrasonic-power, pressure, velocity)
- [x] null input → `Optional.empty()` (no NPE)
- [x] unknown channel name → `Optional.empty()`
- [x] case-insensitivity verified
- [x] Integration tests: full synthetic XML manifest → correct `svdx:*` + `phys:*` annotation emission
- [x] Degenerate inputs: empty bytes, garbled bytes (no exception), missing subject
- [x] Coverage: ~93% line, ~81% branch on `SvdxManifestParser` (target ≥ 70%)

## CLAUDE.md compliance

- Plugin backends build on `/v2/` surface + `appId` — this is a pure parser with no REST layer changes; N/A
- No schema migrations needed — pure annotation emission
- No `aidocs/34` or `aidocs/42`/`44` updates needed — MINOR internal plugin enhancement per task specification
- Follows the same standalone-module build pattern as `plugins/fileformat-robotics/`

https://claude.ai/code/session_01LerDfTVs6ifpgvRKKN7ysk
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LerDfTVs6ifpgvRKKN7ysk)_