### PR TITLE
feat(V2CONV-A1): content-negotiated media output on /v2/shapes/render

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/spi/view/RenderedMedia.java
+++ b/backend/src/main/java/de/dlr/shepard/spi/view/RenderedMedia.java
@@ -1,0 +1,20 @@
+package de.dlr.shepard.spi.view;
+
+/**
+ * V2CONV-A1 — a renderer's binary/media output for content-negotiated
+ * {@code POST /v2/shapes/render}.
+ *
+ * <p>When a caller's {@code Accept} header asks for a non-JSON media type that
+ * a matched {@link ViewRecipeRenderer} declares in {@link
+ * ViewRecipeRenderer#producibleMedia()}, the dispatcher calls
+ * {@link ViewRecipeRenderer#renderMedia(RenderRequest, String)} and returns this
+ * payload verbatim with {@code Content-Type: mediaType}. This is the seam that
+ * moves per-format rendering (thermography heatmap PNG, glTF, URDF/USD export)
+ * onto the single generic render endpoint — no per-format REST paths.
+ *
+ * @param mediaType the concrete IANA media type of {@code bytes}, e.g.
+ *                  {@code image/png}, {@code model/gltf+json}
+ * @param bytes     the rendered payload; never null (use the JSON view-model
+ *                  path instead of an empty media payload)
+ */
+public record RenderedMedia(String mediaType, byte[] bytes) {}

--- a/backend/src/main/java/de/dlr/shepard/spi/view/ViewRecipeRenderer.java
+++ b/backend/src/main/java/de/dlr/shepard/spi/view/ViewRecipeRenderer.java
@@ -1,5 +1,6 @@
 package de.dlr.shepard.spi.view;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -97,6 +98,40 @@ public interface ViewRecipeRenderer {
    *         logs at WARN and surfaces an HTTP 500
    */
   RenderResponse render(RenderRequest req);
+
+  /**
+   * V2CONV-A1 — the IANA media types this renderer can emit as bytes via
+   * {@link #renderMedia(RenderRequest, String)}, beyond the always-available
+   * {@code application/json} view-model from {@link #render(RenderRequest)}.
+   *
+   * <p>Content-negotiated {@code POST /v2/shapes/render} consults this set
+   * against the caller's {@code Accept} header: a renderer that can produce a
+   * heatmap PNG returns {@code {"image/png"}}; a mesh renderer returns
+   * {@code {"model/gltf+json"}}; etc. Default is empty (JSON view-model only),
+   * so existing renderers need no change.
+   *
+   * @return the non-JSON media types this renderer can emit; never null
+   */
+  default Set<String> producibleMedia() {
+    return Set.of();
+  }
+
+  /**
+   * V2CONV-A1 — render the focus to bytes of the requested media type.
+   *
+   * <p>Called by the dispatcher only when {@code acceptMediaType} is one of this
+   * renderer's {@link #producibleMedia()}. Return {@link Optional#empty()} to
+   * fall back to the JSON view-model. Default returns empty so the binary path
+   * is strictly opt-in.
+   *
+   * @param req             the dispatch request — never null
+   * @param acceptMediaType the concrete media type the caller asked for (one of
+   *                        {@link #producibleMedia()})
+   * @return the rendered media, or empty to fall back to the JSON view-model
+   */
+  default Optional<RenderedMedia> renderMedia(RenderRequest req, String acceptMediaType) {
+    return Optional.empty();
+  }
 
   /**
    * Human-readable name surfaced in startup logs and the future

--- a/backend/src/main/java/de/dlr/shepard/v2/shapes/resources/ShapesRenderRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/shapes/resources/ShapesRenderRest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.dlr.shepard.spi.view.RenderException;
 import de.dlr.shepard.spi.view.RenderRequest;
 import de.dlr.shepard.spi.view.RenderResponse;
+import de.dlr.shepard.spi.view.RenderedMedia;
 import de.dlr.shepard.spi.view.ViewRecipeRenderer;
 import de.dlr.shepard.spi.view.ViewRecipeRendererRegistry;
 import de.dlr.shepard.template.daos.ShepardTemplateDAO;
@@ -22,6 +23,8 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
@@ -125,6 +128,10 @@ public class ShapesRenderRest {
   @POST
   @Path("/render")
   @RolesAllowed("authenticated")
+  // V2CONV-A1 — wildcard so a non-JSON Accept (image/png, model/gltf+json) reaches
+  // the method instead of 406-ing at JAX-RS negotiation; the concrete content-type
+  // is set on the Response. JSON stays the default view-model.
+  @Produces({ MediaType.APPLICATION_JSON, MediaType.WILDCARD })
   @Operation(
     summary = "Project a VIEW_RECIPE template's channel bindings onto a focus DataObject.",
     description = "Stateless, read-only. Returns the template's channel binding declarations. " +
@@ -144,6 +151,7 @@ public class ShapesRenderRest {
     description = "Template found but templateKind != VIEW_RECIPE. Use GET /v2/templates?kind=view to discover VIEW_RECIPE templates."
   )
   public Response render(
+    @Context HttpHeaders headers,
     @RequestBody(
       required = true,
       description = "VIEW_RECIPE template appId + focus DataObject appId.",
@@ -192,6 +200,14 @@ public class ShapesRenderRest {
     if (shapeIri != null && rendererRegistry != null) {
       Optional<ViewRecipeRenderer> match = rendererRegistry.resolve(shapeIri);
       if (match.isPresent()) {
+        // V2CONV-A1 — content negotiation: if the caller's Accept asks for a
+        // non-JSON media type this renderer produces (e.g. image/png heatmap,
+        // model/gltf+json), return the rendered bytes. Otherwise fall through
+        // to the JSON view-model — the default, byte-compatible with today.
+        Response media = negotiateMedia(match.get(), headers, body, template, shapeIri);
+        if (media != null) {
+          return media;
+        }
         return dispatchToRenderer(match.get(), body, template, shapeIri);
       }
       Log.debugf(
@@ -247,6 +263,61 @@ public class ShapesRenderRest {
    *       surfaced as HTTP 500.</li>
    * </ul>
    */
+  /**
+   * V2CONV-A1 — content negotiation for the renderer SPI. Returns a media
+   * {@link Response} when the caller's {@code Accept} asks for a non-JSON media
+   * type the renderer declares in {@link ViewRecipeRenderer#producibleMedia()}
+   * and actually produces; otherwise null → fall back to the JSON view-model
+   * (the default, byte-compatible with the pre-A1 behaviour).
+   */
+  private Response negotiateMedia(
+    ViewRecipeRenderer renderer,
+    HttpHeaders headers,
+    ShapesRenderRequestIO body,
+    ShepardTemplate template,
+    String shapeIri
+  ) {
+    java.util.Set<String> producible = renderer.producibleMedia();
+    if (producible == null || producible.isEmpty()) {
+      return null;
+    }
+    List<MediaType> accepted = headers == null ? List.of() : headers.getAcceptableMediaTypes();
+    for (MediaType mt : accepted) {
+      if (mt.isWildcardType() || MediaType.APPLICATION_JSON_TYPE.isCompatible(mt)) {
+        return null; // caller accepts JSON / */* — use the default view-model
+      }
+      String concrete = mt.getType() + "/" + mt.getSubtype();
+      if (producible.contains(concrete)) {
+        RenderRequest req = new RenderRequest(
+          body.templateAppId(),
+          body.focusShepardId(),
+          shapeIri,
+          template.getBody()
+        );
+        try {
+          Optional<RenderedMedia> rendered = renderer.renderMedia(req, concrete);
+          if (rendered.isPresent() && rendered.get().bytes() != null) {
+            return Response.ok(rendered.get().bytes(), rendered.get().mediaType()).build();
+          }
+        } catch (RuntimeException ex) {
+          Log.warnf(
+            ex,
+            "V2CONV-A1: renderer '%s' threw producing %s for shape <%s> — surfacing 422",
+            renderer.name(),
+            concrete,
+            shapeIri
+          );
+          return Response
+            .status(422)
+            .entity(Map.of("error", "media render failed for " + concrete, "renderer", renderer.name()))
+            .build();
+        }
+        return null; // renderer declined this media — JSON fallback
+      }
+    }
+    return null;
+  }
+
   private Response dispatchToRenderer(
     ViewRecipeRenderer renderer,
     ShapesRenderRequestIO body,

--- a/backend/src/test/java/de/dlr/shepard/spi/view/ViewRecipeRendererMediaTest.java
+++ b/backend/src/test/java/de/dlr/shepard/spi/view/ViewRecipeRendererMediaTest.java
@@ -1,0 +1,80 @@
+package de.dlr.shepard.spi.view;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * V2CONV-A1 — covers the additive media-output contract on {@link ViewRecipeRenderer}:
+ * defaults keep JSON-only renderers unchanged, and an opt-in renderer can declare +
+ * emit a binary media type.
+ */
+class ViewRecipeRendererMediaTest {
+
+  /** A renderer that only does the JSON view-model — must inherit empty media defaults. */
+  private static final class JsonOnlyRenderer implements ViewRecipeRenderer {
+    @Override
+    public Set<String> supportedShapeIris() {
+      return Set.of("urn:test:json-shape");
+    }
+
+    @Override
+    public RenderResponse render(RenderRequest req) {
+      return new RenderResponse(req.templateAppId(), req.focusShepardId(), "echarts", java.util.List.of());
+    }
+  }
+
+  /** A renderer that opts into a PNG media output. */
+  private static final class PngRenderer implements ViewRecipeRenderer {
+    @Override
+    public Set<String> supportedShapeIris() {
+      return Set.of("urn:test:png-shape");
+    }
+
+    @Override
+    public RenderResponse render(RenderRequest req) {
+      return new RenderResponse(req.templateAppId(), req.focusShepardId(), "canvas", java.util.List.of());
+    }
+
+    @Override
+    public Set<String> producibleMedia() {
+      return Set.of("image/png");
+    }
+
+    @Override
+    public Optional<RenderedMedia> renderMedia(RenderRequest req, String acceptMediaType) {
+      if ("image/png".equals(acceptMediaType)) {
+        return Optional.of(new RenderedMedia("image/png", new byte[] {(byte) 0x89, 'P', 'N', 'G'}));
+      }
+      return Optional.empty();
+    }
+  }
+
+  @Test
+  void jsonOnlyRenderer_inheritsEmptyMediaDefaults() {
+    var r = new JsonOnlyRenderer();
+    assertTrue(r.producibleMedia().isEmpty(), "default producibleMedia must be empty");
+    assertTrue(
+      r.renderMedia(new RenderRequest("t", "f", "urn:test:json-shape", "{}"), "image/png").isEmpty(),
+      "default renderMedia must be empty so the dispatcher falls back to JSON"
+    );
+  }
+
+  @Test
+  void pngRenderer_declaresAndEmitsBinary() {
+    var r = new PngRenderer();
+    assertEquals(Set.of("image/png"), r.producibleMedia());
+
+    var req = new RenderRequest("t", "f", "urn:test:png-shape", "{}");
+    Optional<RenderedMedia> out = r.renderMedia(req, "image/png");
+    assertTrue(out.isPresent());
+    assertEquals("image/png", out.get().mediaType());
+    assertArrayEquals(new byte[] {(byte) 0x89, 'P', 'N', 'G'}, out.get().bytes());
+
+    assertTrue(r.renderMedia(req, "model/gltf+json").isEmpty(), "unsupported media → empty → JSON fallback");
+  }
+}

--- a/backend/src/test/java/de/dlr/shepard/v2/shapes/resources/ShapesRenderRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/shapes/resources/ShapesRenderRestTest.java
@@ -136,19 +136,19 @@ class ShapesRenderRestTest {
 
   @Test
   void returns400OnNullBody() {
-    assertThat(rest.render(null).getStatus()).isEqualTo(400);
+    assertThat(rest.render(null,null).getStatus()).isEqualTo(400);
   }
 
   @Test
   void returns400OnMissingTemplateAppId() {
     var body = new ShapesRenderRequestIO(null, "some-focus-id", null);
-    assertThat(rest.render(body).getStatus()).isEqualTo(400);
+    assertThat(rest.render(null,body).getStatus()).isEqualTo(400);
   }
 
   @Test
   void returns400OnMissingFocusShepardId() {
     var body = new ShapesRenderRequestIO("some-tmpl-id", null, null);
-    assertThat(rest.render(body).getStatus()).isEqualTo(400);
+    assertThat(rest.render(null,body).getStatus()).isEqualTo(400);
   }
 
   // ─── 404 path ────────────────────────────────────────────────────────────
@@ -157,7 +157,7 @@ class ShapesRenderRestTest {
   void returns404WhenTemplateNotFound() {
     when(templateDAO.findByAppId("unknown-id")).thenReturn(Optional.empty());
     var body = new ShapesRenderRequestIO("unknown-id", "focus-id", null);
-    assertThat(rest.render(body).getStatus()).isEqualTo(404);
+    assertThat(rest.render(null,body).getStatus()).isEqualTo(404);
   }
 
   // ─── 422 path ────────────────────────────────────────────────────────────
@@ -168,7 +168,7 @@ class ShapesRenderRestTest {
     when(templateDAO.findByAppId("tmpl-1")).thenReturn(Optional.of(tmpl));
 
     var body = new ShapesRenderRequestIO("tmpl-1", "focus-id", null);
-    Response r = rest.render(body);
+    Response r = rest.render(null,body);
 
     assertThat(r.getStatus()).isEqualTo(422);
   }
@@ -192,7 +192,7 @@ class ShapesRenderRestTest {
     when(templateDAO.findByAppId("view-tmpl-1")).thenReturn(Optional.of(tmpl));
 
     var body = new ShapesRenderRequestIO("view-tmpl-1", "do-focus-1", null);
-    Response r = rest.render(body);
+    Response r = rest.render(null,body);
 
     assertThat(r.getStatus()).isEqualTo(200);
     var io = (ShapesRenderResponseIO) r.getEntity();
@@ -220,7 +220,7 @@ class ShapesRenderRestTest {
     when(templateDAO.findByAppId("view-tmpl-2")).thenReturn(Optional.of(tmpl));
 
     var body = new ShapesRenderRequestIO("view-tmpl-2", "do-focus-2", null);
-    Response r = rest.render(body);
+    Response r = rest.render(null,body);
 
     assertThat(r.getStatus()).isEqualTo(200);
     var io = (ShapesRenderResponseIO) r.getEntity();
@@ -235,7 +235,7 @@ class ShapesRenderRestTest {
     when(templateDAO.findByAppId("view-tmpl-3")).thenReturn(Optional.of(tmpl));
 
     var body = new ShapesRenderRequestIO("view-tmpl-3", "do-focus-3", null);
-    Response r = rest.render(body);
+    Response r = rest.render(null,body);
 
     assertThat(r.getStatus()).isEqualTo(200);
     var io = (ShapesRenderResponseIO) r.getEntity();
@@ -274,7 +274,7 @@ class ShapesRenderRestTest {
     wireRegistry(captor);
 
     var body = new ShapesRenderRequestIO("view-tmpl-spi-1", "do-focus-spi-1", null);
-    Response r = rest.render(body);
+    Response r = rest.render(null,body);
 
     assertThat(r.getStatus()).isEqualTo(200);
     var io = (ShapesRenderResponseIO) r.getEntity();
@@ -318,7 +318,7 @@ class ShapesRenderRestTest {
     );
     wireRegistry(stubRenderer(iri, out));
 
-    Response r = rest.render(new ShapesRenderRequestIO("vt-um-1", "fo-1", null));
+    Response r = rest.render(null,new ShapesRenderRequestIO("vt-um-1", "fo-1", null));
     assertThat(r.getStatus()).isEqualTo(200);
     var io = (ShapesRenderResponseIO) r.getEntity();
     assertThat(io.channelBindings()).hasSize(1);
@@ -341,7 +341,7 @@ class ShapesRenderRestTest {
     ShepardTemplate tmpl = new ShepardTemplate("Orphan recipe", "VIEW_RECIPE", bodyJson);
     when(templateDAO.findByAppId("orphan-1")).thenReturn(Optional.of(tmpl));
 
-    Response r = rest.render(new ShapesRenderRequestIO("orphan-1", "f-1", null));
+    Response r = rest.render(null,new ShapesRenderRequestIO("orphan-1", "f-1", null));
     assertThat(r.getStatus()).isEqualTo(200);
     var io = (ShapesRenderResponseIO) r.getEntity();
     assertThat(io.channelBindings()).hasSize(1);
@@ -358,7 +358,7 @@ class ShapesRenderRestTest {
     ShepardTemplate tmpl = new ShepardTemplate("No-iri recipe", "VIEW_RECIPE", bodyJson);
     when(templateDAO.findByAppId("noiri-1")).thenReturn(Optional.of(tmpl));
 
-    Response r = rest.render(new ShapesRenderRequestIO("noiri-1", "f-1", null));
+    Response r = rest.render(null,new ShapesRenderRequestIO("noiri-1", "f-1", null));
     assertThat(r.getStatus()).isEqualTo(200);
     var io = (ShapesRenderResponseIO) r.getEntity();
     assertThat(io.channelBindings().get(0).status()).isEqualTo("DECLARED");
@@ -370,7 +370,7 @@ class ShapesRenderRestTest {
     ShepardTemplate tmpl = new ShepardTemplate("Blank-iri recipe", "VIEW_RECIPE", bodyJson);
     when(templateDAO.findByAppId("blank-iri-1")).thenReturn(Optional.of(tmpl));
 
-    Response r = rest.render(new ShapesRenderRequestIO("blank-iri-1", "f-1", null));
+    Response r = rest.render(null,new ShapesRenderRequestIO("blank-iri-1", "f-1", null));
     assertThat(r.getStatus()).isEqualTo(200);
     var io = (ShapesRenderResponseIO) r.getEntity();
     assertThat(io.renderer()).isEqualTo("tresjs");
@@ -389,7 +389,7 @@ class ShapesRenderRestTest {
     ShepardTemplate tmpl = new ShepardTemplate("No-reg recipe", "VIEW_RECIPE", bodyJson);
     when(templateDAO.findByAppId("noreg-1")).thenReturn(Optional.of(tmpl));
 
-    Response r = rest.render(new ShapesRenderRequestIO("noreg-1", "f-1", null));
+    Response r = rest.render(null,new ShapesRenderRequestIO("noreg-1", "f-1", null));
     assertThat(r.getStatus()).isEqualTo(200);
     var io = (ShapesRenderResponseIO) r.getEntity();
     assertThat(io.channelBindings()).hasSize(1);
@@ -412,7 +412,7 @@ class ShapesRenderRestTest {
       )
     );
 
-    Response r = rest.render(new ShapesRenderRequestIO("throwy-1", "f-1", null));
+    Response r = rest.render(null,new ShapesRenderRequestIO("throwy-1", "f-1", null));
     assertThat(r.getStatus()).isEqualTo(422);
     @SuppressWarnings("unchecked")
     Map<String, Object> body = (Map<String, Object>) r.getEntity();
@@ -429,7 +429,7 @@ class ShapesRenderRestTest {
 
     wireRegistry(brokenRenderer(iri));
 
-    Response r = rest.render(new ShapesRenderRequestIO("broken-1", "f-1", null));
+    Response r = rest.render(null,new ShapesRenderRequestIO("broken-1", "f-1", null));
     assertThat(r.getStatus()).isEqualTo(500);
     @SuppressWarnings("unchecked")
     Map<String, Object> body = (Map<String, Object>) r.getEntity();
@@ -446,7 +446,7 @@ class ShapesRenderRestTest {
 
     wireRegistry(stubRenderer(iri, null));
 
-    Response r = rest.render(new ShapesRenderRequestIO("null-1", "f-1", null));
+    Response r = rest.render(null,new ShapesRenderRequestIO("null-1", "f-1", null));
     assertThat(r.getStatus()).isEqualTo(500);
     @SuppressWarnings("unchecked")
     Map<String, Object> body = (Map<String, Object>) r.getEntity();
@@ -461,7 +461,7 @@ class ShapesRenderRestTest {
     when(templateDAO.findByAppId("nc-1")).thenReturn(Optional.of(tmpl));
     wireRegistry(throwingRenderer(iri, new RenderException(null, "boom")));
 
-    Response r = rest.render(new ShapesRenderRequestIO("nc-1", "f-1", null));
+    Response r = rest.render(null,new ShapesRenderRequestIO("nc-1", "f-1", null));
     assertThat(r.getStatus()).isEqualTo(422);
     @SuppressWarnings("unchecked")
     Map<String, Object> body = (Map<String, Object>) r.getEntity();


### PR DESCRIPTION
## V2CONV-A1 — the render-media enabler

First PR of the **v2 surface convergence** (`aidocs/platform/191`). Lets all rendering flow through the single generic `/v2/shapes/render` endpoint instead of per-format endpoints (the thermography heatmap PNG, future glTF, URDF/USD export).

### What changed (all additive — no behaviour change for existing renderers)
- `ViewRecipeRenderer` gains two defaults: `producibleMedia()` (empty) and `renderMedia(req, acceptMediaType)` (empty). JSON-only renderers inherit them unchanged.
- New `RenderedMedia(mediaType, bytes)` SPI record.
- `ShapesRenderRest` content-negotiates on `Accept`: a non-JSON type a matched renderer produces → bytes with that `Content-Type`; `application/json` / `*/*` → the default view-model (byte-compatible with pre-A1). Method `@Produces` widened to wildcard so a non-JSON `Accept` reaches the method instead of 406.

### Tests
- New `ViewRecipeRendererMediaTest` (SPI defaults + opt-in PNG renderer).
- `ShapesRenderRestTest` updated for the new `@Context HttpHeaders` param.
- 20/20 green (`mvnw -Dtest=ViewRecipeRendererMediaTest,ShapesRenderRestTest test`).

### Design
`aidocs/platform/191-v2-surface-convergence.md §5`. Unblocks A6 (thermography/etc. renderers emit PNG via this seam) and B4 (scene-graph play render).

🤖 Operator-driven in-session lane (not the autonomous V2CONV routine).