### PR TITLE
feat(apisimp): document getThumbnail size @QueryParam (APISIMP-CONTAINERS-THUMBNAIL-SIZE-PARAM)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -1338,6 +1338,7 @@ public class ContainersV2Rest {
   public Response getThumbnail(
     @PathParam("appId") String appId,
     @PathParam("oid") String oid,
+    @Parameter(description = "Thumbnail pixel size. Accepted values: 64, 200, 400. Any other value (including absent) is normalised to 400.")
     @QueryParam("size") Integer size,
     @Context SecurityContext sc
   ) {

--- a/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
@@ -623,6 +623,26 @@ class ContainersV2RestTest {
     assertEquals("size", actual);
   }
 
+  // ─── APISIMP-CONTAINERS-THUMBNAIL-SIZE-PARAM regression ──────────────────────
+
+  @Test
+  void getThumbnail_sizeParamIsDocumented() throws NoSuchMethodException {
+    Method method = ContainersV2Rest.class.getMethod(
+        "getThumbnail", String.class, String.class, Integer.class,
+        jakarta.ws.rs.core.SecurityContext.class);
+    String desc = Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "size".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> {
+          var ann = p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+          return ann != null ? ann.description() : "";
+        })
+        .findFirst().orElse("");
+    org.junit.jupiter.api.Assertions.assertFalse(
+        desc.isBlank(),
+        "getThumbnail size @Parameter description must be present and non-blank — got: '" + desc + "'");
+  }
+
   // ─── APISIMP-CHANNEL-DATA-TIME-UNIT-UNDOCUMENTED regression ───────────────
 
   @Test


### PR DESCRIPTION
## Summary

Part of the APISIMP sweep — adding `@Parameter(description=...)` to bare `@QueryParam` params throughout `/v2/` REST resources.

- **`ContainersV2Rest.getThumbnail()`** line 1341: `@QueryParam("size") Integer size` had no `@Parameter` annotation. The valid size set (64 / 200 / 400) and the normalisation-to-400 fallback were documented only in the `@Operation.description` prose — the per-param OpenAPI schema was bare, so client generators emitted an untyped, undescribed `size` parameter.
- Adds `@Parameter(description="Thumbnail pixel size. Accepted values: 64, 200, 400. Any other value (including absent) is normalised to 400.")` to the `size` param.
- Adds `getThumbnail_sizeParamIsDocumented()` reflection regression test to `ContainersV2RestTest` — guards against silent removal of the annotation. (57 tests total, +1.)

## Checklist

- [x] `@Parameter` import already present in `ContainersV2Rest` — no new import needed
- [x] `ContainersV2RestTest` — 57/57 pass locally
- [x] Backlog row `APISIMP-CONTAINERS-THUMBNAIL-SIZE-PARAM` filed in `aidocs/16` (commit `e9b44ce9b` on main, fire-140)

## Test plan

- [ ] CI green on this branch
- [ ] After merge: verify Swagger UI shows the `size` parameter with its description under `GET /v2/containers/{appId}/payload/{oid}/thumbnail`


---
_Generated by [Claude Code](https://claude.ai/code/session_01474j9gaTgZ2nehHXnUDyB7)_