### PR TITLE
docs(APISIMP-PROVENANCE-PROV-VARIANT-PARAMS): @Parameter annotations on ProvenanceRest content-negotiation variants

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
@@ -154,12 +154,14 @@ public class ProvenanceRest {
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller asked for another user's rows without instance-admin role.")
   public Response listActivitiesProvJson(
+    @Parameter(description = "Filter to a specific Agent's activities. Casual users may only pass their own username.")
     @QueryParam("agent") String agent,
+    @Parameter(description = "Filter to a specific target-entity kind, e.g. 'Collection' or 'DataObject'.")
     @QueryParam("targetKind") String targetKind,
-    @QueryParam("targetAppId") String targetAppId,
-    @QueryParam("since") Long since,
-    @QueryParam("until") Long until,
-    @QueryParam("pageSize") Integer pageSize,
+    @Parameter(description = "Filter to a specific target-entity appId.") @QueryParam("targetAppId") String targetAppId,
+    @Parameter(description = "Inclusive lower bound on startedAt (millis since epoch).") @QueryParam("since") Long since,
+    @Parameter(description = "Inclusive upper bound on startedAt (millis since epoch).") @QueryParam("until") Long until,
+    @Parameter(description = "Max rows (pageSize). Defaults to 100; capped at 1000.") @QueryParam("pageSize") Integer pageSize,
     @Context SecurityContext securityContext
   ) {
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
@@ -193,12 +195,14 @@ public class ProvenanceRest {
   @APIResponse(responseCode = "403", description = "Caller asked for another user's rows without instance-admin role.")
   @APIResponse(responseCode = "406", description = "Unknown profile= parameter on the Accept header.")
   public Response listActivitiesJsonLd(
+    @Parameter(description = "Filter to a specific Agent's activities. Casual users may only pass their own username.")
     @QueryParam("agent") String agent,
+    @Parameter(description = "Filter to a specific target-entity kind, e.g. 'Collection' or 'DataObject'.")
     @QueryParam("targetKind") String targetKind,
-    @QueryParam("targetAppId") String targetAppId,
-    @QueryParam("since") Long since,
-    @QueryParam("until") Long until,
-    @QueryParam("pageSize") Integer pageSize,
+    @Parameter(description = "Filter to a specific target-entity appId.") @QueryParam("targetAppId") String targetAppId,
+    @Parameter(description = "Inclusive lower bound on startedAt (millis since epoch).") @QueryParam("since") Long since,
+    @Parameter(description = "Inclusive upper bound on startedAt (millis since epoch).") @QueryParam("until") Long until,
+    @Parameter(description = "Max rows (pageSize). Defaults to 100; capped at 1000.") @QueryParam("pageSize") Integer pageSize,
     @HeaderParam(HttpHeaders.ACCEPT) String acceptHeader,
     @Context SecurityContext securityContext
   ) {
@@ -273,10 +277,10 @@ public class ProvenanceRest {
   @APIResponse(responseCode = "200", description = "Activities serialised as PROV-JSON.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
   public Response listEntityActivitiesProvJson(
-    @PathParam("appId") String entityAppId,
-    @QueryParam("since") Long since,
-    @QueryParam("until") Long until,
-    @QueryParam("pageSize") Integer pageSize,
+    @Parameter(description = "Target entity's appId.", required = true) @PathParam("appId") String entityAppId,
+    @Parameter(description = "Inclusive lower bound on startedAt (millis since epoch).") @QueryParam("since") Long since,
+    @Parameter(description = "Inclusive upper bound on startedAt (millis since epoch).") @QueryParam("until") Long until,
+    @Parameter(description = "Max rows (pageSize). Defaults to 100; capped at 1000.") @QueryParam("pageSize") Integer pageSize,
     @Context SecurityContext securityContext
   ) {
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
@@ -303,10 +307,10 @@ public class ProvenanceRest {
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "406", description = "Unknown profile= parameter on the Accept header.")
   public Response listEntityActivitiesJsonLd(
-    @PathParam("appId") String entityAppId,
-    @QueryParam("since") Long since,
-    @QueryParam("until") Long until,
-    @QueryParam("pageSize") Integer pageSize,
+    @Parameter(description = "Target entity's appId.", required = true) @PathParam("appId") String entityAppId,
+    @Parameter(description = "Inclusive lower bound on startedAt (millis since epoch).") @QueryParam("since") Long since,
+    @Parameter(description = "Inclusive upper bound on startedAt (millis since epoch).") @QueryParam("until") Long until,
+    @Parameter(description = "Max rows (pageSize). Defaults to 100; capped at 1000.") @QueryParam("pageSize") Integer pageSize,
     @HeaderParam(HttpHeaders.ACCEPT) String acceptHeader,
     @Context SecurityContext securityContext
   ) {
@@ -374,11 +378,13 @@ public class ProvenanceRest {
   @APIResponse(responseCode = "403", description = "Caller asked for another user's rows without instance-admin role.")
   @APIResponse(responseCode = "406", description = "Unknown profile= parameter on the Accept header.")
   public Response countActivitiesJsonLd(
+    @Parameter(description = "Filter to a specific Agent's activities. Casual users may only pass their own username.")
     @QueryParam("agent") String agent,
+    @Parameter(description = "Filter to a specific target-entity kind, e.g. 'Collection' or 'DataObject'.")
     @QueryParam("targetKind") String targetKind,
-    @QueryParam("targetAppId") String targetAppId,
-    @QueryParam("since") Long since,
-    @QueryParam("until") Long until,
+    @Parameter(description = "Filter to a specific target-entity appId.") @QueryParam("targetAppId") String targetAppId,
+    @Parameter(description = "Inclusive lower bound on startedAt (millis since epoch).") @QueryParam("since") Long since,
+    @Parameter(description = "Inclusive upper bound on startedAt (millis since epoch).") @QueryParam("until") Long until,
     @HeaderParam(HttpHeaders.ACCEPT) String acceptHeader,
     @Context SecurityContext securityContext
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestParamDocTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestParamDocTest.java
@@ -1,0 +1,104 @@
+package de.dlr.shepard.v2.provenance.resources;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.SecurityContext;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * APISIMP-PROVENANCE-PROV-VARIANT-PARAMS — reflection regression tests
+ * asserting that every {@code @QueryParam} on the five content-negotiation
+ * variant methods in {@link ProvenanceRest} carries a non-blank
+ * {@code @Parameter} description.
+ *
+ * <p>The primary JSON {@code listActivities()} method was already documented;
+ * these tests guard the PROV-JSON and JSON-LD variants that were missing the
+ * same annotations.
+ */
+class ProvenanceRestParamDocTest {
+
+  /** Find the first method parameter annotated {@code @QueryParam(name)}. */
+  private static java.lang.reflect.Parameter queryParam(Method m, String name) {
+    return Arrays.stream(m.getParameters())
+      .filter(p -> {
+        QueryParam qp = p.getAnnotation(QueryParam.class);
+        return qp != null && name.equals(qp.value());
+      })
+      .findFirst()
+      .orElse(null);
+  }
+
+  private static void assertDocumented(Method m, String paramName) {
+    java.lang.reflect.Parameter p = queryParam(m, paramName);
+    assertNotNull(p, "@QueryParam(\"" + paramName + "\") not found on " + m.getName());
+    Parameter ann = p.getAnnotation(Parameter.class);
+    assertNotNull(ann, "@Parameter missing on '" + paramName + "' in " + m.getName());
+    assertTrue(
+      ann.description() != null && !ann.description().isBlank(),
+      "@Parameter.description must be non-blank for '" + paramName + "' in " + m.getName()
+    );
+  }
+
+  // ── listActivitiesProvJson ────────────────────────────────────────────────
+
+  @Test
+  void listActivitiesProvJson_agentParam_isDocumented() throws NoSuchMethodException {
+    Method m = ProvenanceRest.class.getMethod(
+      "listActivitiesProvJson",
+      String.class, String.class, String.class, Long.class, Long.class, Integer.class,
+      SecurityContext.class
+    );
+    assertDocumented(m, "agent");
+  }
+
+  // ── listActivitiesJsonLd ──────────────────────────────────────────────────
+
+  @Test
+  void listActivitiesJsonLd_pageSize_isDocumented() throws NoSuchMethodException {
+    Method m = ProvenanceRest.class.getMethod(
+      "listActivitiesJsonLd",
+      String.class, String.class, String.class, Long.class, Long.class, Integer.class,
+      String.class, SecurityContext.class
+    );
+    assertDocumented(m, "pageSize");
+  }
+
+  // ── listEntityActivitiesProvJson ──────────────────────────────────────────
+
+  @Test
+  void listEntityActivitiesProvJson_since_isDocumented() throws NoSuchMethodException {
+    Method m = ProvenanceRest.class.getMethod(
+      "listEntityActivitiesProvJson",
+      String.class, Long.class, Long.class, Integer.class, SecurityContext.class
+    );
+    assertDocumented(m, "since");
+  }
+
+  // ── listEntityActivitiesJsonLd ────────────────────────────────────────────
+
+  @Test
+  void listEntityActivitiesJsonLd_pageSize_isDocumented() throws NoSuchMethodException {
+    Method m = ProvenanceRest.class.getMethod(
+      "listEntityActivitiesJsonLd",
+      String.class, Long.class, Long.class, Integer.class, String.class, SecurityContext.class
+    );
+    assertDocumented(m, "pageSize");
+  }
+
+  // ── countActivitiesJsonLd ─────────────────────────────────────────────────
+
+  @Test
+  void countActivitiesJsonLd_targetKind_isDocumented() throws NoSuchMethodException {
+    Method m = ProvenanceRest.class.getMethod(
+      "countActivitiesJsonLd",
+      String.class, String.class, String.class, Long.class, Long.class,
+      String.class, SecurityContext.class
+    );
+    assertDocumented(m, "targetKind");
+  }
+}


### PR DESCRIPTION
## Summary

- **Row**: `APISIMP-PROVENANCE-PROV-VARIANT-PARAMS` (APISIMP sweep)
- **Scope**: annotation-only, no runtime behaviour change

### What changed

`ProvenanceRest` has one primary JSON `listActivities()` method whose 6 `@QueryParam` params were already fully annotated with `@Parameter(description=...)`. The 5 content-negotiation variant methods (PROV-JSON list, JSON-LD list, PROV-JSON entity, JSON-LD entity, JSON-LD count) had 23 bare `@QueryParam` params with no OpenAPI documentation.

This PR mirrors the descriptions from the primary method to each variant:

| Method | Params documented |
|---|---|
| `listActivitiesProvJson` | agent, targetKind, targetAppId, since, until, pageSize |
| `listActivitiesJsonLd` | agent, targetKind, targetAppId, since, until, pageSize |
| `listEntityActivitiesProvJson` | since, until, pageSize |
| `listEntityActivitiesJsonLd` | since, until, pageSize |
| `countActivitiesJsonLd` | agent, targetKind, targetAppId, since, until |

Also adds `ProvenanceRestParamDocTest`: 5 reflection regression tests (one per variant) that assert a representative `@QueryParam` carries a non-blank `@Parameter` description — same pattern as `CollectionTimelineRestTest`.

## Test plan

- [x] `cd backend && ./mvnw -B -DnoPlugins -DbootstrapTestjar test-compile` — passes
- [ ] CI `mvn verify` — check runs green (annotation-only change; tests use reflection to guard docs)
- [x] No runtime behaviour change — annotations are OpenAPI metadata only

## Notes

Depends on nothing; no migration required. Part of the APISIMP sweep documented in `aidocs/platform/191-v2-surface-convergence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvrQixvyA4hspSELsjW7vF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvrQixvyA4hspSELsjW7vF)_