### PR TITLE
fix(apisimp): align getThumbnail Java param name with @QueryParam annotation (APISIMP-THUMBNAIL-SIZE-PARAM-NAME)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -1333,7 +1333,7 @@ public class ContainersV2Rest {
   public Response getThumbnail(
     @PathParam("appId") String appId,
     @PathParam("oid") String oid,
-    @QueryParam("size") Integer sizeParam,
+    @QueryParam("size") Integer size,
     @Context SecurityContext sc
   ) {
     String caller = callerOrNull(sc);
@@ -1342,7 +1342,7 @@ public class ContainersV2Rest {
     if (resolved.isEmpty()) return problem(PROBLEM_TYPE_NOT_FOUND, "Not found", Response.Status.NOT_FOUND, "No container found for appId");
     Response gate = gate(resolved.get().container(), AccessType.Read, caller);
     if (gate != null) return gate;
-    return resolved.get().handler().getThumbnail(appId, oid, sizeParam)
+    return resolved.get().handler().getThumbnail(appId, oid, size)
       .orElse(unsupportedKind("thumbnails"));
   }
 

--- a/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
@@ -606,4 +606,22 @@ class ContainersV2RestTest {
         .findFirst().orElse("NOT_FOUND");
     assertEquals("maxPoints", actual);
   }
+
+  // ─── APISIMP-THUMBNAIL-SIZE-PARAM-NAME regression ───────────────────────────
+
+  @Test
+  void getThumbnail_sizeParamAnnotationMatchesJavaName() throws NoSuchMethodException {
+    // Regression guard: the Java parameter name must match the @QueryParam annotation value.
+    // Previously the param was named "sizeParam" while the annotation said "size", causing
+    // a mismatch between the wire name and the internal identifier.
+    Method method = ContainersV2Rest.class.getMethod(
+        "getThumbnail", String.class, String.class, Integer.class,
+        jakarta.ws.rs.core.SecurityContext.class);
+    String actual = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && p.getAnnotation(QueryParam.class).value().equals("size"))
+        .map(p -> p.getName())
+        .findFirst().orElse("NOT_FOUND");
+    assertEquals("size", actual);
+  }
 }


### PR DESCRIPTION
## Summary

- Rename `sizeParam` → `size` in `ContainersV2Rest.getThumbnail()` so the Java parameter name matches the `@QueryParam("size")` annotation value — cosmetic alignment, **no wire change**.
- Add reflection regression test `getThumbnail_sizeParamAnnotationMatchesJavaName` to `ContainersV2RestTest` to lock the name going forward.
- Add `APISIMP-THUMBNAIL-SIZE-PARAM-NAME` row to `aidocs/16`; regenerate `aidocs/01`.

**Backlog row:** `aidocs/16` → APISIMP-THUMBNAIL-SIZE-PARAM-NAME (XS, ✅ done)

## Test plan
- [ ] `mvn verify -pl backend` green (regression test asserts `@QueryParam("size")` param is named `size`)
- [ ] No frontend change needed (wire name unchanged)
- [ ] `aidocs/01` regenerated cleanly (467 docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPkdb7emzWuiQMYjTMftLz

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPkdb7emzWuiQMYjTMftLz)_