### PR TITLE
fix(APISIMP-CONTAINERS-V2-PARAMS-UNDOCUMENTED-1): document 4 @QueryParams on create/delete/list in ContainersV2Rest

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -140,7 +140,11 @@ public class ContainersV2Rest {
   )
   @APIResponse(responseCode = "400", description = "Unknown/uninstalled kind or invalid body.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
-  public Response create(@QueryParam("kind") String kind, JsonNode body, @Context SecurityContext sc) {
+  public Response create(
+    @Parameter(required = true, description = "Container kind to create: `file` | `timeseries` | `structured-data`. Returns 400 for unknown or uninstalled kinds.")
+    @QueryParam("kind") String kind,
+    JsonNode body,
+    @Context SecurityContext sc) {
     String caller = callerOrNull(sc);
     if (caller == null) return problem(PROBLEM_TYPE_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, "No valid JWT or API key was provided");
     if (kind == null || kind.isBlank()) {
@@ -334,6 +338,7 @@ public class ContainersV2Rest {
   @APIResponse(responseCode = "404", description = "No container with that appId.")
   public Response delete(
     @PathParam("appId") String appId,
+    @Parameter(description = "When `true`, deletes the container even if it has active DataObject references (those references are orphaned). Defaults to `false` (safe-delete: 409 if references exist).")
     @QueryParam("force") @DefaultValue("false") boolean force,
     @Context SecurityContext sc
   ) {
@@ -387,7 +392,9 @@ public class ContainersV2Rest {
   @APIResponse(responseCode = "400", description = "Missing/unknown kind.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
   public Response list(
+    @Parameter(required = true, description = "Container kind to list: `file` | `timeseries` | `structured-data`. Returns 400 when absent or unrecognised.")
     @QueryParam("kind") String kind,
+    @Parameter(description = "Optional substring filter on container name. Case-sensitive. Omit to return all containers of the given kind.")
     @QueryParam("name") String name,
     @Context SecurityContext sc
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
@@ -718,4 +718,64 @@ class ContainersV2RestTest {
         desc.isBlank(),
         "maxPoints @Parameter description must be present and non-blank — got: '" + desc + "'");
   }
+
+  // ─── APISIMP-CONTAINERS-V2-PARAMS-UNDOCUMENTED-1 regression ─────────────────
+
+  @Test
+  void create_kindParamIsRequiredAndDescribed() {
+    var method = Arrays.stream(ContainersV2Rest.class.getMethods())
+        .filter(m -> m.getName().equals("create"))
+        .findFirst().orElseThrow();
+    var ann = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "kind".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class))
+        .findFirst().orElse(null);
+    org.junit.jupiter.api.Assertions.assertNotNull(ann, "create() kind @QueryParam must have @Parameter");
+    org.junit.jupiter.api.Assertions.assertTrue(ann.required(), "create() kind must be required=true");
+    org.junit.jupiter.api.Assertions.assertFalse(ann.description().isBlank(), "create() kind description must be non-blank");
+  }
+
+  @Test
+  void delete_forceParamIsDescribed() {
+    var method = Arrays.stream(ContainersV2Rest.class.getMethods())
+        .filter(m -> m.getName().equals("delete"))
+        .findFirst().orElseThrow();
+    var ann = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "force".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class))
+        .findFirst().orElse(null);
+    org.junit.jupiter.api.Assertions.assertNotNull(ann, "delete() force @QueryParam must have @Parameter");
+    org.junit.jupiter.api.Assertions.assertFalse(ann.description().isBlank(), "delete() force description must be non-blank");
+  }
+
+  @Test
+  void list_kindParamIsRequiredAndDescribed() {
+    var method = Arrays.stream(ContainersV2Rest.class.getMethods())
+        .filter(m -> m.getName().equals("list"))
+        .findFirst().orElseThrow();
+    var kindAnn = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "kind".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class))
+        .findFirst().orElse(null);
+    org.junit.jupiter.api.Assertions.assertNotNull(kindAnn, "list() kind @QueryParam must have @Parameter");
+    org.junit.jupiter.api.Assertions.assertTrue(kindAnn.required(), "list() kind must be required=true");
+    org.junit.jupiter.api.Assertions.assertFalse(kindAnn.description().isBlank(), "list() kind description must be non-blank");
+  }
+
+  @Test
+  void list_nameParamIsDescribed() {
+    var method = Arrays.stream(ContainersV2Rest.class.getMethods())
+        .filter(m -> m.getName().equals("list"))
+        .findFirst().orElseThrow();
+    var nameAnn = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "name".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class))
+        .findFirst().orElse(null);
+    org.junit.jupiter.api.Assertions.assertNotNull(nameAnn, "list() name @QueryParam must have @Parameter");
+    org.junit.jupiter.api.Assertions.assertFalse(nameAnn.description().isBlank(), "list() name description must be non-blank");
+  }
 }


### PR DESCRIPTION
## Summary

`ContainersV2Rest.create()`, `delete()`, and `list()` each had undocumented `@QueryParam` parameters — callers relying only on the generated OpenAPI schema could not tell:
- which params are required (both `kind` params return 400 when absent, but the schema marked them as optional)
- what valid kind values are (`file` | `timeseries` | `structured-data`)
- what `force=true` does in the delete path (safe-delete vs. force-delete semantics)
- that `list.name` is an optional substring filter, not an exact match

No runtime behaviour changed — annotation-only additions.

## Changes

- `ContainersV2Rest.java`: add `@Parameter(required=true, description=…)` to `create.kind` and `list.kind`; add `@Parameter(description=…)` to `delete.force` and `list.name`
- `ContainersV2RestTest.java`: 4 reflection regression tests asserting each `@Parameter` is present, has a non-blank description, and (for required params) has `required=true`
- `aidocs/16`: file `APISIMP-CONTAINERS-V2-PARAMS-UNDOCUMENTED-1` (this PR, in-progress), `APISIMP-CONTAINERS-V2-PARAMS-UNDOCUMENTED-2` (queued — listChannels.page/pageSize + getLiveWindow 8-tuple), `APISIMP-BUNDLE-REF-PARAMS-UNDOCUMENTED` (queued)
- `aidocs/01-doc-stage-index.md`: regenerated (469 docs)

## Checklist

- [x] No runtime behaviour change — annotation-only addition
- [x] 4 reflection regression tests added (`create_kindParamIsRequiredAndDescribed`, `delete_forceParamIsDescribed`, `list_kindParamIsRequiredAndDescribed`, `list_nameParamIsDescribed`)
- [x] `aidocs/16` updated: CONTAINERS-V2-PARAMS-UNDOCUMENTED-1 filed (in-progress), -2 and BUNDLE-REF queued
- [x] `aidocs/01-doc-stage-index.md` regenerated
- [x] No v1 `/shepard/api/` surface touched
- [x] `@Parameter` import already present in `ContainersV2Rest.java` (line 60) — no new import needed

🤖 fire-127 dispatch — APISIMP series

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqMrTCmYjaAjp7NkozS7Rh)_