### PR TITLE
fix(APISIMP-PREDICATE-STATS-LIMIT-PARAMS-UNDOCUMENTED): add @Parameter docs to topValuesLimit/sampleLimit in SemanticPredicateStatsRest

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticPredicateStatsRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticPredicateStatsRest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -88,8 +89,12 @@ public class SemanticPredicateStatsRest {
   @APIResponse(responseCode = "401", description = "Authentication required.")
   public Response getPredicateStats(
     @PathParam("predicateIriBase64") String predicateIriBase64,
-    @QueryParam("topValuesLimit") @DefaultValue("20") int topValuesLimit,
-    @QueryParam("sampleLimit") @DefaultValue("10") int sampleLimit
+    @QueryParam("topValuesLimit") @DefaultValue("20")
+    @Parameter(description = "Maximum number of distinct object-value rows to return in `topValues` (default: 20).")
+    int topValuesLimit,
+    @QueryParam("sampleLimit") @DefaultValue("10")
+    @Parameter(description = "Maximum number of sample-entity rows to return in `sampleEntities` (default: 10).")
+    int sampleLimit
   ) {
     String iri = decodeIri(predicateIriBase64);
     if (iri == null) {

--- a/backend/src/test/java/de/dlr/shepard/v2/semantic/resources/SemanticPredicateStatsRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/semantic/resources/SemanticPredicateStatsRestTest.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.semantic.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -13,12 +14,16 @@ import static org.mockito.Mockito.when;
 import de.dlr.shepard.context.semantic.services.SemanticAnnotationService;
 import de.dlr.shepard.context.semantic.services.SemanticAnnotationService.PredicateStats;
 import de.dlr.shepard.v2.semantic.io.PredicateStatsIO;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -200,5 +205,51 @@ class SemanticPredicateStatsRestTest {
     Response r = rest.getPredicateStats(urlSafeB64(iri), 20, 10);
     PredicateStatsIO body = (PredicateStatsIO) r.getEntity();
     assertEquals(42L, body.topValues().get(0).count());
+  }
+
+  // ─── APISIMP-PREDICATE-STATS-LIMIT-PARAMS-UNDOCUMENTED regression ─────────
+
+  @Test
+  void getPredicateStats_topValuesLimitParamIsDocumented() throws Exception {
+    Method method = SemanticPredicateStatsRest.class.getMethod(
+        "getPredicateStats", String.class, int.class, int.class);
+    java.lang.reflect.Parameter topParam = Arrays.stream(method.getParameters())
+        .filter(p -> {
+          QueryParam qp = p.getAnnotation(QueryParam.class);
+          return qp != null && "topValuesLimit".equals(qp.value());
+        })
+        .findFirst()
+        .orElseThrow(() -> new AssertionError(
+            "No @QueryParam(\"topValuesLimit\") found on getPredicateStats"));
+
+    Parameter annotation = topParam.getAnnotation(Parameter.class);
+    assertNotNull(annotation,
+        "@Parameter annotation missing on 'topValuesLimit' @QueryParam in getPredicateStats");
+    assertNotNull(annotation.description(),
+        "@Parameter description must be set on 'topValuesLimit'");
+    assertFalse(annotation.description().isBlank(),
+        "@Parameter description must not be blank on 'topValuesLimit'");
+  }
+
+  @Test
+  void getPredicateStats_sampleLimitParamIsDocumented() throws Exception {
+    Method method = SemanticPredicateStatsRest.class.getMethod(
+        "getPredicateStats", String.class, int.class, int.class);
+    java.lang.reflect.Parameter sampleParam = Arrays.stream(method.getParameters())
+        .filter(p -> {
+          QueryParam qp = p.getAnnotation(QueryParam.class);
+          return qp != null && "sampleLimit".equals(qp.value());
+        })
+        .findFirst()
+        .orElseThrow(() -> new AssertionError(
+            "No @QueryParam(\"sampleLimit\") found on getPredicateStats"));
+
+    Parameter annotation = sampleParam.getAnnotation(Parameter.class);
+    assertNotNull(annotation,
+        "@Parameter annotation missing on 'sampleLimit' @QueryParam in getPredicateStats");
+    assertNotNull(annotation.description(),
+        "@Parameter description must be set on 'sampleLimit'");
+    assertFalse(annotation.description().isBlank(),
+        "@Parameter description must not be blank on 'sampleLimit'");
   }
 }


### PR DESCRIPTION
## Summary

- Adds `@Parameter(description=...)` to the `topValuesLimit` `@QueryParam` on `SemanticPredicateStatsRest.getPredicateStats()` so the generated OpenAPI schema documents the max distinct object-value rows returned in `topValues` (default: 20).
- Adds `@Parameter(description=...)` to the `sampleLimit` `@QueryParam` so the generated OpenAPI schema documents the max sample-entity rows returned in `sampleEntities` (default: 10).
- No runtime change — annotation-only.
- Adds 2 reflection regression tests (`getPredicateStats_topValuesLimitParamIsDocumented`, `getPredicateStats_sampleLimitParamIsDocumented`) that verify the `@Parameter` annotations are present and non-blank.

## Backlog row

`APISIMP-PREDICATE-STATS-LIMIT-PARAMS-UNDOCUMENTED` (XS) — filed in fire-115 sweep (`aidocs/agent-findings/apisimp-sweep-2026-06-18-fire115.md`)

## Files changed

| File | Change |
|------|--------|
| `backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticPredicateStatsRest.java` | Added `import org.eclipse.microprofile.openapi.annotations.parameters.Parameter` + `@Parameter` on `topValuesLimit` + `@Parameter` on `sampleLimit` |
| `backend/src/test/java/de/dlr/shepard/v2/semantic/resources/SemanticPredicateStatsRestTest.java` | Added 2 reflection regression tests + imports (`assertFalse`, `QueryParam`, `Method`, `Arrays`, `Parameter`) |

## AC

- [x] OpenAPI schema carries a `description` for `topValuesLimit` in `GET /v2/semantic/predicates/{predicateIriBase64}/stats`.
- [x] OpenAPI schema carries a `description` for `sampleLimit` in `GET /v2/semantic/predicates/{predicateIriBase64}/stats`.
- [x] `mvn verify -pl backend` green (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011P7gPSyreu5LPycmx5RUCG)_