### PR TITLE
fix(APISIMP-PLUGIN-ABSOLUTE-PROBLEM-URIS): relative problem-type URIs in plugin REST resources

### DIFF
--- a/plugins/git/src/main/java/de/dlr/shepard/v2/git/resources/GitReferenceRest.java
+++ b/plugins/git/src/main/java/de/dlr/shepard/v2/git/resources/GitReferenceRest.java
@@ -102,7 +102,7 @@ public class GitReferenceRest {
       return Response.status(Response.Status.NOT_IMPLEMENTED)
         .type("application/problem+json")
         .entity(new ProblemJson(
-            "https://shepard.dlr.de/problems/git.adapter.unsupported-host",
+            "/problems/git.adapter.unsupported-host",
             "No GitAdapter is registered for this host.",
             501,
             "v1 ships a GitLab adapter only; GitHub and Gitea ship in G1d.",

--- a/plugins/kip/docs/quickstart.md
+++ b/plugins/kip/docs/quickstart.md
@@ -100,7 +100,7 @@ HTTP/1.1 404 Not Found
 Content-Type: application/problem+json
 
 {
-  "type": "https://shepard.dlr.de/problems/kip.pid.not-found",
+  "type": "/problems/kip.pid.not-found",
   "title": "KIP record not found for PID suffix",
   "status": 404,
   "detail": "No :Publication row matches the requested PID."

--- a/plugins/kip/docs/reference.md
+++ b/plugins/kip/docs/reference.md
@@ -35,7 +35,7 @@ version).
 ```
 
 **Not found (404):** RFC 7807 `application/problem+json` with
-`type: https://shepard.dlr.de/problems/kip.pid.not-found`.
+`type: /problems/kip.pid.not-found`.
 
 ## Config keys
 

--- a/plugins/kip/src/main/java/de/dlr/shepard/plugins/kip/resources/KipResolverRest.java
+++ b/plugins/kip/src/main/java/de/dlr/shepard/plugins/kip/resources/KipResolverRest.java
@@ -114,7 +114,7 @@ public class KipResolverRest {
     if (suffix == null || suffix.isBlank()) {
       return problem(
         Response.Status.NOT_FOUND,
-        "https://shepard.dlr.de/problems/kip.pid.not-found",
+        "/problems/kip.pid.not-found",
         "No publication with that PID suffix",
         "PID suffix must not be empty."
       );
@@ -123,7 +123,7 @@ public class KipResolverRest {
     if (publication.isEmpty()) {
       return problem(
         Response.Status.NOT_FOUND,
-        "https://shepard.dlr.de/problems/kip.pid.not-found",
+        "/problems/kip.pid.not-found",
         "No publication with that PID suffix",
         "No :Publication row at this shepard has pid=" + suffix + "."
       );

--- a/plugins/v1-compat/docs/quickstart.md
+++ b/plugins/v1-compat/docs/quickstart.md
@@ -99,7 +99,7 @@ Link: </v2/>; rel="successor-version"
 X-Shepard-Legacy: true
 
 {
-  "type": "https://shepard.dlr.de/problems/v1-disabled",
+  "type": "/problems/v1-disabled",
   "title": "Legacy v1 surface disabled",
   "status": 410,
   "detail": "The legacy /shepard/api/... surface is disabled on this instance. Migrate to /v2/.",

--- a/plugins/v1-compat/docs/reference.md
+++ b/plugins/v1-compat/docs/reference.md
@@ -105,7 +105,7 @@ Link: </v2/>; rel="successor-version"
 X-Shepard-Legacy: true
 
 {
-  "type": "https://shepard.dlr.de/problems/v1-disabled",
+  "type": "/problems/v1-disabled",
   "title": "Legacy v1 surface disabled",
   "status": 410,
   "detail": "The legacy /shepard/api/... surface is disabled on this instance. Migrate to /v2/.",

--- a/plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/filters/LegacyV1GateFilter.java
+++ b/plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/filters/LegacyV1GateFilter.java
@@ -42,7 +42,7 @@ import jakarta.inject.Inject;
 public class LegacyV1GateFilter {
 
   /** RFC 7807 problem type URI for the disabled-v1-surface body. */
-  public static final String PROBLEM_TYPE_V1_DISABLED = "https://shepard.dlr.de/problems/v1-disabled";
+  public static final String PROBLEM_TYPE_V1_DISABLED = "/problems/v1-disabled";
 
   /** Stable human-readable title for the problem body. */
   static final String PROBLEM_TITLE = "Legacy v1 surface disabled";


### PR DESCRIPTION
## Summary

Implements `APISIMP-PLUGIN-ABSOLUTE-PROBLEM-URIS` (filed in fire-40 sweep).

RFC 7807 §3.1 permits relative URI references for the `type` field. The absolute `https://shepard.dlr.de/problems/…` form bakes in a hostname that operators may not control (on-prem, air-gapped, custom domain). Switch three plugins to `/problems/…` relative URIs — consistent with the core backend pattern.

**Changed plugins:**
- `shepard-plugin-git` — `GitReferenceRest` (unsupported-host 501)
- `shepard-plugin-kip` — `KipResolverRest` (pid.not-found 404 ×2) + docs
- `shepard-plugin-v1-compat` — `LegacyV1GateFilter` constant + docs

No wire-shape change from a client perspective (the `type` URI is opaque for machine use; clients compare it as a string).

## Test plan

- [ ] `mvn -q test-compile -pl plugins/kip,plugins/v1-compat,plugins/git` passes
- [ ] No new SpotBugs findings
- [ ] CI green

https://claude.ai/code/session_01T63XwExpj3uqqfSVKhJ1FC

---
_Generated by [Claude Code](https://claude.ai/code/session_01T63XwExpj3uqqfSVKhJ1FC)_