### PR TITLE
fix(APISIMP-TERM-SEARCH-PAGESIZE-CAP-UNDOCUMENTED): document q required + pageSize server-side cap in OpenAPI schema

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticTermSearchRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticTermSearchRest.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.neo4j.ogm.session.Session;
@@ -196,7 +197,14 @@ public class SemanticTermSearchRest {
   @APIResponse(responseCode = "400", description = "Query parameter `q` is missing, blank, or shorter than 2 characters.")
   @APIResponse(responseCode = "401", description = "Authentication required (no JWT and no X-API-KEY).")
   public Response search(
+    @Parameter(
+      description = "Search string to match against ontology term labels. Must be at least 2 characters.",
+      required = true
+    )
     @QueryParam("q") String q,
+    @Parameter(
+      description = "Maximum number of results to return (default 20). Server-side cap: 50 — values above 50 are silently clamped to 50."
+    )
     @QueryParam("pageSize") @DefaultValue("20") int pageSize,
     @Context SecurityContext sc
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/semantic/resources/SemanticTermSearchRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/semantic/resources/SemanticTermSearchRestTest.java
@@ -277,6 +277,47 @@ class SemanticTermSearchRestTest {
     );
   }
 
+  // ─── APISIMP-TERM-SEARCH-PAGESIZE-CAP-UNDOCUMENTED regression ─────────────
+
+  @Test
+  void q_paramIsMarkedRequiredWithDescription() throws NoSuchMethodException {
+    java.lang.reflect.Method method = SemanticTermSearchRest.class.getMethod(
+        "search", String.class, int.class, jakarta.ws.rs.core.SecurityContext.class);
+    java.lang.reflect.Parameter param = java.util.Arrays.stream(method.getParameters())
+        .filter(p -> {
+          var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class);
+          return qp != null && "q".equals(qp.value());
+        })
+        .findFirst()
+        .orElse(null);
+    assertNotNull(param, "q must carry @QueryParam");
+    var ann = param.getAnnotation(
+        org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "q must carry @Parameter annotation");
+    assertTrue(ann.required(), "@Parameter.required must be true for q");
+    assertTrue(ann.description() != null && !ann.description().isBlank(),
+        "@Parameter.description must be non-blank for q");
+  }
+
+  @Test
+  void pageSize_paramDescribesServerSideCap() throws NoSuchMethodException {
+    java.lang.reflect.Method method = SemanticTermSearchRest.class.getMethod(
+        "search", String.class, int.class, jakarta.ws.rs.core.SecurityContext.class);
+    java.lang.reflect.Parameter param = java.util.Arrays.stream(method.getParameters())
+        .filter(p -> {
+          var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class);
+          return qp != null && "pageSize".equals(qp.value());
+        })
+        .findFirst()
+        .orElse(null);
+    assertNotNull(param, "pageSize must carry @QueryParam");
+    var ann = param.getAnnotation(
+        org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "pageSize must carry @Parameter annotation");
+    assertTrue(ann.description() != null && ann.description().contains("50"),
+        "@Parameter.description for pageSize must mention the server-side cap of 50");
+  }
+
   // ─── helpers ──────────────────────────────────────────────────────────────
 
   private void stubEmptyResult() {


### PR DESCRIPTION
## Summary

- `GET /v2/semantic/terms/search?q=…&pageSize=…` had two undocumented constraints visible only in code or `@Operation` prose:
  - `q` is required (returns 400 when absent, blank, or shorter than 2 chars) but carried no `@Parameter(required=true)` annotation — the OpenAPI schema silently marked it optional.
  - `pageSize` is silently clamped to 50 server-side (`MAX_LIMIT = 50`) — a caller supplying `?pageSize=200` would receive at most 50 results with no indication why, since the constraint only appeared in `@Operation` description prose.
- Fix: add `@Parameter(required=true, description="Search string to match against ontology term labels. Must be at least 2 characters.")` to `q`; add `@Parameter(description="Maximum number of results to return (default 20). Server-side cap: 50 — values above 50 are silently clamped to 50.")` to `pageSize`.
- Add 2 reflection regression tests (`q_paramIsMarkedRequiredWithDescription`, `pageSize_paramDescribesServerSideCap`) asserting the annotations are present with the required properties.

**No runtime behaviour change** — validation and capping logic is unchanged; only the schema annotations improve.

## Test plan

- [x] `mvn test -Dtest=SemanticTermSearchRestTest` — all tests pass (existing 14 + 2 new reflection tests)
- [x] No aidocs stage changes — no doc-stage-index regeneration needed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VsPAq2h2sLActZGK8DHQEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsPAq2h2sLActZGK8DHQEs)_