### PR TITLE
fix(APISIMP-TSCHANNEL-CONTAINER-ID): mark containerId @Schema(deprecated=true) in TimeseriesChannelV2IO

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -422,7 +422,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/40-ecosystem.md`](40-ecosystem.md) | 40 — Shepard ecosystem | 2026-05-23 | 2026-06-16 |
 | [`aidocs/41-synergy-sweep.md`](41-synergy-sweep.md) | 41 — Synergy sweep: collapse-where-generalisation-helps | 2026-05-23 | 2026-06-16 |
 | [`aidocs/42-vision.md`](42-vision.md) | shepard — Vision (for researchers) | 2026-05-23 | 2026-06-16 |
-| [`aidocs/44-fork-vs-upstream-feature-matrix.md`](44-fork-vs-upstream-feature-matrix.md) | Fork vs Upstream — Feature Matrix | 2026-05-23 | 2026-06-17 |
+| [`aidocs/44-fork-vs-upstream-feature-matrix.md`](44-fork-vs-upstream-feature-matrix.md) | Fork vs Upstream — Feature Matrix | 2026-05-23 | 2026-06-18 |
 | [`aidocs/97-shepard-pipelines.md`](97-shepard-pipelines.md) | 97 — Shepard-pipelines: modern REBAR, Shepard-native | 2026-05-23 | 2026-06-16 |
 | [`aidocs/99-api-annoyances.md`](99-api-annoyances.md) | 99 — Shepard API annoyances (structural clunkiness) | 2026-05-23 | 2026-06-16 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-06-13-fire15.md`](agent-findings/apisimp-sweep-2026-06-13-fire15.md) | APISIMP Sweep — 2026-06-13 (fire #N+15) | 2026-06-13 | 2026-06-16 |

--- a/backend/src/main/java/de/dlr/shepard/v2/timeseriescontainer/io/TimeseriesChannelV2IO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/timeseriescontainer/io/TimeseriesChannelV2IO.java
@@ -44,7 +44,7 @@ public record TimeseriesChannelV2IO(
    * once available — requires a TS-IDb/c Postgres migration adding
    * {@code container_app_id UUID} to the {@code timeseries} table.
    */
-  @Schema(description = "DEPRECATED (APISIMP-TSCHANNEL-CONTAINER-ID): numeric Postgres serial FK exposed on wire. Use containerAppId once available — requires TS-IDb/c migration.", required = true)
+  @Schema(description = "DEPRECATED (APISIMP-TSCHANNEL-CONTAINER-ID): numeric Postgres serial FK exposed on wire. Use containerAppId once available — requires TS-IDb/c migration.", required = true, deprecated = true)
   long containerId,
 
   @Schema(required = true, example = "turbopump_vibration")

--- a/backend/src/test/java/de/dlr/shepard/v2/timeseriescontainer/io/TimeseriesChannelV2IOTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/timeseriescontainer/io/TimeseriesChannelV2IOTest.java
@@ -7,8 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.dlr.shepard.data.timeseries.model.TimeseriesEntity;
 import de.dlr.shepard.data.timeseries.model.enums.DataPointValueType;
+import java.lang.reflect.RecordComponent;
 import java.util.Map;
 import java.util.UUID;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -87,6 +89,25 @@ public class TimeseriesChannelV2IOTest {
       "valueType"
     );
     assertEquals(expected, shape.keySet(), "v2 channel IO property set drifted");
+  }
+
+  @Test
+  void containerId_schema_isMarkedDeprecated() {
+    // APISIMP-TSCHANNEL-CONTAINER-ID: containerId is a numeric Postgres serial FK that
+    // violates the "no numeric internal IDs on the v2 wire" contract. Until the TS-IDb/c
+    // migration adds containerAppId, the field must be flagged deprecated in the OpenAPI
+    // schema so generated clients know not to depend on it.
+    RecordComponent component = null;
+    for (RecordComponent rc : TimeseriesChannelV2IO.class.getRecordComponents()) {
+      if (rc.getName().equals("containerId")) {
+        component = rc;
+        break;
+      }
+    }
+    assertNotNull(component, "containerId record component must exist");
+    Schema schema = component.getAnnotation(Schema.class);
+    assertNotNull(schema, "@Schema must be present on containerId");
+    assertTrue(schema.deprecated(), "@Schema(deprecated=true) must be set on containerId (APISIMP-TSCHANNEL-CONTAINER-ID)");
   }
 
   @Test

--- a/backend/src/test/java/de/dlr/shepard/v2/timeseriescontainer/io/TimeseriesChannelV2IOTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/timeseriescontainer/io/TimeseriesChannelV2IOTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.dlr.shepard.data.timeseries.model.TimeseriesEntity;
 import de.dlr.shepard.data.timeseries.model.enums.DataPointValueType;
-import java.lang.reflect.RecordComponent;
 import java.util.Map;
 import java.util.UUID;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -92,21 +91,17 @@ public class TimeseriesChannelV2IOTest {
   }
 
   @Test
-  void containerId_schema_isMarkedDeprecated() {
+  void containerId_schema_isMarkedDeprecated() throws NoSuchFieldException {
     // APISIMP-TSCHANNEL-CONTAINER-ID: containerId is a numeric Postgres serial FK that
     // violates the "no numeric internal IDs on the v2 wire" contract. Until the TS-IDb/c
     // migration adds containerAppId, the field must be flagged deprecated in the OpenAPI
     // schema so generated clients know not to depend on it.
-    RecordComponent component = null;
-    for (RecordComponent rc : TimeseriesChannelV2IO.class.getRecordComponents()) {
-      if (rc.getName().equals("containerId")) {
-        component = rc;
-        break;
-      }
-    }
-    assertNotNull(component, "containerId record component must exist");
-    Schema schema = component.getAnnotation(Schema.class);
-    assertNotNull(schema, "@Schema must be present on containerId");
+    //
+    // MicroProfile @Schema targets ElementType.FIELD (not RECORD_COMPONENT), so the
+    // annotation propagates to the backing field — use getDeclaredField, not RecordComponent.
+    java.lang.reflect.Field field = TimeseriesChannelV2IO.class.getDeclaredField("containerId");
+    Schema schema = field.getAnnotation(Schema.class);
+    assertNotNull(schema, "@Schema must be present on containerId backing field");
     assertTrue(schema.deprecated(), "@Schema(deprecated=true) must be set on containerId (APISIMP-TSCHANNEL-CONTAINER-ID)");
   }
 


### PR DESCRIPTION
## Summary

`TimeseriesChannelV2IO.containerId` is a numeric Postgres serial FK that violates the v2 "no numeric internal IDs on the wire" contract. This slice (1 of 2) adds `@Schema(deprecated=true)` to the field so OpenAPI generators surface a machine-readable deprecation warning, prompting new integrations to use `shepardId` instead.

Slice 2 (adding a companion `containerAppId` UUID v7 field) is gated on the TS-IDb/c Postgres migration that adds `container_app_id UUID` to the `timeseries` table.

## Files changed

| File | Change |
|---|---|
| `TimeseriesChannelV2IO.java` | Add `deprecated = true` to `@Schema` on `containerId` |
| `TimeseriesChannelV2IOTest.java` | New test `containerId_schema_isMarkedDeprecated` — reflection asserts `@Schema(deprecated=true)` is set |
| `aidocs/16-dispatcher-backlog.md` | `APISIMP-TSCHANNEL-CONTAINER-ID` → in-progress (slice 1) |
| `aidocs/34-upstream-upgrade-path.md` | ADDITIVE tracker row (zero wire break) |
| `aidocs/01-doc-stage-index.md` | Regenerated |

## Wire-compat note

This is **ADDITIVE** — no wire shape changes. `deprecated=true` is an OpenAPI metadata flag only. The `containerId` field is still present in responses. Upstream 5.2 callers are unaffected.

## Test plan

- [x] `cd backend && ./mvnw -B -DnoPlugins -DbootstrapTestjar test-compile` → BUILD SUCCESS
- [ ] CI: `TimeseriesChannelV2IOTest#containerId_schema_isMarkedDeprecated` must pass

Backlog row: `APISIMP-TSCHANNEL-CONTAINER-ID` (fire-105)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyi4m5rJ2c9NPwv6qLWNDT)_