### PR TITLE
fix(APISIMP-CHANNEL-DOWNSAMPLE-UNDOCUMENTED): document downsample and maxPoints params in getChannelData

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -650,7 +650,9 @@ public class ContainersV2Rest {
     @QueryParam("start") @NotNull @PositiveOrZero Long start,
     @Parameter(description = "Window end, nanoseconds since Unix epoch (exclusive). Must be > start.", required = true)
     @QueryParam("end")   @NotNull @PositiveOrZero Long end,
+    @Parameter(description = "Downsampling algorithm. Only 'lttb' (Largest Triangle Three Buckets) is supported; any other value disables downsampling.")
     @QueryParam("downsample") String downsample,
+    @Parameter(description = "Maximum number of data points to return when downsample=lttb is active. Ignored when downsample is absent or unrecognised.")
     @QueryParam("maxPoints") Integer maxPoints,
     @Context SecurityContext sc
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
@@ -660,4 +660,42 @@ class ContainersV2RestTest {
         endDesc.toLowerCase().contains("nanosecond"),
         "end @Parameter description must mention 'nanosecond' — got: " + endDesc);
   }
+
+  // ─── APISIMP-CHANNEL-DOWNSAMPLE-UNDOCUMENTED regression ─────────────────────
+
+  @Test
+  void getChannelData_downsampleParamHasParameterAnnotation() throws NoSuchMethodException {
+    Method method = ContainersV2Rest.class.getMethod(
+        "getChannelData", String.class, UUID.class, Long.class, Long.class,
+        String.class, Integer.class, jakarta.ws.rs.core.SecurityContext.class);
+    String desc = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "downsample".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+    org.junit.jupiter.api.Assertions.assertFalse(
+        desc.isBlank(),
+        "downsample @Parameter description must be present and non-blank — got: '" + desc + "'");
+  }
+
+  @Test
+  void getChannelData_maxPointsParamHasParameterAnnotation() throws NoSuchMethodException {
+    Method method = ContainersV2Rest.class.getMethod(
+        "getChannelData", String.class, UUID.class, Long.class, Long.class,
+        String.class, Integer.class, jakarta.ws.rs.core.SecurityContext.class);
+    String desc = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "maxPoints".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+    org.junit.jupiter.api.Assertions.assertFalse(
+        desc.isBlank(),
+        "maxPoints @Parameter description must be present and non-blank — got: '" + desc + "'");
+  }
 }


### PR DESCRIPTION
## What

Add `@Parameter` annotations to the `downsample` and `maxPoints` query params of
`GET /v2/containers/{appId}/channels/{shepardId}/data` in `ContainersV2Rest`.

Neither param had any `@Parameter` annotation — the OpenAPI spec listed them as bare
untyped optional parameters with no description. A client generator or SDK user had
no way to know:
- that `"lttb"` is the only valid `downsample` value
- that `maxPoints` is ignored when `downsample` is absent or unrecognised

The `@Operation` description mentioned `?downsample=lttb&maxPoints=N` in prose only.

## Changes

- `ContainersV2Rest.java:653–654` — add `@Parameter(description=…)` before each `@QueryParam`
- `ContainersV2RestTest.java` — add 2 reflection regression tests:
  `getChannelData_downsampleParamHasParameterAnnotation`,
  `getChannelData_maxPointsParamHasParameterAnnotation`

No runtime behaviour change. No wire change.

## Checklist

- [x] `@Parameter` annotations present on `downsample` and `maxPoints`
- [x] 2 reflection regression tests added
- [x] No wire / runtime change
- [x] Part of APISIMP sweep (fire-114 dispatch)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VsPAq2h2sLActZGK8DHQEs)_