### PR TITLE
docs(backlog): fire-154 stale row corrections — P24, MFFD-RENDER-NDT-GRID, MFFD-RENDER-AFP-THERMO-OVERLAY

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -444,7 +444,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/agent-findings/apisimp-sweep-2026-06-18-fire108.md`](agent-findings/apisimp-sweep-2026-06-18-fire108.md) | APISIMP sweep — fire-108 (2026-06-18) | 2026-06-18 | 2026-06-18 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-06-18-fire115.md`](agent-findings/apisimp-sweep-2026-06-18-fire115.md) | APISIMP Sweep — fire-115 (2026-06-18) | 2026-06-18 | 2026-06-18 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-06-19-fire137.md`](agent-findings/apisimp-sweep-2026-06-19-fire137.md) | APISIMP Sweep — 2026-06-19 (fire-137) | 2026-06-19 | 2026-06-19 |
-| [`aidocs/agent-findings/apisimp-sweep-2026-06-19-fire145.md`](agent-findings/apisimp-sweep-2026-06-19-fire145.md) | APISIMP Sweep — fire-145 · 2026-06-19 | 2026-06-19 | — |
+| [`aidocs/agent-findings/apisimp-sweep-2026-06-19-fire145.md`](agent-findings/apisimp-sweep-2026-06-19-fire145.md) | APISIMP Sweep — fire-145 · 2026-06-19 | 2026-06-19 | 2026-06-24 |
 | [`aidocs/agent-findings/audience-frontmatter-retrofit-2026-05-23.md`](agent-findings/audience-frontmatter-retrofit-2026-05-23.md) | Audience-persona front-matter retrofit (DOCS-3A9) | 2026-05-23 | 2026-06-18 |
 | [`aidocs/agent-findings/db-baseline-post-mffd.md`](agent-findings/db-baseline-post-mffd.md) | DB Baseline: post-MFFD ingest (2026-05-26) | 2026-05-26 | 2026-06-18 |
 | [`aidocs/agent-findings/db-opt2-hot-path-analysis.md`](agent-findings/db-opt2-hot-path-analysis.md) | DB-OPT2: Hot-path index analysis | 2026-05-26 | 2026-06-18 |


### PR DESCRIPTION
## Summary

Corrects 4 stale rows in `aidocs/16-dispatcher-backlog.md` discovered during fire-154 dispatch selection (fire-153's "next dispatch" section proposed entries that were already merged):

- **P24**: was `needs build` — `StructuredDataReferenceKindHandler` + `StructuredDataContainerKindHandler` already shipped 2026-06-17 (fires 94/95/96); marked `done`
- **MFFD-RENDER-AFP-THERMO-OVERLAY-3** (slice 3 row): was `in-flight 2026-06-14` — PR #1920 merged 2026-06-15; marked `✓ shipped`
- **MFFD-RENDER-NDT-GRID** (parent row): was `in-flight slice 3` — PR #1905 merged 2026-06-14; marked `✓ all 3 slices shipped`
- **MFFD-RENDER-AFP-THERMO-OVERLAY** (parent row): was `Slice 1 ✓ shipped 2026-06-10; Slice 2 in-flight 2026-06-14` — slices 1–3 all shipped; updated to reflect this

`aidocs/01` doc-stage index regenerated.

## Test plan

- [ ] No code changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmT9s2JECbXe4Yh3d3T93U

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmT9s2JECbXe4Yh3d3T93U)_