### PR TITLE
fix(APISIMP-TYPED-PRED-ID): suppress predecessorId from TypedPredecessorSummaryIO wire

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIO.java
@@ -1,5 +1,6 @@
 package de.dlr.shepard.v2.dataobject.io;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
@@ -25,9 +26,11 @@ public record TypedPredecessorSummaryIO(
   String predecessorAppId,
 
   @Deprecated
+  @JsonIgnore
   @Schema(
     readOnly = true,
     deprecated = true,
+    hidden = true,
     description =
       "Deprecated — join on predecessorAppId (UUID v7) instead. " +
       "Numeric Neo4j shepardId of the predecessor DataObject."

--- a/backend/src/test/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIOTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIOTest.java
@@ -1,0 +1,44 @@
+package de.dlr.shepard.v2.dataobject.io;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * APISIMP-TYPED-PRED-ID — regression guard: {@code predecessorId} must not appear
+ * in the serialized JSON output. It is a numeric Neo4j internal ID that violates
+ * the v2 "no numeric internal IDs on the wire" contract.
+ */
+public class TypedPredecessorSummaryIOTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void predecessorId_isNotSerializedToWire() throws Exception {
+    TypedPredecessorSummaryIO io = new TypedPredecessorSummaryIO(
+      "01930a2b-fe4c-7e3c-9f1d-8a5b2c3d4e5f",
+      42L,
+      "TR-004",
+      "PUBLISHED",
+      "prov:wasRevisionOf"
+    );
+
+    String json = mapper.writeValueAsString(io);
+
+    assertFalse(
+      json.contains("predecessorId"),
+      "predecessorId (numeric Neo4j ID) must not appear in serialized JSON — " +
+      "it violates the v2 no-numeric-id contract. JSON was: " + json
+    );
+    assertTrue(
+      json.contains("predecessorAppId"),
+      "predecessorAppId must be present in serialized JSON. JSON was: " + json
+    );
+    assertTrue(
+      json.contains("predecessorName"),
+      "predecessorName must be present in serialized JSON. JSON was: " + json
+    );
+  }
+}


### PR DESCRIPTION
## Summary

`TypedPredecessorSummaryIO.predecessorId` (Neo4j numeric `long`) was annotated `@Deprecated` and `@Schema(deprecated=true)` but lacked `@JsonIgnore` — it was being serialized in every `GET /v2/collections/{cid}/data-objects/{did}` response, violating the v2 "no numeric internal IDs on wire" contract.

**Change:**
- Added `@JsonIgnore` to the `predecessorId` record component (`TypedPredecessorSummaryIO.java`) — propagates to the backing field and the accessor method; Jackson 2.15+ suppresses both during serialization.
- Also set `@Schema(hidden=true)` to keep the OpenAPI spec clean.
- Added regression test `TypedPredecessorSummaryIOTest.predecessorId_isNotSerializedToWire` that asserts the field is absent from serialized JSON and `predecessorAppId` is present.
- `aidocs/34` tracker row added (WIRE BREAK — v2 surface only; `predecessorAppId` UUID v7 was already present).
- `aidocs/16` APISIMP-TYPED-PRED-ID row promoted: queued → in-progress.

## Wire impact

**WIRE BREAK (v2 surface only)** — `predecessorId` no longer appears in `typedPredecessorSummaries[]` items within `GET /v2/collections/{cid}/data-objects/{did}` responses. `predecessorAppId` (UUID v7), `predecessorName`, `predecessorStatus`, and `relationshipType` are all still present. The upstream `/shepard/api/...` v1 surface is unchanged.

**Callers that were reading `.predecessorId` must switch to `.predecessorAppId` (UUID v7 string).** The `predecessorAppId` field was already present in all responses before this change.

## Files changed

- `backend/src/main/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIO.java` — `@JsonIgnore` + `@Schema(hidden=true)` on `predecessorId`
- `backend/src/test/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIOTest.java` — NEW regression test
- `aidocs/34-upstream-upgrade-path.md` — WIRE BREAK tracker row
- `aidocs/16-dispatcher-backlog.md` — row status update
- `aidocs/01-doc-stage-index.md` — regenerated

## Test plan

- [ ] `mvn verify -pl backend` green (JUnit + JaCoCo + SpotBugs)
- [ ] `TypedPredecessorSummaryIOTest.predecessorId_isNotSerializedToWire` passes — asserts `predecessorId` absent, `predecessorAppId` present, `predecessorName` present
- [ ] No regression in `DataObjectDetailV2IO` serialization

Fixes: APISIMP-TYPED-PRED-ID (filed in fire-106 sweep, `aidocs/agent-findings/apisimp-sweep-2026-06-18-fire106.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjhBKCtdgBTG7nJ2qf82Hn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjhBKCtdgBTG7nJ2qf82Hn)_