### PR TITLE
fix(APISIMP-EMPTY-BODIES-BATCH-16): RFC 7807 bodies for empty 4xx in plugin cluster

### DIFF
--- a/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java
+++ b/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java
@@ -144,7 +144,7 @@ public class AasShellsRest {
     String appId = resolveAppId(aasId);
     Collection collection = collectionDAO.findByAppId(appId, username);
     if (collection == null) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "AAS Shell not found");
     }
     List<DataObject> dataObjects = dataObjectDAO.findTopLevelByCollectionAppId(appId);
     return Response.ok(mappingService.toShell(collection, dataObjects)).build();
@@ -179,10 +179,25 @@ public class AasShellsRest {
     String appId = resolveAppId(aasId);
     Collection collection = collectionDAO.findByAppId(appId, username);
     if (collection == null) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "AAS Shell not found");
     }
     List<DataObject> dataObjects = dataObjectDAO.findTopLevelByCollectionAppId(appId);
     return Response.ok(mappingService.toSubmodelRefs(dataObjects)).build();
+  }
+
+  private static Response problem(Response.Status status, String detail) {
+    String type = switch (status) {
+      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
+      case FORBIDDEN -> "urn:shepard:error:forbidden";
+      case BAD_REQUEST -> "urn:shepard:error:validation";
+      case NOT_FOUND -> "urn:shepard:error:not-found";
+      case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
+      default -> "urn:shepard:error:internal";
+    };
+    return Response.status(status)
+      .type("application/problem+json")
+      .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
+      .build();
   }
 
   /**

--- a/plugins/git/src/main/java/de/dlr/shepard/v2/git/resources/GitReferenceRest.java
+++ b/plugins/git/src/main/java/de/dlr/shepard/v2/git/resources/GitReferenceRest.java
@@ -93,7 +93,7 @@ public class GitReferenceRest {
 
     GitReference gr = gitReferenceDAO.findByAppId(gitReferenceAppId);
     if (gr == null || gr.getDataObject() == null || !dataObjectAppId.equals(gr.getDataObject().getAppId())) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "GitReference not found");
     }
 
     String caller = securityContext.getUserPrincipal().getName();
@@ -143,7 +143,7 @@ public class GitReferenceRest {
 
     GitReference gr = gitReferenceDAO.findByAppId(gitReferenceAppId);
     if (gr == null || gr.getDataObject() == null || !dataObjectAppId.equals(gr.getDataObject().getAppId())) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "GitReference not found");
     }
 
     String caller = securityContext.getUserPrincipal().getName();
@@ -166,16 +166,31 @@ public class GitReferenceRest {
 
   private Response checkAccess(String dataObjectAppId, AccessType accessType, SecurityContext securityContext) {
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
     long ogmId;
     try {
       ogmId = entityIdResolver.resolveLong(dataObjectAppId);
     } catch (NotFoundException nfe) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "DataObject not found");
     }
     if (!permissionsService.isAccessTypeAllowedForUser(ogmId, accessType, caller)) {
-      return Response.status(Response.Status.FORBIDDEN).build();
+      return problem(Response.Status.FORBIDDEN, "Insufficient permissions");
     }
     return null;
+  }
+
+  private static Response problem(Response.Status status, String detail) {
+    String type = switch (status) {
+      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
+      case FORBIDDEN -> "urn:shepard:error:forbidden";
+      case BAD_REQUEST -> "urn:shepard:error:validation";
+      case NOT_FOUND -> "urn:shepard:error:not-found";
+      case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
+      default -> "urn:shepard:error:internal";
+    };
+    return Response.status(status)
+      .type("application/problem+json")
+      .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
+      .build();
   }
 }

--- a/plugins/git/src/main/java/de/dlr/shepard/v2/users/resources/MeCredentialsRest.java
+++ b/plugins/git/src/main/java/de/dlr/shepard/v2/users/resources/MeCredentialsRest.java
@@ -70,7 +70,7 @@ public class MeCredentialsRest {
   @APIResponse(responseCode = "401", description = "Authentication required.")
   public Response list(@Context SecurityContext securityContext) {
     String caller = callerOrNull(securityContext);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     List<GitCredentialIO> result = gitCredentialDAO.findAllByUser(caller).stream().map(GitCredentialIO::new).toList();
     return Response.ok(result).build();
@@ -94,7 +94,7 @@ public class MeCredentialsRest {
     @Context UriInfo uriInfo
   ) {
     String caller = callerOrNull(securityContext);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     if (body == null) return problem(Response.Status.BAD_REQUEST, "Request body is required");
     if (body.getHost() == null || body.getHost().isBlank()) {
@@ -134,10 +134,10 @@ public class MeCredentialsRest {
   @APIResponse(responseCode = "404", description = "Not found or not owned by caller.")
   public Response read(@PathParam("appId") String appId, @Context SecurityContext securityContext) {
     String caller = callerOrNull(securityContext);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     GitCredential cred = gitCredentialDAO.findByUserAndAppId(caller, appId);
-    if (cred == null) return Response.status(Response.Status.NOT_FOUND).build();
+    if (cred == null) return problem(Response.Status.NOT_FOUND, "Git credential not found");
     return Response.ok(new GitCredentialIO(cred)).build();
   }
 
@@ -159,7 +159,7 @@ public class MeCredentialsRest {
     @Context SecurityContext securityContext
   ) {
     String caller = callerOrNull(securityContext);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     if (body != null && body.getPat() != null && !body.getPat().isBlank()) {
       byte[] key = resolveKey();
@@ -167,7 +167,7 @@ public class MeCredentialsRest {
     }
 
     GitCredential existing = gitCredentialDAO.findByUserAndAppId(caller, appId);
-    if (existing == null) return Response.status(Response.Status.NOT_FOUND).build();
+    if (existing == null) return problem(Response.Status.NOT_FOUND, "Git credential not found");
 
     GitCredential delta = new GitCredential();
     if (body != null) {
@@ -182,7 +182,7 @@ public class MeCredentialsRest {
     }
 
     GitCredential updated = gitCredentialDAO.updateByUserAndAppId(caller, appId, delta);
-    if (updated == null) return Response.status(Response.Status.NOT_FOUND).build();
+    if (updated == null) return problem(Response.Status.NOT_FOUND, "Git credential not found");
     return Response.ok(new GitCredentialIO(updated)).build();
   }
 
@@ -196,10 +196,10 @@ public class MeCredentialsRest {
   @APIResponse(responseCode = "404", description = "Not found or not owned by caller.")
   public Response delete(@PathParam("appId") String appId, @Context SecurityContext securityContext) {
     String caller = callerOrNull(securityContext);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     boolean deleted = gitCredentialDAO.deleteByUserAndAppId(caller, appId);
-    return deleted ? Response.noContent().build() : Response.status(Response.Status.NOT_FOUND).build();
+    return deleted ? Response.noContent().build() : problem(Response.Status.NOT_FOUND, "Git credential not found");
   }
 
   private String callerOrNull(SecurityContext sc) {
@@ -233,11 +233,13 @@ public class MeCredentialsRest {
 
   private static Response problem(Response.Status status, String detail) {
     String type = switch (status) {
+      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
+      case FORBIDDEN -> "urn:shepard:error:forbidden";
       case BAD_REQUEST -> "urn:shepard:error:validation";
       case NOT_FOUND -> "urn:shepard:error:not-found";
       case CONFLICT -> "urn:shepard:error:conflict";
       case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
-      default -> "urn:shepard:error:validation";
+      default -> "urn:shepard:error:internal";
     };
     return Response.status(status)
       .type("application/problem+json")

--- a/plugins/spatiotemporal/src/main/java/de/dlr/shepard/v2/spatial/promote/SpatialPromoteRest.java
+++ b/plugins/spatiotemporal/src/main/java/de/dlr/shepard/v2/spatial/promote/SpatialPromoteRest.java
@@ -93,7 +93,7 @@ public class SpatialPromoteRest {
     @Context SecurityContext sc
   ) {
     String caller = sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
     if (fileReferenceAppId == null || fileReferenceAppId.isBlank()) {
       return Response.status(Response.Status.BAD_REQUEST)
         .type("application/problem+json")
@@ -109,14 +109,14 @@ public class SpatialPromoteRest {
     // Permission gate: Write on the parent DataObject of the source FileReference.
     FileReference fileRef = singletonFileReferenceService.getByAppId(fileReferenceAppId);
     if (fileRef == null || fileRef.isDeleted()) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "FileReference not found");
     }
     DataObject parent = fileRef.getDataObject();
     if (parent == null || parent.getAppId() == null) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "DataObject not found");
     }
     if (!permissionsService.isAccessAllowedForDataObjectAppId(parent.getAppId(), AccessType.Write, caller)) {
-      return Response.status(Response.Status.FORBIDDEN).build();
+      return problem(Response.Status.FORBIDDEN, "Insufficient permissions");
     }
 
     try {
@@ -134,7 +134,22 @@ public class SpatialPromoteRest {
           null))
         .build();
     } catch (NotFoundException nfe) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, nfe.getMessage());
     }
+  }
+
+  private static Response problem(Response.Status status, String detail) {
+    String type = switch (status) {
+      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
+      case FORBIDDEN -> "urn:shepard:error:forbidden";
+      case BAD_REQUEST -> "urn:shepard:error:validation";
+      case NOT_FOUND -> "urn:shepard:error:not-found";
+      case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
+      default -> "urn:shepard:error:internal";
+    };
+    return Response.status(status)
+      .type("application/problem+json")
+      .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
+      .build();
   }
 }

--- a/plugins/video/src/main/java/de/dlr/shepard/v2/video/resources/VideoAnnotationRest.java
+++ b/plugins/video/src/main/java/de/dlr/shepard/v2/video/resources/VideoAnnotationRest.java
@@ -74,27 +74,29 @@ public class VideoAnnotationRest {
     String caller
   ) {
     VideoStreamReference ref = videoStreamReferenceDAO.findByAppId(refAppId);
-    if (ref == null) return Response.status(Response.Status.NOT_FOUND).build();
-    if (ref.getDataObject() == null) return Response.status(Response.Status.NOT_FOUND).build();
+    if (ref == null) return problem(Response.Status.NOT_FOUND, "VideoStreamReference not found");
+    if (ref.getDataObject() == null) return problem(Response.Status.NOT_FOUND, "VideoStreamReference not found");
 
     String refParentAppId = ref.getDataObject().getAppId();
     if (refParentAppId != null && !refParentAppId.equals(dataObjectAppId)) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "VideoStreamReference not found");
     }
 
     if (!permissionsService.isAccessAllowedForDataObjectAppId(dataObjectAppId, accessType, caller)) {
-      return Response.status(Response.Status.FORBIDDEN).build();
+      return problem(Response.Status.FORBIDDEN, "Insufficient permissions");
     }
     return null;
   }
 
   private static Response problem(Response.Status status, String detail) {
     String type = switch (status) {
+      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
+      case FORBIDDEN -> "urn:shepard:error:forbidden";
       case BAD_REQUEST -> "urn:shepard:error:validation";
       case NOT_FOUND -> "urn:shepard:error:not-found";
       case CONFLICT -> "urn:shepard:error:conflict";
       case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
-      default -> "urn:shepard:error:validation";
+      default -> "urn:shepard:error:internal";
     };
     return Response.status(status)
       .type("application/problem+json")
@@ -130,7 +132,7 @@ public class VideoAnnotationRest {
     @Context SecurityContext sc
   ) {
     String caller = callerOrNull(sc);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     Response gate = checkParentAndAccess(refAppId, dataObjectAppId, AccessType.Read, caller);
     if (gate != null) return gate;
@@ -178,7 +180,7 @@ public class VideoAnnotationRest {
     }
 
     String caller = callerOrNull(sc);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     Response gate = checkParentAndAccess(refAppId, dataObjectAppId, AccessType.Write, caller);
     if (gate != null) return gate;
@@ -222,13 +224,13 @@ public class VideoAnnotationRest {
     @Context SecurityContext sc
   ) {
     String caller = callerOrNull(sc);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     Response gate = checkParentAndAccess(refAppId, dataObjectAppId, AccessType.Read, caller);
     if (gate != null) return gate;
 
     VideoAnnotation a = annotationDAO.findByAppId(annotationAppId);
-    if (a == null) return Response.status(Response.Status.NOT_FOUND).build();
+    if (a == null) return problem(Response.Status.NOT_FOUND, "VideoAnnotation not found");
     return Response.ok(new VideoAnnotationIO(a)).build();
   }
 
@@ -261,13 +263,13 @@ public class VideoAnnotationRest {
     @Context SecurityContext sc
   ) {
     String caller = callerOrNull(sc);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     Response gate = checkParentAndAccess(refAppId, dataObjectAppId, AccessType.Write, caller);
     if (gate != null) return gate;
 
     VideoAnnotation a = annotationDAO.findByAppId(annotationAppId);
-    if (a == null) return Response.status(Response.Status.NOT_FOUND).build();
+    if (a == null) return problem(Response.Status.NOT_FOUND, "VideoAnnotation not found");
 
     if (body.getStartSeconds() != null) a.setStartSeconds(body.getStartSeconds());
     if (body.getEndSeconds() != null) a.setEndSeconds(body.getEndSeconds());
@@ -305,13 +307,13 @@ public class VideoAnnotationRest {
     @Context SecurityContext sc
   ) {
     String caller = callerOrNull(sc);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     Response gate = checkParentAndAccess(refAppId, dataObjectAppId, AccessType.Write, caller);
     if (gate != null) return gate;
 
     VideoAnnotation a = annotationDAO.findByAppId(annotationAppId);
-    if (a == null) return Response.status(Response.Status.NOT_FOUND).build();
+    if (a == null) return problem(Response.Status.NOT_FOUND, "VideoAnnotation not found");
     annotationDAO.unlinkAndDelete(refAppId, a);
     return Response.noContent().build();
   }

--- a/plugins/video/src/main/java/de/dlr/shepard/v2/video/resources/VideoStreamReferenceV2Rest.java
+++ b/plugins/video/src/main/java/de/dlr/shepard/v2/video/resources/VideoStreamReferenceV2Rest.java
@@ -101,7 +101,7 @@ public class VideoStreamReferenceV2Rest {
     @Context SecurityContext sc
   ) {
     String caller = callerOrNull(sc);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     if (upload == null || upload.uploadedFile() == null) {
       return Response.status(Response.Status.BAD_REQUEST)
@@ -116,10 +116,10 @@ public class VideoStreamReferenceV2Rest {
     }
 
     Long doOgmId = videoStreamReferenceService.getDataObjectOgmId(dataObjectAppId);
-    if (doOgmId == null) return Response.status(Response.Status.NOT_FOUND).build();
+    if (doOgmId == null) return problem(Response.Status.NOT_FOUND, "DataObject not found");
 
     if (!permissionsService.isAccessAllowedForDataObjectAppId(dataObjectAppId, AccessType.Write, caller)) {
-      return Response.status(Response.Status.FORBIDDEN).build();
+      return problem(Response.Status.FORBIDDEN, "Insufficient permissions");
     }
 
     String refName = (name != null && !name.isBlank()) ? name : upload.fileName();
@@ -135,7 +135,7 @@ public class VideoStreamReferenceV2Rest {
       );
       return Response.status(Response.Status.CREATED).entity(new VideoStreamReferenceIO(created)).build();
     } catch (jakarta.ws.rs.NotFoundException nfe) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, nfe.getMessage());
     } catch (StorageNotInstalledException ex) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(ex.getMessage()).build();
     } catch (StorageException ex) {
@@ -195,10 +195,10 @@ public class VideoStreamReferenceV2Rest {
     @Context SecurityContext sc
   ) {
     String caller = callerOrNull(sc);
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
 
     VideoStreamReference ref = videoStreamReferenceDAO.findByAppId(appId);
-    if (ref == null) return Response.status(Response.Status.NOT_FOUND).build();
+    if (ref == null) return problem(Response.Status.NOT_FOUND, "VideoStreamReference not found");
 
     Response gate = checkParentAndAccess(ref, dataObjectAppId, AccessType.Read, caller);
     if (gate != null) return gate;
@@ -282,6 +282,21 @@ public class VideoStreamReferenceV2Rest {
     return sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;
   }
 
+  private static Response problem(Response.Status status, String detail) {
+    String type = switch (status) {
+      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
+      case FORBIDDEN -> "urn:shepard:error:forbidden";
+      case BAD_REQUEST -> "urn:shepard:error:validation";
+      case NOT_FOUND -> "urn:shepard:error:not-found";
+      case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
+      default -> "urn:shepard:error:internal";
+    };
+    return Response.status(status)
+      .type("application/problem+json")
+      .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
+      .build();
+  }
+
   /**
    * Validate that the reference's parent DataObject matches the URL's
    * {@code dataObjectAppId} and that the caller has the required access.
@@ -295,14 +310,14 @@ public class VideoStreamReferenceV2Rest {
     String caller
   ) {
     if (ref.getDataObject() == null) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "VideoStreamReference not found");
     }
     String refParentAppId = ref.getDataObject().getAppId();
     if (refParentAppId != null && !refParentAppId.equals(dataObjectAppId)) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "VideoStreamReference not found");
     }
     if (!permissionsService.isAccessAllowedForDataObjectAppId(dataObjectAppId, accessType, caller)) {
-      return Response.status(Response.Status.FORBIDDEN).build();
+      return problem(Response.Status.FORBIDDEN, "Insufficient permissions");
     }
     return null;
   }

--- a/plugins/wiki-writer/src/main/java/de/dlr/shepard/plugins/wikiwriter/resources/WikiWriterRest.java
+++ b/plugins/wiki-writer/src/main/java/de/dlr/shepard/plugins/wikiwriter/resources/WikiWriterRest.java
@@ -108,14 +108,14 @@ public class WikiWriterRest {
     Long collectionOgmId = resolveOrNull(collectionAppId);
     Long dataObjectOgmId = resolveOrNull(dataObjectAppId);
     if (collectionOgmId == null || dataObjectOgmId == null) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      return problem(Response.Status.NOT_FOUND, "Collection or DataObject not found");
     }
 
     // Gate: Write permission on the DataObject (inherited from parent Collection).
     String caller = sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;
-    if (caller == null) return Response.status(Response.Status.UNAUTHORIZED).build();
+    if (caller == null) return problem(Response.Status.UNAUTHORIZED, "Authentication required");
     if (!permissionsService.isAccessAllowedForDataObjectAppId(dataObjectAppId, AccessType.Write, caller)) {
-      return Response.status(Response.Status.FORBIDDEN).build();
+      return problem(Response.Status.FORBIDDEN, "Insufficient permissions");
     }
 
     // Guard: LLM provider must be available.
@@ -157,5 +157,20 @@ public class WikiWriterRest {
     } catch (NotFoundException nfe) {
       return null;
     }
+  }
+
+  private static Response problem(Response.Status status, String detail) {
+    String type = switch (status) {
+      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
+      case FORBIDDEN -> "urn:shepard:error:forbidden";
+      case BAD_REQUEST -> "urn:shepard:error:validation";
+      case NOT_FOUND -> "urn:shepard:error:not-found";
+      case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
+      default -> "urn:shepard:error:internal";
+    };
+    return Response.status(status)
+      .type("application/problem+json")
+      .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
+      .build();
   }
 }


### PR DESCRIPTION
## Summary

- Add `problem()` helper + structured `application/problem+json` bodies to **36 bare 4xx responses** across **7 plugin REST files**
- Every 4xx in these files now returns `urn:shepard:error:*` type, HTTP status title, status code, and `detail` string
- `AiAdminRest.java` already had full coverage via its own `notFound()` helper — no changes needed

### Files changed

| File | Sites fixed |
|------|-------------|
| `plugins/video/.../VideoAnnotationRest.java` | 12 |
| `plugins/git/.../MeCredentialsRest.java` | 9 |
| `plugins/video/.../VideoStreamReferenceV2Rest.java` | 8 |
| `plugins/spatiotemporal/.../SpatialPromoteRest.java` | 5 |
| `plugins/git/.../GitReferenceRest.java` | 5 |
| `plugins/wiki-writer/.../WikiWriterRest.java` | 3 |
| `plugins/aas/.../AasShellsRest.java` | 2 |

### Problem helper pattern (added to each file)

```java
private static Response problem(Response.Status status, String detail) {
    String type = switch (status) {
        case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
        case FORBIDDEN    -> "urn:shepard:error:forbidden";
        case BAD_REQUEST  -> "urn:shepard:error:validation";
        case NOT_FOUND    -> "urn:shepard:error:not-found";
        case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
        default           -> "urn:shepard:error:internal";
    };
    return Response.status(status)
        .type("application/problem+json")
        .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
        .build();
}
```

## Test plan

- [ ] `mvn -q compile -pl backend` — backend main compiles clean (verified locally)
- [ ] CI plugin compile passes for all 7 modules
- [ ] `mvn verify -pl backend` — JaCoCo + SpotBugs green
- [ ] No new SpotBugs / findsecbugs HIGH findings introduced

## Tracking

- `aidocs/16` APISIMP-EMPTY-BODIES-BATCH-16 row updated: `queued` → `🔄 PR open (2026-06-13)`
- Part of APISIMP-EMPTY-BODIES series (BATCH-13 ✓, BATCH-14 🔄 #1895, BATCH-15 ✓, BATCH-16 this PR)

https://claude.ai/code/session_01Sui1sYo4DhYA3HPy8NEi2i

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sui1sYo4DhYA3HPy8NEi2i)_