### PR TITLE
fix(APISIMP-CONTAINERS-V2-PARAMS-UNDOCUMENTED-2): document 10 @QueryParams on listChannels + getLiveWindow

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -569,7 +569,9 @@ public class ContainersV2Rest {
   @APIResponse(responseCode = "415", description = "This container kind has no channel concept.")
   public Response listChannels(
     @PathParam("appId") String appId,
+    @Parameter(description = "0-based page index. Default `0`. Values past the last page return an empty items list.")
     @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
+    @Parameter(description = "Number of channels per page. Default `200`. Must be >= 0.")
     @QueryParam("pageSize") @DefaultValue("200") @PositiveOrZero int pageSize,
     @Context SecurityContext sc
   ) {
@@ -879,13 +881,24 @@ public class ContainersV2Rest {
   @APIResponse(responseCode = "415", description = "This container kind has no live-window concept.")
   public Response getLiveWindow(
       @PathParam("appId") String appId,
+      @Parameter(description = "Preferred channel selector: the UUID v7 shepardId of the channel. " +
+        "Takes precedence over the 5-tuple (measurement/device/location/symbolicName/field). " +
+        "Exactly one of shepardId or a complete 5-tuple must be supplied.")
       @QueryParam("shepardId") UUID shepardId,
+      @Parameter(description = "5-tuple selector — measurement component. Required when shepardId is absent.")
       @QueryParam("measurement") String measurement,
+      @Parameter(description = "5-tuple selector — device component. Required when shepardId is absent.")
       @QueryParam("device") String device,
+      @Parameter(description = "5-tuple selector — location component. Required when shepardId is absent.")
       @QueryParam("location") String location,
+      @Parameter(description = "5-tuple selector — symbolicName component. Required when shepardId is absent.")
       @QueryParam("symbolicName") String symbolicName,
+      @Parameter(description = "5-tuple selector — field component. Required when shepardId is absent.")
       @QueryParam("field") String field,
+      @Parameter(description = "Window size in seconds. Default `300`. Min `1`, max `3600`.")
       @QueryParam("windowSeconds") @DefaultValue("300") @Min(1) @Max(3600) int windowSeconds,
+      @Parameter(description = "When `true` (default), the response includes the first point before and " +
+        "the first point after the window boundary so charts render continuous lines.")
       @QueryParam("withBoundaryPoints") @DefaultValue("true") boolean withBoundaryPoints,
       @Context SecurityContext sc
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
@@ -778,4 +778,99 @@ class ContainersV2RestTest {
     org.junit.jupiter.api.Assertions.assertNotNull(nameAnn, "list() name @QueryParam must have @Parameter");
     org.junit.jupiter.api.Assertions.assertFalse(nameAnn.description().isBlank(), "list() name description must be non-blank");
   }
+
+  // ─── APISIMP-CONTAINERS-V2-PARAMS-UNDOCUMENTED-2 regression ─────────────────
+
+  @Test
+  void listChannels_pageParamHasParameterAnnotation() throws NoSuchMethodException {
+    Method method = ContainersV2Rest.class.getMethod(
+        "listChannels", String.class, int.class, int.class,
+        jakarta.ws.rs.core.SecurityContext.class);
+    String desc = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "page".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+    org.junit.jupiter.api.Assertions.assertFalse(
+        desc.isBlank(),
+        "listChannels page @Parameter description must be present and non-blank — got: '" + desc + "'");
+  }
+
+  @Test
+  void listChannels_pageSizeParamHasParameterAnnotation() throws NoSuchMethodException {
+    Method method = ContainersV2Rest.class.getMethod(
+        "listChannels", String.class, int.class, int.class,
+        jakarta.ws.rs.core.SecurityContext.class);
+    String desc = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "pageSize".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+    org.junit.jupiter.api.Assertions.assertFalse(
+        desc.isBlank(),
+        "listChannels pageSize @Parameter description must be present and non-blank — got: '" + desc + "'");
+  }
+
+  @Test
+  void getLiveWindow_shepardIdParamHasParameterAnnotation() throws NoSuchMethodException {
+    Method method = ContainersV2Rest.class.getMethod(
+        "getLiveWindow", String.class, UUID.class,
+        String.class, String.class, String.class, String.class, String.class,
+        int.class, boolean.class, jakarta.ws.rs.core.SecurityContext.class);
+    String desc = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "shepardId".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+    org.junit.jupiter.api.Assertions.assertFalse(
+        desc.isBlank(),
+        "getLiveWindow shepardId @Parameter description must be present — got: '" + desc + "'");
+  }
+
+  @Test
+  void getLiveWindow_windowSecondsParamHasParameterAnnotation() throws NoSuchMethodException {
+    Method method = ContainersV2Rest.class.getMethod(
+        "getLiveWindow", String.class, UUID.class,
+        String.class, String.class, String.class, String.class, String.class,
+        int.class, boolean.class, jakarta.ws.rs.core.SecurityContext.class);
+    String desc = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "windowSeconds".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+    org.junit.jupiter.api.Assertions.assertFalse(
+        desc.isBlank(),
+        "getLiveWindow windowSeconds @Parameter description must be present — got: '" + desc + "'");
+  }
+
+  @Test
+  void getLiveWindow_withBoundaryPointsParamHasParameterAnnotation() throws NoSuchMethodException {
+    Method method = ContainersV2Rest.class.getMethod(
+        "getLiveWindow", String.class, UUID.class,
+        String.class, String.class, String.class, String.class, String.class,
+        int.class, boolean.class, jakarta.ws.rs.core.SecurityContext.class);
+    String desc = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "withBoundaryPoints".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+    org.junit.jupiter.api.Assertions.assertFalse(
+        desc.isBlank(),
+        "getLiveWindow withBoundaryPoints @Parameter description must be present — got: '" + desc + "'");
+  }
 }


### PR DESCRIPTION
## Summary

Continuation of APISIMP-CONTAINERS-V2-PARAMS-UNDOCUMENTED sweep (slice -1 = PR #2011, slice -2 = this PR).

Documents 10 previously bare `@QueryParam` parameters in `ContainersV2Rest`:

**`listChannels`** (2 params):
- `page` — 0-based page index, default `0`, `@PositiveOrZero`
- `pageSize` — channels per page, default `200`, `@PositiveOrZero`

**`getLiveWindow`** (8 params):
- `shepardId` — UUID v7 preferred channel selector; takes precedence over 5-tuple; exactly one of shepardId or complete 5-tuple required
- `measurement`, `device`, `location`, `symbolicName`, `field` — 5-tuple fallback channel selectors
- `windowSeconds` — window size in seconds; default `300`, min `1`, max `3600`
- `withBoundaryPoints` — include boundary points for continuous chart lines; default `true`

No runtime behaviour changed — annotation-only additions.

## Changes

- `ContainersV2Rest.java`: `@Parameter(description=…)` on all 10 params
- `ContainersV2RestTest.java`: 5 new reflection regression tests
- `aidocs/16`: APISIMP-CONTAINERS-V2-PARAMS-UNDOCUMENTED-2 → in-progress; APISIMP-BUNDLE-REF-PARAMS-UNDOCUMENTED filed as queued
- `aidocs/01-doc-stage-index.md`: regenerated

## Checklist

- [x] Annotation-only — no runtime behaviour change
- [x] 5 new regression tests in `ContainersV2RestTest`
- [x] `aidocs/16` updated + doc-stage index regenerated
- [x] Branches from `main`; no v1 surface touched

⚠️ **Orchestrator note:** `aidocs/16` in this PR adds the CONTAINERS-V2-PARAMS-UNDOCUMENTED-2 and BUNDLE-REF rows. PRs #2010 and #2011 also add these rows (as `queued`). Merge #2010 → rebase #2011 → rebase this PR to resolve the one-row conflict in `aidocs/16` (change `queued` to `in-progress` for the CONTAINERS-V2-2 row).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXtYxpUJYim6dMrcsLTVjA)_