### PR TITLE
docs(apisimp): document orderBy/orderDesc @Parameter descriptions on UserGroupV2Rest (APISIMP-USERGROUP-ORDERBY-PARAMS-UNDOCUMENTED)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserGroupV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserGroupV2Rest.java
@@ -79,10 +79,10 @@ public class UserGroupV2Rest {
     content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = UserGroupV2IO.class))
   )
   @APIResponse(responseCode = "401", description = "Authentication required.")
-  @Parameter(name = Constants.QP_PAGE)
-  @Parameter(name = "pageSize")
-  @Parameter(name = Constants.QP_ORDER_BY_ATTRIBUTE)
-  @Parameter(name = Constants.QP_ORDER_DESC)
+  @Parameter(name = Constants.QP_PAGE, description = "Zero-based page index. Both page and pageSize must be provided to enable pagination; if either is omitted all results are returned.")
+  @Parameter(name = "pageSize", description = "Page size (number of groups per page). Both page and pageSize must be provided to enable pagination; if either is omitted all results are returned.")
+  @Parameter(name = Constants.QP_ORDER_BY_ATTRIBUTE, description = "Sort attribute. Accepted values: name, createdAt, updatedAt. Default: insertion order (no guaranteed ordering when omitted).")
+  @Parameter(name = Constants.QP_ORDER_DESC, description = "Sort direction. true = descending; false or omitted = ascending.")
   public Response listUserGroups(
     @QueryParam(Constants.QP_PAGE) @PositiveOrZero Integer page,
     @QueryParam("pageSize") @PositiveOrZero Integer pageSize,

--- a/backend/src/test/java/de/dlr/shepard/v2/users/resources/UserGroupV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/users/resources/UserGroupV2RestTest.java
@@ -2,6 +2,7 @@ package de.dlr.shepard.v2.users.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.dlr.shepard.auth.permission.io.PermissionsIO;
 import de.dlr.shepard.auth.permission.model.Permissions;
 import de.dlr.shepard.auth.permission.model.Roles;
+import de.dlr.shepard.auth.users.endpoints.UserGroupAttributes;
 import de.dlr.shepard.auth.users.entities.User;
 import de.dlr.shepard.auth.users.entities.UserGroup;
 import de.dlr.shepard.auth.users.services.UserGroupService;
@@ -24,8 +26,10 @@ import de.dlr.shepard.common.util.PermissionType;
 import de.dlr.shepard.common.util.QueryParamHelper;
 import de.dlr.shepard.v2.users.io.UserGroupV2IO;
 import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -103,6 +107,48 @@ class UserGroupV2RestTest {
     assertEquals(1, body.size());
     assertEquals(APP_ID, body.get(0).getAppId());
     assertEquals(GROUP_NAME, body.get(0).getName());
+  }
+
+  // ── @Parameter doc regression (APISIMP-USERGROUP-ORDERBY-PARAMS-UNDOCUMENTED) ──
+
+  @Test
+  void listUserGroups_orderByParamIsDocumented() throws NoSuchMethodException {
+    Method method = UserGroupV2Rest.class.getMethod(
+      "listUserGroups", Integer.class, Integer.class, UserGroupAttributes.class, Boolean.class
+    );
+    Parameter[] apiParams = method.getAnnotationsByType(Parameter.class);
+    Parameter orderByParam = null;
+    for (Parameter p : apiParams) {
+      if ("orderBy".equals(p.name())) {
+        orderByParam = p;
+        break;
+      }
+    }
+    assertNotNull(orderByParam, "@Parameter(name=\"orderBy\") not found on listUserGroups()");
+    assertTrue(
+      orderByParam.description() != null && orderByParam.description().length() > 10,
+      "@Parameter(name=\"orderBy\") description must not be blank — APISIMP-USERGROUP-ORDERBY-PARAMS-UNDOCUMENTED"
+    );
+  }
+
+  @Test
+  void listUserGroups_orderDescParamIsDocumented() throws NoSuchMethodException {
+    Method method = UserGroupV2Rest.class.getMethod(
+      "listUserGroups", Integer.class, Integer.class, UserGroupAttributes.class, Boolean.class
+    );
+    Parameter[] apiParams = method.getAnnotationsByType(Parameter.class);
+    Parameter orderDescParam = null;
+    for (Parameter p : apiParams) {
+      if ("orderDesc".equals(p.name())) {
+        orderDescParam = p;
+        break;
+      }
+    }
+    assertNotNull(orderDescParam, "@Parameter(name=\"orderDesc\") not found on listUserGroups()");
+    assertTrue(
+      orderDescParam.description() != null && orderDescParam.description().length() > 10,
+      "@Parameter(name=\"orderDesc\") description must not be blank — APISIMP-USERGROUP-ORDERBY-PARAMS-UNDOCUMENTED"
+    );
   }
 
   // ── GET /v2/user-groups/{appId} ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `description=` to the four method-level `@Parameter` annotations on `UserGroupV2Rest.listUserGroups()`.

Previously the annotations only declared `name=`, so a caller inspecting the OpenAPI schema could not tell:
- `orderBy` accepts `name`, `createdAt`, `updatedAt` (not the uppercase enum literal names)
- `orderDesc` defaults to ascending when absent or `false`
- `page` and `pageSize` must be provided **together** — either alone is ignored and all results are returned

| Param | Added description |
|---|---|
| `page` | Zero-based page index. Both page and pageSize must be provided to enable pagination; if either is omitted all results are returned. |
| `pageSize` | Page size (number of groups per page). Both page and pageSize must be provided to enable pagination; if either is omitted all results are returned. |
| `orderBy` | Sort attribute. Accepted values: name, createdAt, updatedAt. Default: insertion order (no guaranteed ordering when omitted). |
| `orderDesc` | Sort direction. true = descending; false or omitted = ascending. |

Two reflection regression tests added to `UserGroupV2RestTest` to guard the `orderBy` and `orderDesc` descriptions:
- `listUserGroups_orderByParamIsDocumented`
- `listUserGroups_orderDescParamIsDocumented`

## Changed files

| File | Change |
|---|---|
| `UserGroupV2Rest.java` | Add `description=` to 4 method-level `@Parameter` annotations on `listUserGroups()` |
| `UserGroupV2RestTest.java` | Add `assertTrue` import; add `UserGroupAttributes`, `Method`, `Parameter` imports; add 2 reflection regression tests |

## Test plan

- [x] CI `mvn verify -pl backend` — 2 new regression tests pass; no runtime behaviour change
- [x] `doc-stage-check` gate: no aidocs edited in this PR; no index regeneration needed
- [x] No frontend changes; no wire shape change; DOC-ONLY

APISIMP-USERGROUP-ORDERBY-PARAMS-UNDOCUMENTED (fire-143)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3zycC6UjgXpXvaidSg7JF)_