### PR TITLE
fix(APISIMP-INSTANCE-ADMIN-AUDIT-PARAMS): document 6 @QueryParams on permission audit log endpoint

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/admin/resources/InstanceAdminRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/resources/InstanceAdminRest.java
@@ -40,6 +40,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -223,11 +224,17 @@ public class InstanceAdminRest {
   @APIResponse(description = "The `from` or `to` query parameter is not a valid ISO-8601 instant string.", responseCode = "400")
   public Response permissionAuditLog(
     @Context SecurityContext securityContext,
+    @Parameter(description = "Optional filter; returns only entries for this entity appId (Collection, DataObject, etc.). Omit to query across all entities.")
     @QueryParam("entityAppId") String entityAppId,
+    @Parameter(description = "Optional filter; returns only entries where the actor username matches exactly. Omit to query across all actors.")
     @QueryParam("actor") String actor,
+    @Parameter(description = "Optional ISO-8601 instant lower bound (inclusive) on occurred_at. Malformed value returns 400. Example: 2026-01-01T00:00:00Z.")
     @QueryParam("from") String from,
+    @Parameter(description = "Optional ISO-8601 instant upper bound (exclusive) on occurred_at. Malformed value returns 400. Example: 2026-02-01T00:00:00Z.")
     @QueryParam("to") String to,
+    @Parameter(description = "Zero-based page index (default 0).")
     @QueryParam("page") @DefaultValue("0") int page,
+    @Parameter(description = "Page size (default 50). Server-side cap: 500 — values above 500 are silently clamped.")
     @QueryParam("pageSize") @DefaultValue("50") int pageSize
   ) {
     requireInstanceAdmin(securityContext);

--- a/backend/src/test/java/de/dlr/shepard/v2/admin/resources/PermissionAuditLogRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/admin/resources/PermissionAuditLogRestTest.java
@@ -18,10 +18,14 @@ import de.dlr.shepard.v2.admin.services.InstanceAdminService;
 import de.dlr.shepard.v2.admin.services.PermissionAuditLogQueryService;
 import de.dlr.shepard.v2.admin.services.PermissionAuditService;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
+import java.lang.reflect.Method;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -166,5 +170,71 @@ class PermissionAuditLogRestTest {
     @SuppressWarnings("unchecked")
     List<PermissionAuditLogEntryIO> body = (List<PermissionAuditLogEntryIO>) r.getEntity();
     assertTrue(body.isEmpty());
+  }
+
+  // ─── APISIMP-INSTANCE-ADMIN-AUDIT-PARAMS regression ──────────────────────
+
+  private static String auditLogParamDesc(String queryParamName) throws NoSuchMethodException {
+    Method method = InstanceAdminRest.class.getMethod(
+        "permissionAuditLog",
+        SecurityContext.class, String.class, String.class,
+        String.class, String.class, int.class, int.class);
+    return Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && queryParamName.equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(
+              org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+  }
+
+  @Test
+  void auditLog_entityAppIdParamHasParameterAnnotation() throws NoSuchMethodException {
+    String desc = auditLogParamDesc("entityAppId");
+    Assertions.assertFalse(desc.isBlank(),
+        "permissionAuditLog() 'entityAppId' must carry a @Parameter description");
+  }
+
+  @Test
+  void auditLog_actorParamHasParameterAnnotation() throws NoSuchMethodException {
+    String desc = auditLogParamDesc("actor");
+    Assertions.assertFalse(desc.isBlank(),
+        "permissionAuditLog() 'actor' must carry a @Parameter description");
+  }
+
+  @Test
+  void auditLog_fromParamDescriptionMentions400() throws NoSuchMethodException {
+    String desc = auditLogParamDesc("from");
+    Assertions.assertFalse(desc.isBlank(),
+        "permissionAuditLog() 'from' must carry a @Parameter description");
+    Assertions.assertTrue(desc.contains("400"),
+        "permissionAuditLog() 'from' description must mention 400 (parse-error behaviour)");
+  }
+
+  @Test
+  void auditLog_toParamDescriptionMentions400() throws NoSuchMethodException {
+    String desc = auditLogParamDesc("to");
+    Assertions.assertFalse(desc.isBlank(),
+        "permissionAuditLog() 'to' must carry a @Parameter description");
+    Assertions.assertTrue(desc.contains("400"),
+        "permissionAuditLog() 'to' description must mention 400 (parse-error behaviour)");
+  }
+
+  @Test
+  void auditLog_pageParamHasParameterAnnotation() throws NoSuchMethodException {
+    String desc = auditLogParamDesc("page");
+    Assertions.assertFalse(desc.isBlank(),
+        "permissionAuditLog() 'page' must carry a @Parameter description");
+  }
+
+  @Test
+  void auditLog_pageSizeParamDescriptionMentions500() throws NoSuchMethodException {
+    String desc = auditLogParamDesc("pageSize");
+    Assertions.assertFalse(desc.isBlank(),
+        "permissionAuditLog() 'pageSize' must carry a @Parameter description");
+    Assertions.assertTrue(desc.contains("500"),
+        "permissionAuditLog() 'pageSize' description must mention the 500 server-side cap");
   }
 }


### PR DESCRIPTION
## Summary

`InstanceAdminRest.permissionAuditLog()` (`GET /v2/admin/permission-audit/log`) had 6 bare `@QueryParam` annotations — no `@Parameter` OpenAPI descriptions. This is the admin audit-trail endpoint gated by `@RolesAllowed("instance-admin")`.

**`InstanceAdminRest.permissionAuditLog()`** — 6 params:
- `entityAppId` — optional filter; returns only entries for this entity appId
- `actor` — optional filter; returns only entries for this actor username
- `from` — ISO-8601 instant lower bound (inclusive); **parse failure returns 400** — now documented
- `to` — ISO-8601 instant upper bound (exclusive); **parse failure returns 400** — now documented
- `page` — zero-based page index, default 0
- `pageSize` — default 50; **server-side cap: 500** — now documented (enforced in `PermissionAuditLogQueryService.query()` via `Math.min(..., 500)`)

The `from`/`to` 400 behaviour and the `pageSize` 500 cap were previously invisible to a caller relying only on the generated OpenAPI schema.

No runtime behaviour changed — annotation-only additions.

## Changes

- `InstanceAdminRest.java`: `import Parameter` + 6 `@Parameter` annotations on `permissionAuditLog()` params
- `PermissionAuditLogRestTest.java`: 4 new imports + `auditLogParamDesc()` helper + 6 reflection regression tests:
  - `entityAppId`, `actor`, `page` — assert description is non-blank
  - `from`, `to` — additionally assert description contains `"400"` (parse-error behaviour)
  - `pageSize` — additionally asserts description contains `"500"` (server cap)
- `aidocs/16`: add `APISIMP-COLLECTION-SNAPSHOT-LABJ-PARAMS-UNDOCUMENTED` (🔄 fire-125 PR #2008), `APISIMP-INSTANCE-ADMIN-AUDIT-PARAMS` (🔄 this fire), and 5 new QUEUED rows for the next wave
- `aidocs/01-doc-stage-index.md`: regenerated

## Checklist

- [x] No runtime behaviour change — annotation-only additions
- [x] 6 reflection regression tests added; `from`/`to` tests assert the 400 parse-error behaviour is documented; `pageSize` test asserts the 500 cap is documented
- [x] 6 new `APISIMP-*` backlog rows filed for the next wave (CONTAINERS-V2-1, CONTAINERS-V2-2, BUNDLE-REF-PARAMS, SPARQL-QUERY-PARAM)
- [x] `aidocs/01-doc-stage-index.md` regenerated
- [x] No v1 `/shepard/api/` surface touched

🤖 fire-126 dispatch — APISIMP series

---
_Generated by [Claude Code](https://claude.ai/code/session_018GQLHW1koVQ4vHUu3Np1Mw)_