### PR TITLE
feat(APISIMP): document depth param on predecessor/successor chain endpoints

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
@@ -62,6 +62,7 @@ import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -789,6 +790,7 @@ public class DataObjectV2Rest {
   public Response predecessorChain(
     @PathParam("collectionAppId") @NotBlank String collectionAppId,
     @PathParam("dataObjectAppId") @NotBlank String dataObjectAppId,
+    @Parameter(description = "Maximum chain depth (default 10). Clamped server-side to [1, 50] — values below 1 become 1; values above 50 are silently clamped to 50.")
     @QueryParam("depth") @DefaultValue("10") @PositiveOrZero int depth,
     @Context SecurityContext sc
   ) {
@@ -826,6 +828,7 @@ public class DataObjectV2Rest {
   public Response successorChain(
     @PathParam("collectionAppId") @NotBlank String collectionAppId,
     @PathParam("dataObjectAppId") @NotBlank String dataObjectAppId,
+    @Parameter(description = "Maximum chain depth (default 10). Clamped server-side to [1, 50] — values below 1 become 1; values above 50 are silently clamped to 50.")
     @QueryParam("depth") @DefaultValue("10") @PositiveOrZero int depth,
     @Context SecurityContext sc
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2RestTest.java
@@ -32,9 +32,12 @@ import de.dlr.shepard.v2.dataobject.io.DataObjectListItemV2IO;
 import de.dlr.shepard.v2.dataobject.io.DataObjectSummaryIO;
 import jakarta.validation.Validator;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
+import java.lang.reflect.Method;
 import java.security.Principal;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -914,6 +917,44 @@ class DataObjectV2RestTest {
     Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "appId, name , createdAt", securityContext);
     assertEquals(200, r.getStatus());
     assertEquals("fields", r.getHeaders().getFirst("X-Shepard-Payload-Diet"));
+  }
+
+  // ── APISIMP-DO-CHAIN-DEPTH-PARAM regression ──────────────────────────────
+
+  @Test
+  void predecessorChain_depthParamIsDocumented() throws NoSuchMethodException {
+    Method method = DataObjectV2Rest.class.getMethod(
+        "predecessorChain", String.class, String.class, int.class,
+        jakarta.ws.rs.core.SecurityContext.class);
+    String desc = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "depth".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+    org.junit.jupiter.api.Assertions.assertFalse(
+        desc.isBlank(),
+        "predecessorChain depth @Parameter description must be present and non-blank — got: '" + desc + "'");
+  }
+
+  @Test
+  void successorChain_depthParamIsDocumented() throws NoSuchMethodException {
+    Method method = DataObjectV2Rest.class.getMethod(
+        "successorChain", String.class, String.class, int.class,
+        jakarta.ws.rs.core.SecurityContext.class);
+    String desc = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "depth".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+    org.junit.jupiter.api.Assertions.assertFalse(
+        desc.isBlank(),
+        "successorChain depth @Parameter description must be present and non-blank — got: '" + desc + "'");
   }
 
   @Test


### PR DESCRIPTION
## APISIMP-DO-CHAIN-DEPTH-PARAM — fire-140

### What

Add `@Parameter(description=...)` to the `depth` query parameter on
`predecessorChain()` and `successorChain()` in `DataObjectV2Rest`.

### Why

The DAO (`DataObjectDAO.java:538,560`) clamps `depth` server-side to `[1, 50]`
via `Math.max(1, Math.min(depth, 50))`. A caller supplying `?depth=200` silently
receives at most 50 hops with no indication from the OpenAPI schema why. The
`@Operation` description on both methods documented the cap in prose; the per-param
OpenAPI schema was bare.

### Changes

**`DataObjectV2Rest.java`**
- Added `import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;`
- Added `@Parameter(description="Maximum chain depth (default 10). Clamped server-side to [1, 50] — values below 1 become 1; values above 50 are silently clamped to 50.")` to `depth` in `predecessorChain()` and `successorChain()`

**`DataObjectV2RestTest.java`**
- Added `predecessorChain_depthParamIsDocumented` — reflection test
- Added `successorChain_depthParamIsDocumented` — reflection test
- 48 tests pass (was 46 before; +2 new)

### No runtime change

Annotation-only fix. Zero wire-shape modification.

### Checklist

- [x] `@Parameter` description present and non-blank on both chain methods
- [x] 2 reflection regression tests prevent silent removal
- [x] 48 unit tests pass (`DataObjectV2RestTest`)
- [x] Backlog row filed: `APISIMP-DO-CHAIN-DEPTH-PARAM` (fire-140 sweep commit)


---
_Generated by [Claude Code](https://claude.ai/code/session_01474j9gaTgZ2nehHXnUDyB7)_