### PR TITLE
fix(APISIMP-PROJECTS-BYANNOTATION-PARAMS-UNDOCUMENTED): add @Parameter docs to byAnnotation query params

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/project/resources/ProjectsRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/project/resources/ProjectsRest.java
@@ -22,6 +22,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -175,9 +176,34 @@ public class ProjectsRest {
       @PathParam("appId") String appId,
       @PathParam("predicate") String predicate,
       @PathParam("value") String value,
+      @Parameter(
+        description =
+          "Controls what is included in each result row beyond the DataObject identity. " +
+          "Accepted values: `identity` (default) — appId, name, collectionAppId only; " +
+          "`annotations` — additionally populates the per-row `matchedAnnotations` array " +
+          "with the matching predicate+value+source triple(s) for each DataObject."
+      )
       @QueryParam("include") @DefaultValue("identity") String include,
+      @Parameter(
+        description =
+          "When `true` (default), the intent is to walk parent DataObjects in the " +
+          "sub-Collection and include their annotations in the match. " +
+          "NOTE: this flag is accepted on the wire but the parent-walk is not yet " +
+          "implemented — all requests behave as if `inherit=false` until the follow-up " +
+          "lands (tracked in aidocs/16 PROJ-INHERIT-WALK). Wired now so callers can opt " +
+          "in without an API break once the walker ships."
+      )
       @QueryParam("inherit") @DefaultValue("true") boolean inherit,
+      @Parameter(
+        description =
+          "0-based page number. Default 0. Negative values are treated as 0."
+      )
       @QueryParam("page") @DefaultValue("0") int page,
+      @Parameter(
+        description =
+          "Number of results per page. Default 100. Maximum 500. " +
+          "Values above 500 are clamped to 500."
+      )
       @QueryParam("pageSize") @DefaultValue("100") int pageSize) {
 
     if (predicate == null || predicate.isBlank()) {

--- a/backend/src/test/java/de/dlr/shepard/v2/project/resources/ProjectsRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/project/resources/ProjectsRestTest.java
@@ -2,6 +2,7 @@ package de.dlr.shepard.v2.project.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -150,5 +151,70 @@ class ProjectsRestTest {
       "annotations", true, 0, 50);
     assertEquals(200, r.getStatus());
     assertNotNull(r.getEntity());
+  }
+
+  // ─── APISIMP-PROJECTS-BYANNOTATION-PARAMS-UNDOCUMENTED regression ─────────
+
+  private static java.lang.reflect.Parameter findByAnnotationQueryParam(String queryParamName)
+      throws NoSuchMethodException {
+    java.lang.reflect.Method method = ProjectsRest.class.getMethod(
+        "byAnnotation",
+        String.class, String.class, String.class,
+        String.class, boolean.class, int.class, int.class);
+    return java.util.Arrays.stream(method.getParameters())
+        .filter(p -> {
+          var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class);
+          return qp != null && queryParamName.equals(qp.value());
+        })
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Test
+  void byAnnotation_includeParam_hasParameterAnnotationWithDescription()
+      throws NoSuchMethodException {
+    var param = findByAnnotationQueryParam("include");
+    assertNotNull(param, "include must carry @QueryParam");
+    var ann = param.getAnnotation(
+        org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "include must carry @Parameter annotation");
+    assertTrue(ann.description() != null && !ann.description().isBlank(),
+        "@Parameter.description must be non-blank for include");
+  }
+
+  @Test
+  void byAnnotation_inheritParam_hasParameterAnnotationWithNotYetHonouredWarning()
+      throws NoSuchMethodException {
+    var param = findByAnnotationQueryParam("inherit");
+    assertNotNull(param, "inherit must carry @QueryParam");
+    var ann = param.getAnnotation(
+        org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "inherit must carry @Parameter annotation");
+    assertTrue(ann.description() != null && ann.description().contains("not yet"),
+        "@Parameter.description for inherit must mention 'not yet' (not-yet-implemented note)");
+  }
+
+  @Test
+  void byAnnotation_pageParam_hasParameterAnnotationWithDescription()
+      throws NoSuchMethodException {
+    var param = findByAnnotationQueryParam("page");
+    assertNotNull(param, "page must carry @QueryParam");
+    var ann = param.getAnnotation(
+        org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "page must carry @Parameter annotation");
+    assertTrue(ann.description() != null && !ann.description().isBlank(),
+        "@Parameter.description must be non-blank for page");
+  }
+
+  @Test
+  void byAnnotation_pageSizeParam_hasParameterAnnotationWithMaxCap()
+      throws NoSuchMethodException {
+    var param = findByAnnotationQueryParam("pageSize");
+    assertNotNull(param, "pageSize must carry @QueryParam");
+    var ann = param.getAnnotation(
+        org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "pageSize must carry @Parameter annotation");
+    assertTrue(ann.description() != null && ann.description().contains("500"),
+        "@Parameter.description for pageSize must mention the 500 cap");
   }
 }


### PR DESCRIPTION
## Summary

`ProjectsRest.byAnnotation()` accepted four `@QueryParam` params with no `@Parameter` annotation: `include`, `inherit`, `page`, `pageSize`. The `inherit` footgun was especially latent — callers supplying `?inherit=false` saw no effect (parent-walk is not yet implemented) with no OpenAPI-visible warning.

- [x] Add `@Parameter(description=...)` to all four params in `byAnnotation()`
- [x] `inherit` description prominently warns "not yet" implemented, cites follow-up backlog row
- [x] `include` documents accepted values (`identity` / `annotations`)
- [x] `pageSize` documents the max-500 cap
- [x] `page` documents 0-based default
- [x] 4 reflection regression tests added to `ProjectsRestTest` (13 tests total, all pass)
- [x] `aidocs/16` row marked in-progress; doc-stage index regenerated
- [x] No runtime behaviour change

## Checklist
- [x] `mvn test -DnoPlugins -DbootstrapTestjar -Dtest=ProjectsRestTest` → 13/13 PASS
- [x] `mvn -q test-compile -DnoPlugins -DbootstrapTestjar` → BUILD SUCCESS


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lhe87aVmFqC59gkjTATbtn)_