### PR TITLE
fix(APISIMP-PAGINATION-PARAM-NAMING): rename listUserGroups param size → pageSize

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserGroupV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserGroupV2Rest.java
@@ -85,12 +85,12 @@ public class UserGroupV2Rest {
   @Parameter(name = Constants.QP_ORDER_DESC)
   public Response listUserGroups(
     @QueryParam(Constants.QP_PAGE) @PositiveOrZero Integer page,
-    @QueryParam("pageSize") @PositiveOrZero Integer size,
+    @QueryParam("pageSize") @PositiveOrZero Integer pageSize,
     @QueryParam(Constants.QP_ORDER_BY_ATTRIBUTE) UserGroupAttributes orderBy,
     @QueryParam(Constants.QP_ORDER_DESC) Boolean orderDesc
   ) {
     var params = new QueryParamHelper();
-    if (page != null && size != null) params = params.withPageAndSize(page, size);
+    if (page != null && pageSize != null) params = params.withPageAndSize(page, pageSize);
     if (orderBy != null) params = params.withOrderByAttribute(orderBy, orderDesc);
     List<UserGroupV2IO> result = service.getAllUserGroups(params).stream()
       .map(UserGroupV2IO::new)


### PR DESCRIPTION
## Summary

`UserGroupV2Rest.listUserGroups` declared `@QueryParam("pageSize") @PositiveOrZero Integer size` — the method parameter name `size` did not match the query parameter name `pageSize`. Every other v2 list endpoint uses a method param name that matches the `@QueryParam` annotation string for readability (e.g. `Integer page` for `@QueryParam("page")`).

**Change:** Rename Java method parameter `size` → `pageSize` in `UserGroupV2Rest.listUserGroups`. No wire change; no API behaviour change. JAX-RS binds by annotation, not by parameter name.

## Files changed

- `backend/src/main/java/de/dlr/shepard/v2/users/resources/UserGroupV2Rest.java:88` — `Integer size` → `Integer pageSize`
- `aidocs/16-dispatcher-backlog.md` — row marked in-progress
- `aidocs/01-doc-stage-index.md` — regenerated

## Wire impact

**ZERO** — pure Java method parameter rename. The `@QueryParam("pageSize")` annotation is unchanged; JAX-RS binds by annotation string, so the HTTP API is identical before and after. No migration needed.

## Test plan

- [x] `mvn test-compile -pl backend` green — confirms rename compiles cleanly
- [x] No test changes required — binding is by annotation, not by param name

Fixes: APISIMP-PAGINATION-PARAM-NAMING (filed in fire-106 sweep, `aidocs/agent-findings/apisimp-sweep-2026-06-18-fire106.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LW3wjc5P8HDLe4qapbrXem

---
_Generated by [Claude Code](https://claude.ai/code/session_01LW3wjc5P8HDLe4qapbrXem)_