### PR TITLE
ci(CI-FIX-OWASP-PLUGIN): install project JARs before OWASP dependency-check

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,6 +56,13 @@ jobs:
           restore-keys: |
             owasp-nvd-
 
+      - name: Install project JARs into local Maven repo
+        # Required so dependency-check can resolve SNAPSHOT plugin JARs that
+        # aren't yet published to Maven Central (e.g. shepard-plugin-vis-ndt-grid).
+        # Without this step, dependency-check:check fails to download the JAR and
+        # reports a spurious build failure unrelated to any CVE finding.
+        run: mvn -B install -DskipTests -P with-plugins -q
+
       - name: Run dependency-check (fail at CVSS >= 7.0)
         env:
           # NVD recommends an API key for sustainable rate; set NVD_API_KEY in


### PR DESCRIPTION
## Summary

- Adds `mvn install -DskipTests -P with-plugins` step before `dependency-check:check` in `security.yml`
- Fixes spurious OWASP check failures on PRs that introduce new SNAPSHOT plugin JARs (e.g. `shepard-plugin-vis-ndt-grid` in #1807)
- Without this, `dependency-check` cannot download the unreleased plugin JAR from Maven Central and reports a build error unrelated to any CVE

## Why this happens

`security.yml` runs `mvn dependency-check:check` without ever running `mvn install`. The SNAPSHOT plugin JARs produced by this repo are not published to Maven Central, so `dependency-check` finds them missing from the local Maven repo and fails to resolve the project — producing a spurious build failure that looks like a CVE gate but is actually a missing artifact.

## Impact

Unblocks:
- PR #1807 (MFFD-RENDER-NDT-GRID slice 1 — `shepard-plugin-vis-ndt-grid`)
- All future PRs that add new `shepard-plugin-*` modules

## Test plan

- [ ] Verify the OWASP check passes on this PR (no pom.xml changes, so the check runs on existing deps — should pass)
- [ ] After merge, re-run CI on #1807 to confirm OWASP gate now succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nwg3tiqBtVHVHcopmDMaPz)_