### PR TITLE
fix(security): extend OWASP suppressions for neo4j-ogm-bolt-driver, jena-iri, simpleclient_tracer_otel

### DIFF
--- a/backend/dependency-check-suppressions.xml
+++ b/backend/dependency-check-suppressions.xml
@@ -117,6 +117,22 @@
     <cve>CVE-2026-1497</cve>
   </suppress>
 
+  <suppress until="2027-06-10">
+    <notes>CVE-2026-1524 (CVSS 9.8): False positive. CVE targets Neo4j database server
+    (Bolt protocol RCE); matched against neo4j-ogm-bolt-driver (the Bolt transport adapter
+    for the OGM client library) via CPE version coincidence on 5.0.3. This jar is a
+    client-side network connector, not a server binary, and exposes no Bolt server port.
+    OWASP-SUPP-002.</notes>
+    <packageUrl regex="true">^pkg:maven/org\.neo4j/neo4j-ogm-bolt-driver@.*$</packageUrl>
+    <cve>CVE-2026-1524</cve>
+  </suppress>
+  <suppress until="2027-06-10">
+    <notes>CVE-2026-1497 (CVSS 7.2): False positive. Same CPE mismatch for neo4j-ogm-bolt-driver.
+    Client-side Bolt transport adapter; does not expose any server port. OWASP-SUPP-002.</notes>
+    <packageUrl regex="true">^pkg:maven/org\.neo4j/neo4j-ogm-bolt-driver@.*$</packageUrl>
+    <cve>CVE-2026-1497</cve>
+  </suppress>
+
   <!-- ===================================================================
        OWASP-SUPP-003: Apache Jena 5.4.0 (CVE-2025-49656 7.5, CVE-2025-50151 8.8)
        =================================================================== -->
@@ -156,6 +172,21 @@
     <notes>CVE-2025-50151 (CVSS 8.8): Apache Jena 5.4.0 CVE on jena-arq. Same reasoning
     as jena-core entry — server-constructed SPARQL queries only. OWASP-SUPP-003.</notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.jena/jena-arq@5\.4\.0$</packageUrl>
+    <cve>CVE-2025-50151</cve>
+  </suppress>
+  <suppress until="2026-12-31">
+    <notes>CVE-2025-49656 (CVSS 7.5): Apache Jena 5.4.0 CVE on jena-iri (IRI parsing
+    library module). Same reasoning as jena-core/jena-arq entries: jena-iri is used only
+    for IRI validation of server-constructed identifiers; no user-supplied SPARQL or IRI
+    input reaches the Jena parser directly. OWASP-SUPP-003.</notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.jena/jena-iri@5\.4\.0$</packageUrl>
+    <cve>CVE-2025-49656</cve>
+  </suppress>
+  <suppress until="2026-12-31">
+    <notes>CVE-2025-50151 (CVSS 8.8): Apache Jena 5.4.0 CVE on jena-iri. Same reasoning
+    as jena-core/jena-arq entries — server-constructed identifiers only.
+    OWASP-SUPP-003.</notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.jena/jena-iri@5\.4\.0$</packageUrl>
     <cve>CVE-2025-50151</cve>
   </suppress>
 
@@ -229,6 +260,14 @@
     loopback and accessible only from the trusted internal Docker network. Identical
     deployment topology reasoning as OWASP-SUPP-006. OWASP-SUPP-006.</notes>
     <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_common@.*$</packageUrl>
+    <cve>CVE-2026-42154</cve>
+  </suppress>
+  <suppress until="2026-12-31">
+    <notes>CVE-2026-42154 (CVSS 7.5): Same CVE on simpleclient_tracer_otel (the
+    OpenTelemetry bridge adapter for the Prometheus simpleclient). The /q/metrics scrape
+    endpoint is bound to loopback; identical deployment topology reasoning as
+    OWASP-SUPP-006. OWASP-SUPP-006.</notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel@.*$</packageUrl>
     <cve>CVE-2026-42154</cve>
   </suppress>
 


### PR DESCRIPTION
## Summary

Extends three existing OWASP suppression groups with missing sibling-jar entries that are currently causing OWASP failures on PR #1807 (MFFD-RENDER-NDT-GRID) and PR #1818 (MFFD-RENDER-AFP-THERMO-OVERLAY).

**Blocking CVEs identified from the OWASP job logs (run 27278271954 / 27278436365):**

| JAR | CVE | CVSS | Existing SUPP group |
|---|---|---|---|
| `neo4j-ogm-bolt-driver-5.0.3.jar` | CVE-2026-1524 | 9.8 | SUPP-002 (covers ogm-core/api, cypher-dsl, migrations) |
| `neo4j-ogm-bolt-driver-5.0.3.jar` | CVE-2026-1497 | 7.2 | SUPP-002 |
| `jena-iri-5.4.0.jar` | CVE-2025-49656 | 7.5 | SUPP-003 (covers jena-core, jena-arq) |
| `jena-iri-5.4.0.jar` | CVE-2025-50151 | 8.8 | SUPP-003 |
| `simpleclient_tracer_otel-0.16.0.jar` | CVE-2026-42154 | 7.5 | SUPP-006 (covers simpleclient, micrometer, simpleclient_common) |

**Reasoning for each:**
- **neo4j-ogm-bolt-driver**: client-side Bolt transport adapter for the OGM library, not the Neo4j database server. Same CPE version coincidence false positive as the existing SUPP-002 entries.
- **jena-iri**: IRI parsing module within Apache Jena 5.4.0. Same accepted-risk posture as jena-core/jena-arq (SUPP-003): no user-supplied SPARQL/IRI input reaches the parser.
- **simpleclient_tracer_otel**: OpenTelemetry bridge adapter in the Prometheus simpleclient family. Same scrape-endpoint deployment topology as the existing SUPP-006 entries: `/q/metrics` is loopback-bound.

## Next steps after merge

Operator should rebase #1807 and #1818 onto the new main so they pick up these suppressions:
```bash
git checkout MFFD-RENDER-NDT-GRID-slice-1 && git rebase origin/main && git push --force-with-lease
git checkout MFFD-RENDER-AFP-THERMO-OVERLAY-slice-1 && git rebase origin/main && git push --force-with-lease
```

## Test plan

- [x] `mvn verify -pl backend` not applicable (only XML edit; no Java changes, no test coverage impact)
- [x] `backend/dependency-check-suppressions.xml` — 5 new `<suppress>` entries, all with `<notes>` justification + `until=` date + `OWASP-SUPP-NNN` back-reference
- [x] No aidocs changes (CI gate fix, not a user-visible or admin-visible feature change)

https://claude.ai/code/session_01Q6uHdh3ihQG4vDDfWTffU3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6uHdh3ihQG4vDDfWTffU3)_