### PR TITLE
fix(APISIMP-TIMELINE-BINSIZE-UNDOCUMENTED): document binSizeDays ladder values and auto-coarsening in OpenAPI schema

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionTimelineRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionTimelineRest.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -119,6 +120,14 @@ public class CollectionTimelineRest {
   @APIResponse(responseCode = "404", description = "No Collection with that appId.")
   public Response timeline(
     @PathParam("collectionAppId") @NotBlank String collectionAppId,
+    @Parameter(
+      description =
+        "Histogram bin width in days. Accepted ladder values: 1, 7, 30, 90, 365. " +
+        "Non-ladder values snap upward to the next ladder step. When the campaign span " +
+        "would produce more than ~730 bins per lane, the server auto-coarsens upward " +
+        "through the ladder until it fits. Default 1. " +
+        "The actual bin size used is echoed in the response's binSizeDays field."
+    )
     @QueryParam("binSizeDays") @DefaultValue("1") int binSizeDays,
     @Context SecurityContext sc
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/collection/resources/CollectionTimelineRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/collection/resources/CollectionTimelineRestTest.java
@@ -1,6 +1,8 @@
 package de.dlr.shepard.v2.collection.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -212,5 +214,26 @@ class CollectionTimelineRestTest {
       .thenReturn(new TimelineAggregate(List.of(), 0L, null, null));
     Response r = resource.timeline(COLL_APP_ID, 1, sc);
     assertThat(r.getHeaderString("Cache-Control")).isEqualTo("max-age=300, must-revalidate");
+  }
+
+  // ─── APISIMP-TIMELINE-BINSIZE-UNDOCUMENTED regression ────────────────────
+
+  @Test
+  void binSizeDays_paramHasParameterAnnotationWithDescription() throws NoSuchMethodException {
+    java.lang.reflect.Method method = CollectionTimelineRest.class.getMethod(
+        "timeline", String.class, int.class, jakarta.ws.rs.core.SecurityContext.class);
+    java.lang.reflect.Parameter param = java.util.Arrays.stream(method.getParameters())
+        .filter(p -> {
+          var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class);
+          return qp != null && "binSizeDays".equals(qp.value());
+        })
+        .findFirst()
+        .orElse(null);
+    assertNotNull(param, "binSizeDays must carry @QueryParam");
+    var ann = param.getAnnotation(
+        org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "binSizeDays must carry @Parameter annotation");
+    assertTrue(ann.description() != null && !ann.description().isBlank(),
+        "@Parameter.description must be non-blank for binSizeDays");
   }
 }


### PR DESCRIPTION
## Summary

- `GET /v2/collections/{appId}/timeline?binSizeDays=` accepts only ladder values (1, 7, 30, 90, 365) and auto-coarsens when the campaign span would produce more than ~730 bins per lane — but the `@QueryParam` carried no `@Parameter` annotation.
- Callers had to discover the constraint from the `@Operation` description prose or from trial-and-error; the generated OpenAPI schema showed only a bare int query param with no documentation.
- Fix: add `@Parameter(description="Histogram bin width in days. Accepted ladder values: 1, 7, 30, 90, 365. Non-ladder values snap upward to the next ladder step. When the campaign span would produce more than ~730 bins per lane, the server auto-coarsens upward through the ladder until it fits. Default 1. The actual bin size used is echoed in the response's binSizeDays field.")` to `binSizeDays` in `CollectionTimelineRest.timeline()`.
- Add 1 reflection regression test (`binSizeDays_paramHasParameterAnnotationWithDescription`) asserting the annotation is present and non-blank.

**No runtime behaviour change** — validation and auto-coarsening logic is unchanged; only the schema annotation improves.

## Test plan

- [x] `mvn test -Dtest=CollectionTimelineRestTest` — all 9 tests pass (existing 8 + new reflection test)
- [x] No aidocs stage changes — no doc-stage-index regeneration needed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VsPAq2h2sLActZGK8DHQEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsPAq2h2sLActZGK8DHQEs)_