### PR TITLE
fix(COLL-PAGE-RESIDUAL-404S): read creatorOrcid from prop, drop getUser(displayName)

### DIFF
--- a/frontend/components/context/collection/MetadataCompletenessCard.vue
+++ b/frontend/components/context/collection/MetadataCompletenessCard.vue
@@ -21,7 +21,7 @@
  *     license, accessRights, dataObjectIds
  *   - SemanticAnnotation count — `AnnotatedCollection.fetchAnnotations`
  *   - Lab journal entry count — `useFetchCollectionLabJournalEntries`
- *   - Creator ORCID — `UserApi.getUser({username: createdBy})`
+ *   - Creator ORCID — `collection.createdByOrcid` (stamped at creation; no secondary fetch)
  *   - Keyword count — conservatively 0 until a keyword-annotation
  *     endpoint ships (FAIR8 follow-up in aidocs/16-dispatcher-backlog.md)
  *
@@ -29,10 +29,9 @@
  * `null` and the score is conservatively biased toward "incomplete"
  * during loading. The widget never blocks the page render.
  */
-import { UserApi, type Collection } from "@dlr-shepard/backend-client";
+import type { Collection } from "@dlr-shepard/backend-client";
 import { AnnotatedCollection } from "~/composables/annotated";
 import { useFetchCollectionLabJournalEntries } from "~/composables/context/useFetchCollectionLabJournalEntries";
-import { useShepardApi } from "~/composables/common/api/useShepardApi";
 import {
   computeMetadataCompleteness,
   type MetadataCheck,
@@ -101,40 +100,31 @@ const labJournalCount = computed<number | null>(() =>
     : labJournalEntries.value.length,
 );
 
-// ── Fetch: creator ORCID ─────────────────────────────────────────────────
+// ── Creator ORCID ─────────────────────────────────────────────────────────
 //
-// Same Nuxt-context constraint as the annotation fetch — capture the
-// API binding in setup scope, invoke from `onMounted`.
-const userApi = useShepardApi(UserApi);
-const creatorOrcid = ref<string | null>(null);
-async function fetchCreatorOrcid() {
-  const username = props.collection.createdBy?.trim();
-  if (!username) return;
-  try {
-    const user = await userApi.value.getUser({ username });
-    const orcid = (user as unknown as { orcid?: string | null }).orcid ?? null;
-    creatorOrcid.value = orcid ?? "";
-  } catch {
-    // 404 on user is recoverable — treat as "no ORCID set".
-    creatorOrcid.value = "";
-  }
-}
+// collection.createdByOrcid is stamped by the backend at creation time from
+// the creator's User.orcid (AbstractDataObjectIO). Reading it directly avoids
+// the getUser({username: createdBy}) call that produced noisy 404s:
+// collection.createdBy carries a resolved display name (from
+// DisplayNameResolver.effectiveDisplayName), not the raw Keycloak username
+// that getUser expects.
+const creatorOrcid = computed<string | null>(() =>
+  props.collection.createdByOrcid ?? null,
+);
 
 // Initial best-effort fetch on mount + re-fire on auth-settle. The
 // `useAuth().data` ref starts `null` and populates once the
-// NextAuth session has been resolved. Without the watcher the card
-// permanently shows `null`/`0` for both fetches.
+// NextAuth session has been resolved. Without the watcher the annotation
+// fetch would permanently show `0` on first load due to the 401 race.
 const { data: authData } = useAuth();
 onMounted(() => {
   void fetchAnnotationCount();
-  void fetchCreatorOrcid();
 });
 watch(
   () => authData.value?.accessToken,
   newToken => {
     if (newToken) {
       void fetchAnnotationCount();
-      void fetchCreatorOrcid();
     }
   },
 );


### PR DESCRIPTION
## Summary

Fixes the noisy `getUser 404` on every Collection detail page load observed in the Playwright LUMEN repro (COLL-PAGE-RESIDUAL-404S, backlog row 3448).

**Root cause:** `MetadataCompletenessCard.vue` was calling `UserApi.getUser({username: collection.createdBy})` to fetch the creator's ORCID. But `collection.createdBy` is a **display name** (e.g. "Demo Admin") resolved by `DisplayNameResolver.effectiveDisplayName()` in `BasicEntityIO` — not the raw Keycloak `preferred_username` that the `GET /shepard/api/users/{username}` endpoint expects. Result: 404 on every collection page load.

**Fix:** `collection.createdByOrcid` is already stamped at creation time by `AbstractDataObjectIO` from `User.orcid` — it's in the Collection wire shape from both v1 and v2 endpoints. Replace the async `getUser`-based fetch with a synchronous `computed` read of `props.collection.createdByOrcid ?? null`. No secondary HTTP call, no 404 possible.

**Removes:** `UserApi` + `useShepardApi` imports that existed solely for the removed fetch. The auth-settle watcher is kept for `fetchAnnotationCount` (which still needs it for the 401-on-first-load race).

**Scope:** `MetadataCompletenessCard.vue` only — frontend-only, no backend change needed. The other 3 callers listed in the backlog (`shepardObjectAccessor.ts:fetchOwner`, `useFetchCollectionPermissions.ts`, `useHandleUserGroupMembers.ts`) pass `Permissions.owner` / group `usernames` — those are actual usernames from `PermissionsIO.getUsername()`, not display names, so they are not broken.

## Other COLL-PAGE-RESIDUAL-404S items (not in scope)
- (2) `GET /v2/collections/{appId}/publications` + `/v2/projects/{appId}/sub-collections` 404 — intended-empty; no endpoint yet
- (3) `GET /v2/users/me/preferences` 401 under Playwright — token-audience quirk, normal browser login unaffected
- (4) `/avatar` 404 — expected (not reseeded)

## Test plan
- [ ] Open a LUMEN collection page; browser DevTools Network tab shows no `getUser` 404 from the Metadata Completeness Card
- [ ] Card still shows creator ORCID badge when `collection.createdByOrcid` is non-null
- [ ] `npm run lint` and `npm run typecheck` pass (gates: node_modules not installed in CI-less remote env; CI will verify)
- [ ] `computeMetadataCompleteness` still receives `string | null` for `creatorOrcid` — type-compatible (confirmed against `metadataCompleteness.ts:113`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzSiwcXHyQnQJgHyaUZ6rN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzSiwcXHyQnQJgHyaUZ6rN)_