### PR TITLE
fix(APISIMP-SNAPSHOT-LIST-PARAMS-UNDOCUMENTED): add @Parameter docs to SnapshotListRest query params

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotListRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotListRest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -127,8 +128,16 @@ public class SnapshotListRest {
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "404", description = "collectionAppId supplied but does not resolve to an existing Collection.")
   public Response list(
+    @Parameter(description =
+      "Optional. When supplied, scopes the result to snapshots belonging to the "
+      + "Collection with this appId. When absent, all snapshots the caller can "
+      + "read are returned regardless of Collection.")
     @QueryParam("collectionAppId") String collectionAppId,
+    @Parameter(description = "Zero-based page index (default 0). Negative values are clamped to 0.")
     @QueryParam("page") @DefaultValue("0") int page,
+    @Parameter(description =
+      "Page size (default 50). Server-side clamp: [1, 200] — values outside this "
+      + "range are silently clamped to the nearest boundary.")
     @QueryParam("pageSize") @DefaultValue("50") int pageSize,
     @Context SecurityContext sc
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/snapshot/resources/SnapshotListRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/snapshot/resources/SnapshotListRestTest.java
@@ -1,6 +1,8 @@
 package de.dlr.shepard.v2.snapshot.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -9,6 +11,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
 
 import de.dlr.shepard.auth.permission.services.PermissionsService;
 import de.dlr.shepard.common.identifier.EntityIdResolver;
@@ -212,5 +216,47 @@ class SnapshotListRestTest {
     SnapshotListPageIO body = (SnapshotListPageIO) r.getEntity();
     assertThat(body.page()).isEqualTo(3);
     assertThat(body.pageSize()).isEqualTo(25);
+  }
+
+  // ─── APISIMP-SNAPSHOT-LIST-PARAMS-UNDOCUMENTED regression ────────────────
+
+  private java.lang.reflect.Parameter findListParam(String queryParamName) throws NoSuchMethodException {
+    java.lang.reflect.Method method = SnapshotListRest.class.getMethod(
+        "list", String.class, int.class, int.class, jakarta.ws.rs.core.SecurityContext.class);
+    return Arrays.stream(method.getParameters())
+        .filter(p -> {
+          jakarta.ws.rs.QueryParam qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class);
+          return qp != null && queryParamName.equals(qp.value());
+        })
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Test
+  void list_collectionAppIdParam_hasParameterAnnotationWithDescription() throws NoSuchMethodException {
+    java.lang.reflect.Parameter param = findListParam("collectionAppId");
+    assertNotNull(param, "collectionAppId must carry @QueryParam");
+    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "collectionAppId must carry @Parameter");
+    assertFalse(ann.description().isBlank(), "@Parameter.description must be non-blank for collectionAppId");
+  }
+
+  @Test
+  void list_pageParam_hasParameterAnnotationWithDescription() throws NoSuchMethodException {
+    java.lang.reflect.Parameter param = findListParam("page");
+    assertNotNull(param, "page must carry @QueryParam");
+    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "page must carry @Parameter");
+    assertFalse(ann.description().isBlank(), "@Parameter.description must be non-blank for page");
+  }
+
+  @Test
+  void list_pageSizeParam_hasParameterAnnotationDocumentingClamp() throws NoSuchMethodException {
+    java.lang.reflect.Parameter param = findListParam("pageSize");
+    assertNotNull(param, "pageSize must carry @QueryParam");
+    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "pageSize must carry @Parameter");
+    assertFalse(ann.description().isBlank(), "@Parameter.description must be non-blank for pageSize");
+    assertThat(ann.description()).contains("200");
   }
 }


### PR DESCRIPTION
## Summary

- Adds `@Parameter(description=...)` to the `collectionAppId`, `page`, and `pageSize` query params in `SnapshotListRest.list()` so the generated OpenAPI schema documents their semantics.
- `pageSize` description explicitly documents the server-side **[1, 200] clamp** — callers supplying `?pageSize=500` previously received 200 results with no indication of the cap.
- `collectionAppId` description documents the optional scoping behaviour.
- `page` description documents the zero-based index and negative-clamping.
- No runtime change — annotation-only.
- Adds 3 reflection regression tests asserting `@Parameter` annotations are present with non-blank descriptions; `pageSize` test additionally asserts the description mentions `"200"`.

## Backlog row

`APISIMP-SNAPSHOT-LIST-PARAMS-UNDOCUMENTED` (XS) — filed in fire-115 sweep (`aidocs/agent-findings/apisimp-sweep-2026-06-18-fire115.md`)

## Files changed

| File | Change |
|------|--------|
| `backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotListRest.java` | Added `import org.eclipse.microprofile.openapi.annotations.parameters.Parameter` + `@Parameter` on `collectionAppId` + `page` + `pageSize` |
| `backend/src/test/java/de/dlr/shepard/v2/snapshot/resources/SnapshotListRestTest.java` | Added `import java.util.Arrays`, 3 reflection regression tests, `findListParam()` helper |

## AC

- [x] OpenAPI schema carries a `description` for `collectionAppId` in `GET /v2/snapshots`.
- [x] OpenAPI schema carries a `description` for `page` in `GET /v2/snapshots`.
- [x] OpenAPI schema carries a `description` for `pageSize` in `GET /v2/snapshots`, including the 1–200 clamp.
- [x] `mvn verify -pl backend` green (CI).

---
_Generated by [Claude Code](https://claude.ai/code/session_015kUcy2Vu7p5Xzb7RnLCcWs)_