### PR TITLE
fix(APISIMP-ANNOT-LIST-PARAMS-UNDOCUMENTED): add @Parameter docs to all 6 list() params in SemanticAnnotationV2Rest

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java
@@ -43,6 +43,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -149,11 +150,26 @@ public class SemanticAnnotationV2Rest {
   @APIResponse(responseCode = "400", description = "Bad pagination params (RFC 7807).")
   @APIResponse(responseCode = "401", description = "Authentication required.")
   public Response list(
+    @Parameter(description =
+      "Filter by subject entity appId (UUID v7). Only annotations on this entity are returned. "
+      + "Supply to trigger a single entity-level permission check at the list boundary rather than "
+      + "per-row checks across the full result set.")
     @QueryParam("subjectAppId") String subjectAppId,
+    @Parameter(description =
+      "Narrow to a specific subject entity kind (e.g. 'DataObject', 'Collection', 'Container'). "
+      + "Combined with subjectAppId to disambiguate subjects across entity types.")
     @QueryParam("subjectKind") String subjectKind,
+    @Parameter(description =
+      "Filter by predicate IRI. Only annotations using exactly this predicate IRI are returned "
+      + "(e.g. 'urn:shepard:project:partOf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type').")
     @QueryParam("predicateIri") String predicateIri,
+    @Parameter(description =
+      "Filter by vocabulary identifier. Only annotations whose predicate belongs to this "
+      + "vocabulary are returned.")
     @QueryParam("vocabId") String vocabId,
+    @Parameter(description = "Zero-based page index (default 0).")
     @QueryParam("page") @DefaultValue("0") int page,
+    @Parameter(description = "Page size — number of annotations per page (default 50, range 1–200).")
     @QueryParam("pageSize") @DefaultValue("50") int pageSize,
     @Context SecurityContext sc
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2RestTest.java
@@ -714,6 +714,81 @@ class SemanticAnnotationV2RestTest {
     assertThat(resource.create(body, sc, null).getStatus()).isEqualTo(403);
   }
 
+  // ─── APISIMP-ANNOT-LIST-PARAMS-UNDOCUMENTED — @Parameter reflection gates ─
+
+  /**
+   * APISIMP-ANNOT-LIST-PARAMS-UNDOCUMENTED — verifies that every {@code @QueryParam}
+   * on {@link SemanticAnnotationV2Rest#list} carries a non-blank {@code @Parameter}
+   * description so the generated OpenAPI schema documents all six filters.
+   */
+  @Test
+  void listAnnotations_subjectAppId_paramCarriesParameterAnnotation() throws NoSuchMethodException {
+    var param = findListParam("subjectAppId");
+    assertThat(param).as("subjectAppId must carry @QueryParam").isNotNull();
+    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertThat(ann).as("subjectAppId must carry @Parameter").isNotNull();
+    assertThat(ann.description()).as("@Parameter.description for subjectAppId must be non-blank").isNotBlank();
+  }
+
+  @Test
+  void listAnnotations_subjectKind_paramCarriesParameterAnnotation() throws NoSuchMethodException {
+    var param = findListParam("subjectKind");
+    assertThat(param).as("subjectKind must carry @QueryParam").isNotNull();
+    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertThat(ann).as("subjectKind must carry @Parameter").isNotNull();
+    assertThat(ann.description()).as("@Parameter.description for subjectKind must be non-blank").isNotBlank();
+  }
+
+  @Test
+  void listAnnotations_predicateIri_paramCarriesParameterAnnotation() throws NoSuchMethodException {
+    var param = findListParam("predicateIri");
+    assertThat(param).as("predicateIri must carry @QueryParam").isNotNull();
+    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertThat(ann).as("predicateIri must carry @Parameter").isNotNull();
+    assertThat(ann.description()).as("@Parameter.description for predicateIri must be non-blank").isNotBlank();
+  }
+
+  @Test
+  void listAnnotations_vocabId_paramCarriesParameterAnnotation() throws NoSuchMethodException {
+    var param = findListParam("vocabId");
+    assertThat(param).as("vocabId must carry @QueryParam").isNotNull();
+    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertThat(ann).as("vocabId must carry @Parameter").isNotNull();
+    assertThat(ann.description()).as("@Parameter.description for vocabId must be non-blank").isNotBlank();
+  }
+
+  @Test
+  void listAnnotations_page_paramCarriesParameterAnnotation() throws NoSuchMethodException {
+    var param = findListParam("page");
+    assertThat(param).as("page must carry @QueryParam").isNotNull();
+    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertThat(ann).as("page must carry @Parameter").isNotNull();
+    assertThat(ann.description()).as("@Parameter.description for page must be non-blank").isNotBlank();
+  }
+
+  @Test
+  void listAnnotations_pageSize_paramCarriesParameterAnnotation() throws NoSuchMethodException {
+    var param = findListParam("pageSize");
+    assertThat(param).as("pageSize must carry @QueryParam").isNotNull();
+    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertThat(ann).as("pageSize must carry @Parameter").isNotNull();
+    assertThat(ann.description()).as("@Parameter.description for pageSize must be non-blank").isNotBlank();
+  }
+
+  private static java.lang.reflect.Parameter findListParam(String queryParamName)
+      throws NoSuchMethodException {
+    java.lang.reflect.Method method = SemanticAnnotationV2Rest.class.getMethod(
+        "list", String.class, String.class, String.class, String.class,
+        int.class, int.class, SecurityContext.class);
+    return java.util.Arrays.stream(method.getParameters())
+        .filter(p -> {
+          var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class);
+          return qp != null && queryParamName.equals(qp.value());
+        })
+        .findFirst()
+        .orElse(null);
+  }
+
   // ─── helpers ─────────────────────────────────────────────────────────────
 
   private static SemanticAnnotation annotation(


### PR DESCRIPTION
## Summary

`SemanticAnnotationV2Rest.list()` accepts 6 undocumented `@QueryParam` params — `subjectAppId`, `subjectKind`, `predicateIri`, `vocabId`, `page`, `pageSize` — with no `@Parameter` annotations. The `@Operation` description documents the filters in prose only; the OpenAPI param schema was bare, making API clients and code generators unable to discover param semantics.

**Changes:**
- Import `org.eclipse.microprofile.openapi.annotations.parameters.Parameter`
- Add `@Parameter(description=…)` to all 6 params in `list()`:
  - `subjectAppId` — filter by subject entity appId; enables single permission check at list boundary
  - `subjectKind` — narrow to entity kind (e.g. `DataObject`, `Collection`)
  - `predicateIri` — filter to one predicate IRI
  - `vocabId` — filter to one vocabulary
  - `page` — zero-based page index (default 0)
  - `pageSize` — page size (default 50, range 1–200)
- 6 reflection regression tests in `SemanticAnnotationV2RestTest` verifying each param carries `@Parameter` with a non-blank description
- `aidocs/16`: add `APISIMP-ANNOT-LIST-PARAMS-UNDOCUMENTED` row; promote #1997–#2002 to READY/dispatched in tracker
- Regenerate `aidocs/01-doc-stage-index.md`

No runtime behaviour change. Pure documentation improvement.

## Checklist
- [x] `@Parameter(description=…)` added to all 6 `list()` params
- [x] 6 reflection regression tests in `SemanticAnnotationV2RestTest`
- [x] `aidocs/16` row `APISIMP-ANNOT-LIST-PARAMS-UNDOCUMENTED` filed; READY statuses for #1997–#2002 updated
- [x] Doc-stage index regenerated
- [x] No v1 `/shepard/api/` surface touched
- [x] No runtime change — annotation-only

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vy84ZGyUrNYJw9dbP7nApG)_