### PR TITLE
fix(APISIMP-SHAPES-FOCUS-APPID-REQUIRED): mark focusAppId @Parameter required=true in OpenAPI schema

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/shapes/resources/ShapesApplicableRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/shapes/resources/ShapesApplicableRest.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -108,7 +109,13 @@ public class ShapesApplicableRest {
   @APIResponse(responseCode = "400", description = "focusAppId query parameter missing.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "404", description = "No entity carries the focus appId.")
-  public Response listApplicable(@QueryParam("focusAppId") String focusAppId) {
+  public Response listApplicable(
+    @Parameter(
+      description = "AppId of the entity to match shapes against (DataObject, Collection, etc.). Required.",
+      required = true
+    )
+    @QueryParam("focusAppId") String focusAppId
+  ) {
     if (focusAppId == null || focusAppId.isBlank()) {
       return problem(PT_BAD_REQUEST, "focusAppId required", 400, "Query parameter focusAppId is required");
     }

--- a/backend/src/test/java/de/dlr/shepard/v2/shapes/resources/ShapesApplicableRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/shapes/resources/ShapesApplicableRestTest.java
@@ -2,6 +2,7 @@ package de.dlr.shepard.v2.shapes.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -234,5 +235,21 @@ class ShapesApplicableRestTest {
     assertFalse(ShapesApplicableRest.hasShapeGraph("not json"));
     assertFalse(ShapesApplicableRest.hasShapeGraph("{\"shapeGraph\":\"\"}"));
     assertTrue(ShapesApplicableRest.hasShapeGraph("{\"shapeGraph\":\"@prefix sh: <x> .\"}"));
+  }
+
+  // ─── APISIMP-SHAPES-FOCUS-APPID-REQUIRED regression ──────────────────────
+
+  @Test
+  void listApplicable_focusAppIdParam_isMarkedRequired() throws NoSuchMethodException {
+    java.lang.reflect.Method method = ShapesApplicableRest.class.getMethod(
+        "listApplicable", String.class);
+    java.lang.reflect.Parameter param = method.getParameters()[0];
+    var qp = param.getAnnotation(jakarta.ws.rs.QueryParam.class);
+    assertNotNull(qp, "first param must carry @QueryParam");
+    assertEquals("focusAppId", qp.value());
+    var oapiParam = param.getAnnotation(
+        org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(oapiParam, "focusAppId must carry @Parameter annotation");
+    assertTrue(oapiParam.required(), "@Parameter.required must be true for focusAppId");
   }
 }


### PR DESCRIPTION
## Summary

- `GET /v2/shapes/applicable?focusAppId=…` returns HTTP 400 when `focusAppId` is absent (enforced at runtime in `ShapesApplicableRest.java:112`), but the OpenAPI schema had no `@Parameter(required=true)` annotation on the query param.
- Callers could not introspect the requirement from the generated schema alone — they had to discover the constraint from a 400 response.
- Fix: add `@Parameter(description="AppId of the entity to match shapes against. Required.", required=true)` to the `focusAppId` `@QueryParam` in `listApplicable()`.
- Add 1 reflection regression test (`listApplicable_focusAppIdParam_isMarkedRequired`) asserting the annotation is present and `required=true`.
- File 5 new `APISIMP-*` sweep findings in `aidocs/16` (XS, queued).

**No runtime behaviour change** — validation logic is unchanged; only the schema annotation improves.

## Test plan

- [x] `mvn test -Dtest=ShapesApplicableRestTest` — all tests pass (existing + new reflection test)
- [x] `aidocs/16` updated with new queued rows (no aidocs stage change — no doc-stage-index regeneration needed)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VsPAq2h2sLActZGK8DHQEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsPAq2h2sLActZGK8DHQEs)_