### PR TITLE
fix(security): extend OWASP suppressions for sibling jars (SUPP-002/003/006)

### DIFF
--- a/backend/dependency-check-suppressions.xml
+++ b/backend/dependency-check-suppressions.xml
@@ -102,6 +102,21 @@
     <cve>CVE-2026-1497</cve>
   </suppress>
 
+  <suppress until="2027-06-10">
+    <notes>CVE-2026-1524 (CVSS 9.8): False positive. CVE targets Neo4j database server;
+    matched against neo4j-ogm-api (the OGM annotation/interface layer, a client-side API
+    library) via CPE version coincidence on 5.0.3. This jar exposes no server endpoint.
+    OWASP-SUPP-002.</notes>
+    <packageUrl regex="true">^pkg:maven/org\.neo4j/neo4j-ogm-api@.*$</packageUrl>
+    <cve>CVE-2026-1524</cve>
+  </suppress>
+  <suppress until="2027-06-10">
+    <notes>CVE-2026-1497 (CVSS 7.2): False positive. Same CPE mismatch for neo4j-ogm-api.
+    OWASP-SUPP-002.</notes>
+    <packageUrl regex="true">^pkg:maven/org\.neo4j/neo4j-ogm-api@.*$</packageUrl>
+    <cve>CVE-2026-1497</cve>
+  </suppress>
+
   <!-- ===================================================================
        OWASP-SUPP-003: Apache Jena 5.4.0 (CVE-2025-49656 7.5, CVE-2025-50151 8.8)
        =================================================================== -->
@@ -127,6 +142,20 @@
     CVE-2025-49656 — no user-supplied SPARQL input, server-constructed queries only.
     OWASP-SUPP-003.</notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.jena/jena-core@5\.4\.0$</packageUrl>
+    <cve>CVE-2025-50151</cve>
+  </suppress>
+  <suppress until="2026-12-31">
+    <notes>CVE-2025-49656 (CVSS 7.5): Apache Jena 5.4.0 CVE on jena-arq (SPARQL query
+    engine module). Same reasoning as jena-core entry: all queries are server-constructed
+    from validated parameters; no user-supplied SPARQL reaches the parser. CPE matches all
+    org.apache.jena 5.4.0 jars. OWASP-SUPP-003.</notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.jena/jena-arq@5\.4\.0$</packageUrl>
+    <cve>CVE-2025-49656</cve>
+  </suppress>
+  <suppress until="2026-12-31">
+    <notes>CVE-2025-50151 (CVSS 8.8): Apache Jena 5.4.0 CVE on jena-arq. Same reasoning
+    as jena-core entry — server-constructed SPARQL queries only. OWASP-SUPP-003.</notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.jena/jena-arq@5\.4\.0$</packageUrl>
     <cve>CVE-2025-50151</cve>
   </suppress>
 
@@ -192,6 +221,14 @@
     <notes>CVE-2026-42154 (CVSS 7.5): Same CVE via Micrometer Prometheus simpleclient
     bridge. Identical deployment topology reasoning as OWASP-SUPP-006 above.</notes>
     <packageUrl regex="true">^pkg:maven/io\.micrometer/micrometer-registry-prometheus-simpleclient@.*$</packageUrl>
+    <cve>CVE-2026-42154</cve>
+  </suppress>
+  <suppress until="2026-12-31">
+    <notes>CVE-2026-42154 (CVSS 7.5): Same CVE on simpleclient_common (shared utilities
+    for the Prometheus simpleclient family). The /q/metrics scrape endpoint is bound to
+    loopback and accessible only from the trusted internal Docker network. Identical
+    deployment topology reasoning as OWASP-SUPP-006. OWASP-SUPP-006.</notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_common@.*$</packageUrl>
     <cve>CVE-2026-42154</cve>
   </suppress>
 


### PR DESCRIPTION
## Summary

Extends the OWASP Dependency-Check suppression set to cover three sibling jars that were missing from the initial #1821 suppression set, causing blocking CVSS ≥ 7.0 failures on in-flight PRs.

| Group | New artifact | CVEs suppressed | Reasoning |
|---|---|---|---|
| SUPP-002 | `neo4j-ogm-api` | CVE-2026-1524 (9.8), CVE-2026-1497 (7.2) | Same false-positive as `neo4j-ogm-core` — CVEs target Neo4j server binary; ogm-api is the client annotation/interface layer, no server port |
| SUPP-003 | `jena-arq` | CVE-2025-49656 (7.5), CVE-2025-50151 (8.8) | Same accepted-risk as `jena-core` — no user-supplied SPARQL reaches the Jena parser; all queries server-constructed from validated parameters |
| SUPP-006 | `simpleclient_common` | CVE-2026-42154 (7.5) | Same deployment-topology as `simpleclient` — `/q/metrics` is loopback-only, not externally reachable |

## Root cause

The initial suppression set (#1821) covered primary jars but missed sibling modules in the same library families. The NVD CPE matching assigns the same CVE to all modules in a library family, so both `jena-core` AND `jena-arq` (and other Jena sub-modules) get flagged. Same for the OGM and Prometheus families.

## Test plan

- [x] `backend/dependency-check-suppressions.xml` has CVE id + reasoning in every new entry
- [x] All new entries have `until` expiry dates (SUPP-002 group: 2027-06-10; SUPP-003 group: 2026-12-31; SUPP-006 group: 2026-12-31)
- [x] No opaque suppressions — every entry cites the CVE, the artifact, and the reasoning
- [ ] OWASP CI job passes on this PR
- [ ] OWASP CI job passes on MFFD-AFP-THERMO-OVERLAY-1 (#1818) after rebase onto this merge

---
_Generated by [Claude Code](https://claude.ai/code/session_018M1K8Dkq89ux316LqcCBHF)_