### PR TITLE
feat(APISIMP-IMPORT-CONTEXT-PARAMS-UNDOCUMENTED): document collectionAppId+includeSemanticGraph on getContext

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportV2Rest.java
@@ -41,6 +41,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -204,7 +205,21 @@ public class ImportV2Rest {
   @APIResponse(responseCode = "403", description = "Caller lacks Read permission on the Collection.")
   @APIResponse(responseCode = "404", description = "No Collection with that appId.")
   public Response getContext(
+    @Parameter(
+      description =
+        "appId (UUID v7) of the target Collection. Required. Returns 404 when " +
+        "no Collection with this appId exists. The caller must have Read permission.",
+      required = true
+    )
     @QueryParam("collectionAppId") String collectionAppId,
+    @Parameter(
+      description =
+        "When true, the response body includes the full semantic-annotation graph " +
+        "of the target Collection (predicate IRIs, object values, vocabulary ids). " +
+        "Defaults to false. The false path executes a single Cypher count query " +
+        "and skips all annotation look-ups, making it significantly cheaper for " +
+        "importers that do not need annotation context."
+    )
     @QueryParam("includeSemanticGraph") @DefaultValue("false") boolean includeSemanticGraph,
     @Context SecurityContext sc
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/importer/resources/ImportV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/importer/resources/ImportV2RestTest.java
@@ -406,6 +406,47 @@ class ImportV2RestTest {
     assertEquals(403, r.getStatus());
   }
 
+  // ─── APISIMP-IMPORT-CONTEXT-PARAMS-UNDOCUMENTED regression ──────────────
+
+  @Test
+  void getContext_collectionAppId_paramCarriesParameterAnnotation() throws NoSuchMethodException {
+    java.lang.reflect.Method method = ImportV2Rest.class.getMethod(
+        "getContext", String.class, boolean.class, jakarta.ws.rs.core.SecurityContext.class);
+    java.lang.reflect.Parameter param = java.util.Arrays.stream(method.getParameters())
+        .filter(p -> {
+          var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class);
+          return qp != null && "collectionAppId".equals(qp.value());
+        })
+        .findFirst()
+        .orElse(null);
+    assertNotNull(param, "collectionAppId must carry @QueryParam");
+    var ann = param.getAnnotation(
+        org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "collectionAppId must carry @Parameter annotation");
+    assertTrue(ann.description() != null && !ann.description().isBlank(),
+        "@Parameter.description must be non-blank for collectionAppId");
+    assertTrue(ann.required(), "@Parameter.required must be true for collectionAppId");
+  }
+
+  @Test
+  void getContext_includeSemanticGraph_paramCarriesParameterAnnotation() throws NoSuchMethodException {
+    java.lang.reflect.Method method = ImportV2Rest.class.getMethod(
+        "getContext", String.class, boolean.class, jakarta.ws.rs.core.SecurityContext.class);
+    java.lang.reflect.Parameter param = java.util.Arrays.stream(method.getParameters())
+        .filter(p -> {
+          var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class);
+          return qp != null && "includeSemanticGraph".equals(qp.value());
+        })
+        .findFirst()
+        .orElse(null);
+    assertNotNull(param, "includeSemanticGraph must carry @QueryParam");
+    var ann = param.getAnnotation(
+        org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "includeSemanticGraph must carry @Parameter annotation");
+    assertTrue(ann.description() != null && !ann.description().isBlank(),
+        "@Parameter.description must be non-blank for includeSemanticGraph");
+  }
+
   // ─── Factories ────────────────────────────────────────────────────────────
 
   private ImportManifestIO makeMinimalManifest() {


### PR DESCRIPTION
## Summary

`ImportV2Rest.getContext()` accepts `?collectionAppId=` (required — server already returns 400 when absent) and `?includeSemanticGraph=` (boolean, default false — controls whether the semantic annotation graph is included in the response) with no `@Parameter` annotations. The OpenAPI schema marked `collectionAppId` as optional despite the runtime required check; `includeSemanticGraph` had no documentation at all.

**Changes:**
- Add `@Parameter(description=…, required=true)` to `collectionAppId` in `ImportV2Rest.getContext()`
- Add `@Parameter(description=…)` to `includeSemanticGraph` in `ImportV2Rest.getContext()`
- Import `org.eclipse.microprofile.openapi.annotations.parameters.Parameter`
- 2 reflection regression tests in `ImportV2RestTest` verifying both params carry `@Parameter` with non-blank descriptions
- `aidocs/16`: add `APISIMP-IMPORT-DIAGNOSTICS-FILTER-PARAMS` (READY #2001) and `APISIMP-IMPORT-CONTEXT-PARAMS-UNDOCUMENTED` (dispatched this fire) rows
- `aidocs/16`: update READY statuses for PRs #1997/#1998/#1999/#2000
- Regenerate `aidocs/01-doc-stage-index.md`

No runtime behaviour change. Pure documentation improvement.

## Checklist
- [x] `@Parameter(required=true)` added to `collectionAppId` in `getContext()`
- [x] `@Parameter(description=…)` added to `includeSemanticGraph` in `getContext()`
- [x] 2 reflection regression tests in `ImportV2RestTest`
- [x] `aidocs/16` row `APISIMP-IMPORT-CONTEXT-PARAMS-UNDOCUMENTED` filed; READY statuses updated
- [x] Doc-stage index regenerated
- [x] No v1 `/shepard/api/` surface touched
- [x] No runtime change — annotation-only

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiufUAWDv2D16By79XZSir)_