### PR TITLE
fix(APISIMP-LABJOURNAL-MISSING-PAGINATION): add optional page/pageSize to lab-journal-entries list

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
@@ -145,7 +145,9 @@ public class CollectionLabJournalEntriesRest {
         return Response.ok(List.of()).build();
       }
       int from = (int) fromL;
-      ios = ios.subList(from, Math.min(from + pageSize, ios.size()));
+      // Long arithmetic prevents overflow when pageSize is near Integer.MAX_VALUE.
+      int to = (int) Math.min((long) from + pageSize, ios.size());
+      ios = ios.subList(from, to);
     }
     return Response.ok(ios).build();
   }

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
@@ -12,7 +12,6 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
@@ -139,10 +138,13 @@ public class CollectionLabJournalEntriesRest {
       ios.add(new LabJournalEntryIO(e));
     }
     if (pageSize != null && pageSize > 0) {
-      int from = (page != null ? page : 0) * pageSize;
-      if (from >= ios.size()) {
+      // Use long arithmetic to avoid int overflow when page and pageSize are both large.
+      // The downcast back to int is safe: fromL < ios.size() which always fits in int.
+      long fromL = (long) (page != null ? page : 0) * pageSize;
+      if (fromL >= ios.size()) {
         return Response.ok(List.of()).build();
       }
+      int from = (int) fromL;
       ios = ios.subList(from, Math.min(from + pageSize, ios.size()));
     }
     return Response.ok(ios).build();

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
@@ -10,12 +10,15 @@ import de.dlr.shepard.v2.labjournal.daos.CollectionLabJournalEntriesDAO;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -83,7 +86,10 @@ public class CollectionLabJournalEntriesRest {
       "round-trips. Returns an empty array when the collection has no data " +
       "objects or none of them carry lab journal entries.\n\n" +
       "Auth: Read permission on the Collection. 401 if unauthenticated, " +
-      "404 if the collectionAppId resolves to nothing, 403 if the caller lacks Read."
+      "404 if the collectionAppId resolves to nothing, 403 if the caller lacks Read.\n\n" +
+      "Pagination: supply both `page` (0-based) and `pageSize` (positive) to slice the result. " +
+      "Omitting either parameter (or supplying 0 for pageSize) returns all entries — " +
+      "the original bulk-fetch behaviour is preserved for backward compatibility."
   )
   @APIResponse(
     responseCode = "200",
@@ -95,6 +101,8 @@ public class CollectionLabJournalEntriesRest {
   @APIResponse(responseCode = "404", description = "No Collection with that appId.")
   public Response list(
     @PathParam("collectionAppId") String collectionAppId,
+    @QueryParam("page") @PositiveOrZero Integer page,
+    @QueryParam("pageSize") @PositiveOrZero Integer pageSize,
     @Context SecurityContext sc
   ) {
     String caller = sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;
@@ -129,6 +137,13 @@ public class CollectionLabJournalEntriesRest {
         continue;
       }
       ios.add(new LabJournalEntryIO(e));
+    }
+    if (pageSize != null && pageSize > 0) {
+      int from = (page != null ? page : 0) * pageSize;
+      if (from >= ios.size()) {
+        return Response.ok(List.of()).build();
+      }
+      ios = ios.subList(from, Math.min(from + pageSize, ios.size()));
     }
     return Response.ok(ios).build();
   }

--- a/backend/src/test/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRestTest.java
@@ -76,25 +76,25 @@ class CollectionLabJournalEntriesRestTest {
   @Test
   void list_returns401WhenUnauthenticated() {
     when(sc.getUserPrincipal()).thenReturn(null);
-    assertThat(resource.list(COLL_APP_ID, sc).getStatus()).isEqualTo(401);
+    assertThat(resource.list(COLL_APP_ID, null, null, sc).getStatus()).isEqualTo(401);
   }
 
   @Test
   void list_returns404WhenCollectionNotFound() {
     when(entityIdResolver.resolveLong(COLL_APP_ID)).thenThrow(new NotFoundException());
-    assertThat(resource.list(COLL_APP_ID, sc).getStatus()).isEqualTo(404);
+    assertThat(resource.list(COLL_APP_ID, null, null, sc).getStatus()).isEqualTo(404);
   }
 
   @Test
   void list_returns403WhenNoReadPermission() {
     when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
       .thenReturn(false);
-    assertThat(resource.list(COLL_APP_ID, sc).getStatus()).isEqualTo(403);
+    assertThat(resource.list(COLL_APP_ID, null, null, sc).getStatus()).isEqualTo(403);
   }
 
   @Test
   void list_returns200WithEntriesAndDataObjectIdPopulated() {
-    var r = resource.list(COLL_APP_ID, sc);
+    var r = resource.list(COLL_APP_ID, null, null, sc);
     assertThat(r.getStatus()).isEqualTo(200);
     @SuppressWarnings("unchecked")
     var body = (List<LabJournalEntryIO>) r.getEntity();
@@ -126,7 +126,7 @@ class CollectionLabJournalEntriesRestTest {
         buildEntry(11L, 101L, "hydrated", new Date(2_000_000L)),
         orphan
       ));
-    var r = resource.list(COLL_APP_ID, sc);
+    var r = resource.list(COLL_APP_ID, null, null, sc);
     assertThat(r.getStatus()).isEqualTo(200);
     @SuppressWarnings("unchecked")
     var body = (List<LabJournalEntryIO>) r.getEntity();
@@ -138,7 +138,7 @@ class CollectionLabJournalEntriesRestTest {
   @Test
   void list_returns200WithEmptyListWhenNoEntries() {
     when(entriesDAO.findByCollectionAppId(COLL_APP_ID)).thenReturn(List.of());
-    var r = resource.list(COLL_APP_ID, sc);
+    var r = resource.list(COLL_APP_ID, null, null, sc);
     assertThat(r.getStatus()).isEqualTo(200);
     @SuppressWarnings("unchecked")
     var body = (List<LabJournalEntryIO>) r.getEntity();
@@ -147,8 +147,36 @@ class CollectionLabJournalEntriesRestTest {
 
   @Test
   void list_usesCollectionOgmIdForPermissionCheck() {
-    resource.list(COLL_APP_ID, sc);
+    resource.list(COLL_APP_ID, null, null, sc);
     verify(permissionsService).isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER));
+  }
+
+  @Test
+  void list_paginationReturnsSublistWhenPageAndSizeProvided() {
+    var r = resource.list(COLL_APP_ID, 0, 1, sc);
+    assertThat(r.getStatus()).isEqualTo(200);
+    @SuppressWarnings("unchecked")
+    var body = (List<LabJournalEntryIO>) r.getEntity();
+    assertThat(body).hasSize(1);
+    assertThat(body.get(0).getId()).isEqualTo(11L);
+  }
+
+  @Test
+  void list_paginationPageBeyondRangeReturnsEmptyList() {
+    var r = resource.list(COLL_APP_ID, 99, 10, sc);
+    assertThat(r.getStatus()).isEqualTo(200);
+    @SuppressWarnings("unchecked")
+    var body = (List<LabJournalEntryIO>) r.getEntity();
+    assertThat(body).isEmpty();
+  }
+
+  @Test
+  void list_nullPageAndSizeReturnsAllEntries() {
+    var r = resource.list(COLL_APP_ID, null, null, sc);
+    assertThat(r.getStatus()).isEqualTo(200);
+    @SuppressWarnings("unchecked")
+    var body = (List<LabJournalEntryIO>) r.getEntity();
+    assertThat(body).hasSize(2);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add optional `@QueryParam("page")` and `@QueryParam("pageSize")` (both `@PositiveOrZero Integer`) to `CollectionLabJournalEntriesRest.list()` at `GET /v2/collections/{collectionAppId}/lab-journal-entries`.
- Null params or `pageSize=0` preserves the existing "return all" contract — existing callers that omit the params are unaffected (backward-compatible).
- In-memory slice applied after the DAO returns, on the already-sorted list (createdAt DESC).
- 3 pagination regression tests added; all 10 tests green.

**Backlog row:** `aidocs/16` → `APISIMP-LABJOURNAL-MISSING-PAGINATION` (S, in-progress → done on merge)

## Test plan
- [x] `mvn test -Dtest=CollectionLabJournalEntriesRestTest` — 10/10 pass (7 pre-existing + 3 new: page 0+size 1, page beyond range → empty, null params → all entries)
- [x] No frontend change needed (new params are purely additive; the existing frontend caller that omits them continues to receive all entries)
- [x] No aidocs/01 regeneration needed (no aidocs file changed in this PR — status row already filed in the direct-to-main doc commit on fire-112)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012oPvLHmkCYxQQPvpPh44NQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012oPvLHmkCYxQQPvpPh44NQ)_