### PR TITLE
feat(COLL-TIMELINE-DRILLDOWN-FILTER-2): wire annotation lane filter to DataObject list

### DIFF
--- a/backend-client/src/apis/DataObjectsApi.ts
+++ b/backend-client/src/apis/DataObjectsApi.ts
@@ -74,6 +74,8 @@ export interface GetRdfRequest {
 
 export interface ListDataObjectsRequest {
     collectionAppId: string;
+    /** COLL-TIMELINE-DRILLDOWN-FILTER-2: annotation lane filter in format "predicateIri=value". */
+    annotationFilter?: string;
     fields?: string;
     include?: string;
     name?: string;
@@ -429,6 +431,10 @@ export class DataObjectsApi extends runtime.BaseAPI {
         }
 
         const queryParameters: any = {};
+
+        if (requestParameters['annotationFilter'] != null) {
+            queryParameters['annotationFilter'] = requestParameters['annotationFilter'];
+        }
 
         if (requestParameters['fields'] != null) {
             queryParameters['fields'] = requestParameters['fields'];

--- a/backend/src/main/java/de/dlr/shepard/common/util/QueryParamHelper.java
+++ b/backend/src/main/java/de/dlr/shepard/common/util/QueryParamHelper.java
@@ -20,6 +20,10 @@ public class QueryParamHelper {
   private Long successorId;
   private OrderByAttribute orderByAttribute;
   private Boolean orderDesc;
+  /** COLL-TIMELINE-DRILLDOWN-FILTER-2: annotation predicate IRI for lane filter. */
+  private String annotationFilterPredicateIri;
+  /** COLL-TIMELINE-DRILLDOWN-FILTER-2: annotation literal value for lane filter. */
+  private String annotationFilterValue;
 
   public QueryParamHelper withName(String name) {
     this.name = name;
@@ -83,5 +87,31 @@ public class QueryParamHelper {
 
   public boolean hasOrderByAttribute() {
     return this.orderByAttribute != null;
+  }
+
+  /**
+   * COLL-TIMELINE-DRILLDOWN-FILTER-2: sets the annotation predicate/value pair.
+   * Format: "predicateIri=value" — split on the first '=' character.
+   * Silently ignores malformed input (no '=' or blank parts).
+   */
+  public QueryParamHelper withAnnotationFilter(String annotationFilter) {
+    if (annotationFilter == null || annotationFilter.isBlank()) return this;
+    int sep = annotationFilter.indexOf('=');
+    if (sep < 1 || sep >= annotationFilter.length() - 1) return this;
+    this.annotationFilterPredicateIri = annotationFilter.substring(0, sep);
+    this.annotationFilterValue = annotationFilter.substring(sep + 1);
+    return this;
+  }
+
+  public boolean hasAnnotationFilter() {
+    return annotationFilterPredicateIri != null && annotationFilterValue != null;
+  }
+
+  public String getAnnotationFilterPredicateIri() {
+    return annotationFilterPredicateIri;
+  }
+
+  public String getAnnotationFilterValue() {
+    return annotationFilterValue;
   }
 }

--- a/backend/src/main/java/de/dlr/shepard/context/collection/daos/DataObjectDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/context/collection/daos/DataObjectDAO.java
@@ -246,6 +246,12 @@ public class DataObjectDAO extends VersionableEntityDAO<DataObject> {
       where += " AND d.status = $status";
     }
 
+    if (paramsWithShepardIds.hasAnnotationFilter()) {
+      paramsMap.put("annoIri", paramsWithShepardIds.getAnnotationFilterPredicateIri());
+      paramsMap.put("annoVal", paramsWithShepardIds.getAnnotationFilterValue());
+      match += " MATCH (d)-[:ANNOTATED_WITH]->(anno:SemanticAnnotation {predicateIri: $annoIri, objectLiteral: $annoVal})";
+    }
+
     String query = match + where + " WITH d";
     if (paramsWithShepardIds.hasOrderByAttribute()) {
       query +=
@@ -342,6 +348,12 @@ public class DataObjectDAO extends VersionableEntityDAO<DataObject> {
     if (params.hasStatus()) {
       paramsMap.put("status", params.getStatus());
       where += " AND d.status = $status";
+    }
+
+    if (params.hasAnnotationFilter()) {
+      paramsMap.put("annoIri", params.getAnnotationFilterPredicateIri());
+      paramsMap.put("annoVal", params.getAnnotationFilterValue());
+      match += " MATCH (d)-[:ANNOTATED_WITH]->(anno:SemanticAnnotation {predicateIri: $annoIri, objectLiteral: $annoVal})";
     }
 
     String query = match + where + " RETURN count(d) AS total";

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
@@ -192,6 +192,7 @@ public class DataObjectV2Rest {
     @QueryParam("pageSize") @DefaultValue("50") @PositiveOrZero int pageSize,
     @QueryParam("include") String include,
     @QueryParam("fields") String fields,
+    @QueryParam("annotationFilter") String annotationFilter,
     @Context SecurityContext sc
   ) {
     // DB-OPT5: validate ?fields= early so a bad query returns 400 before any DB hit.
@@ -222,6 +223,7 @@ public class DataObjectV2Rest {
     var params = new QueryParamHelper();
     if (name != null) params = params.withName(name);
     if (status != null) params = params.withStatus(status);
+    if (annotationFilter != null) params = params.withAnnotationFilter(annotationFilter);
     params = params.withPageAndSize(safePage, safeSize);
 
     var dataObjects = dataObjectService.getAllDataObjectsByShepardIds(collectionOgmId, params, null);

--- a/backend/src/test/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2RestTest.java
@@ -1,9 +1,11 @@
 package de.dlr.shepard.v2.dataobject.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -20,6 +22,7 @@ import de.dlr.shepard.auth.permission.services.PermissionsService;
 import de.dlr.shepard.common.exceptions.InvalidBodyException;
 import de.dlr.shepard.common.identifier.EntityIdResolver;
 import de.dlr.shepard.common.util.AccessType;
+import de.dlr.shepard.common.util.QueryParamHelper;
 import de.dlr.shepard.context.collection.daos.DataObjectDAO;
 import de.dlr.shepard.context.collection.entities.Collection;
 import de.dlr.shepard.context.collection.entities.DataObject;
@@ -40,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -146,7 +150,7 @@ class DataObjectV2RestTest {
   @Test
   void listReturns404WhenCollectionUnknown() {
     when(entityIdResolver.resolveLong(COLL_APP_ID)).thenThrow(new NotFoundException());
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, securityContext);
     assertEquals(404, r.getStatus());
     verify(dataObjectService, never()).getAllDataObjectsByShepardIds(anyLong(), any(), any());
   }
@@ -156,7 +160,7 @@ class DataObjectV2RestTest {
     when(entityIdResolver.resolveLong(COLL_APP_ID)).thenReturn(COLL_OGM_ID);
     when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
       .thenReturn(false);
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, securityContext);
     assertEquals(403, r.getStatus());
   }
 
@@ -169,7 +173,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), any(), eq(null)))
       .thenReturn(List.of(d));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -190,7 +194,7 @@ class DataObjectV2RestTest {
     when(dataObjectDAO.findRefCountsByAppIds(List.of(DO_APP_ID)))
       .thenReturn(Map.of(DO_APP_ID, new long[] { 3L, 5L, 2L }));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -217,7 +221,7 @@ class DataObjectV2RestTest {
     when(timeseriesDataPointRepository.findTimeBoundsByContainerIds(List.of(containerNeo4jId)))
       .thenReturn(Map.of(containerNeo4jId, new long[] { 1_000_000L, 9_000_000L }));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, "time-bounds", null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, "time-bounds", null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -240,7 +244,7 @@ class DataObjectV2RestTest {
     when(dataObjectDAO.countByCollectionByShepardIds(eq(COLL_OGM_ID), any())).thenReturn(8514L);
 
     // page=3, size=25 → firstIndex=75, lastIndex=75 (1 item)
-    Response r = resource.list(COLL_APP_ID, null, null, 3, 25, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 3, 25, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     // Content-Range must be present with format "dataobjects firstIndex-lastIndex/total"
@@ -263,7 +267,7 @@ class DataObjectV2RestTest {
       .thenReturn(Collections.emptyList());
     when(dataObjectDAO.countByCollectionByShepardIds(eq(COLL_OGM_ID), any())).thenReturn(0L);
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 25, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 25, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     String contentRange = (String) r.getHeaders().getFirst("Content-Range");
@@ -283,7 +287,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), any(), eq(null)))
       .thenReturn(List.of(d));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -291,6 +295,57 @@ class DataObjectV2RestTest {
     assertEquals(1, body.size());
     assertNull(body.get(0).getTimeBoundsStart());
     assertNull(body.get(0).getTimeBoundsEnd());
+  }
+
+  // ── COLL-TIMELINE-DRILLDOWN-FILTER-2: annotationFilter param ─────────────
+
+  @Test
+  void listPassesAnnotationFilterToDAO() {
+    DataObject d = makeDataObject(DO_OGM_ID, DO_APP_ID, "afp-track-1");
+    when(entityIdResolver.resolveLong(COLL_APP_ID)).thenReturn(COLL_OGM_ID);
+    when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
+      .thenReturn(true);
+    ArgumentCaptor<QueryParamHelper> paramsCaptor = ArgumentCaptor.forClass(QueryParamHelper.class);
+    when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
+      .thenReturn(List.of(d));
+
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null,
+      "urn:shepard:mffd:process-type=afp-course", securityContext);
+
+    assertEquals(200, r.getStatus());
+    QueryParamHelper captured = paramsCaptor.getValue();
+    assertTrue(captured.hasAnnotationFilter());
+    assertEquals("urn:shepard:mffd:process-type", captured.getAnnotationFilterPredicateIri());
+    assertEquals("afp-course", captured.getAnnotationFilterValue());
+  }
+
+  @Test
+  void listIgnoresMalformedAnnotationFilter() {
+    when(entityIdResolver.resolveLong(COLL_APP_ID)).thenReturn(COLL_OGM_ID);
+    when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
+      .thenReturn(true);
+    when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), any(), eq(null)))
+      .thenReturn(Collections.emptyList());
+
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null,
+      "malformed-no-equals", securityContext);
+
+    assertEquals(200, r.getStatus());
+  }
+
+  @Test
+  void listNullAnnotationFilterIsIgnored() {
+    when(entityIdResolver.resolveLong(COLL_APP_ID)).thenReturn(COLL_OGM_ID);
+    when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
+      .thenReturn(true);
+    ArgumentCaptor<QueryParamHelper> paramsCaptor = ArgumentCaptor.forClass(QueryParamHelper.class);
+    when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
+      .thenReturn(Collections.emptyList());
+
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, securityContext);
+
+    assertEquals(200, r.getStatus());
+    assertFalse(paramsCaptor.getValue().hasAnnotationFilter());
   }
 
   // ── get ───────────────────────────────────────────────────────────────────
@@ -816,7 +871,7 @@ class DataObjectV2RestTest {
   @Test
   void listDefaultTrimDropsHeavyFields() {
     stubListSingleDataObject();
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, securityContext);
     assertEquals(200, r.getStatus());
     String body = (String) r.getEntity();
     // Heavy fields gone by default
@@ -839,7 +894,7 @@ class DataObjectV2RestTest {
   @Test
   void listIncludeFullReturnsFullShape() {
     stubListSingleDataObject();
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, "full", null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, "full", null, null, securityContext);
     assertEquals(200, r.getStatus());
     String body = (String) r.getEntity();
     // All fields back including the heavy ones
@@ -852,7 +907,7 @@ class DataObjectV2RestTest {
   @Test
   void listFieldsParamLimitsToRequestedFields() {
     stubListSingleDataObject();
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "appId,name,createdAt", securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "appId,name,createdAt", null, securityContext);
     assertEquals(200, r.getStatus());
     String body = (String) r.getEntity();
     org.junit.jupiter.api.Assertions.assertTrue(body.contains("\"appId\""));
@@ -870,7 +925,7 @@ class DataObjectV2RestTest {
   void listFieldsParamAlwaysIncludesIdentity() {
     stubListSingleDataObject();
     // Ask only for createdAt; id, appId, name should still come back as identity guarantees.
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "createdAt", securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "createdAt", null, securityContext);
     assertEquals(200, r.getStatus());
     String body = (String) r.getEntity();
     org.junit.jupiter.api.Assertions.assertTrue(body.contains("\"appId\""));
@@ -885,7 +940,7 @@ class DataObjectV2RestTest {
   @Test
   void listFieldsParamEmptyStringTreatedAsAbsent() {
     stubListSingleDataObject();
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "", securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "", null, securityContext);
     assertEquals(200, r.getStatus());
     // Empty fields → default-trim mode (not 400, not "fields" mode)
     assertEquals("default-trim", r.getHeaders().getFirst("X-Shepard-Payload-Diet"));
@@ -896,7 +951,7 @@ class DataObjectV2RestTest {
     when(entityIdResolver.resolveLong(COLL_APP_ID)).thenReturn(COLL_OGM_ID);
     when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
       .thenReturn(true);
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "appId,bogusField,name", securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "appId,bogusField,name", null, securityContext);
     assertEquals(400, r.getStatus());
     // 400 returns ProblemJson entity with the offending field name in 'detail'
     de.dlr.shepard.common.exceptions.ProblemJson body = (de.dlr.shepard.common.exceptions.ProblemJson) r.getEntity();
@@ -911,7 +966,7 @@ class DataObjectV2RestTest {
   void listFieldsParamWhitespaceTolerated() {
     stubListSingleDataObject();
     // Whitespace around commas should not produce 400.
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "appId, name , createdAt", securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "appId, name , createdAt", null, securityContext);
     assertEquals(200, r.getStatus());
     assertEquals("fields", r.getHeaders().getFirst("X-Shepard-Payload-Diet"));
   }
@@ -931,8 +986,8 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), any(), eq(null)))
       .thenReturn(List.of(d, d, d, d, d));
 
-    String trimmed = (String) resource.list(COLL_APP_ID, null, null, 0, 50, null, null, securityContext).getEntity();
-    String full = (String) resource.list(COLL_APP_ID, null, null, 0, 50, "full", null, securityContext).getEntity();
+    String trimmed = (String) resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, securityContext).getEntity();
+    String full = (String) resource.list(COLL_APP_ID, null, null, 0, 50, "full", null, null, securityContext).getEntity();
     System.out.printf(
       "DB-OPT5 end-to-end measurement (5 DOs, 800-char description + 12-attr map per DO): full=%d B, default-trim=%d B (%.1f%% smaller)%n",
       full.length(), trimmed.length(), 100.0 * (full.length() - trimmed.length()) / full.length()

--- a/frontend/components/context/collection/CollectionDataObjectsPanel.vue
+++ b/frontend/components/context/collection/CollectionDataObjectsPanel.vue
@@ -23,6 +23,16 @@
           variant="tonal"
         >{{ s }}</v-chip>
       </v-chip-group>
+      <!-- COLL-TIMELINE-DRILLDOWN-FILTER-2: active lane chip from timeline drill-down -->
+      <v-chip
+        v-if="activeProcessTypeLane"
+        size="small"
+        color="primary"
+        variant="tonal"
+        closable
+        prepend-icon="mdi-filter"
+        @click:close="clearProcessTypeLane"
+      >{{ activeProcessTypeLane }}</v-chip>
     </div>
 
     <v-progress-linear v-if="loading && pagedItems.length === 0" indeterminate aria-label="Loading datasets" />
@@ -172,7 +182,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { useRouter } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
 import { usePagedDataObjects } from "~/composables/context/usePagedDataObjects";
 import { useTimeoutFn } from "@vueuse/core";
 
@@ -182,7 +192,28 @@ const props = defineProps<{
 }>();
 
 const router = useRouter();
+const route = useRoute();
 const collectionAppId = computed(() => props.collectionAppId ?? null);
+
+// COLL-TIMELINE-DRILLDOWN-FILTER-2: read ?process-type=<lane> from the URL
+// (emitted by CollectionTimelinePane.vue drillDownPath() on bin click).
+// Derive the annotation filter as "urn:shepard:mffd:process-type=<lane>".
+const PROCESS_TYPE_PREDICATE = "urn:shepard:mffd:process-type";
+const activeProcessTypeLane = computed<string | null>(() => {
+  const v = route.query['process-type'];
+  return typeof v === 'string' && v.length > 0 ? v : null;
+});
+const annotationFilter = computed<string | undefined>(() =>
+  activeProcessTypeLane.value != null
+    ? `${PROCESS_TYPE_PREDICATE}=${activeProcessTypeLane.value}`
+    : undefined
+);
+
+function clearProcessTypeLane() {
+  const q = { ...route.query };
+  delete q['process-type'];
+  void router.replace({ query: q });
+}
 
 const STATUSES = [
   "DRAFT", "IN_REVIEW", "READY", "PUBLISHED", "ARCHIVED", "FAILED",
@@ -211,11 +242,15 @@ watch(statusFilter, () => { page.value = 0; });
 
 const pageSize = 25;
 
+// Reset page on annotation filter change (lane drill-down → page 0)
+watch(annotationFilter, () => { page.value = 0; });
+
 const { items: rawItems, loading, hasMore, totalItems } = usePagedDataObjects({
   collectionId: props.collectionId,
   collectionAppId,
   name: serverName,
   status: statusFilter,
+  annotationFilter,
   page,
   pageSize,
   includeTimeBounds: true,

--- a/frontend/composables/context/usePagedDataObjects.ts
+++ b/frontend/composables/context/usePagedDataObjects.ts
@@ -34,6 +34,8 @@ export interface PagedDataObjectsOptions {
   pageSize?: number;
   /** When true, each item includes timeBoundsStart / timeBoundsEnd (2 extra DB round-trips). */
   includeTimeBounds?: boolean;
+  /** COLL-TIMELINE-DRILLDOWN-FILTER-2: annotation lane filter ("predicateIri=value"). */
+  annotationFilter?: Ref<string | undefined>;
 }
 
 export interface PagedDataObjectsResult {
@@ -58,6 +60,7 @@ export interface PagedDataObjectsResult {
 export function usePagedDataObjects(opts: PagedDataObjectsOptions): PagedDataObjectsResult {
   const { collectionId, collectionAppId, name, page } = opts;
   const status = opts.status;
+  const annotationFilter = opts.annotationFilter;
   const pageSize = opts.pageSize ?? 25;
   const includeTimeBounds = opts.includeTimeBounds ?? false;
 
@@ -113,6 +116,7 @@ export function usePagedDataObjects(opts: PagedDataObjectsOptions): PagedDataObj
         collectionAppId: identifier,
         name: nameFilter,
         status: statusFilter,
+        annotationFilter: annotationFilter?.value || undefined,
         page: currentPage,
         pageSize: pageSize,
         include: includeTimeBounds ? 'time-bounds' : undefined,
@@ -133,9 +137,13 @@ export function usePagedDataObjects(opts: PagedDataObjectsOptions): PagedDataObj
     }
   }
 
-  const watchSources = status
-    ? [collectionAppId, name, status, page] as const
-    : [collectionAppId, name, page] as const;
+  const watchSources = [
+    collectionAppId,
+    name,
+    page,
+    ...(status ? [status] : []),
+    ...(annotationFilter ? [annotationFilter] : []),
+  ] as const;
   watch(watchSources, () => {
     void fetch();
   }, { immediate: true });


### PR DESCRIPTION
## Summary

COLL-TIMELINE-DRILLDOWN-FILTER-2 — closes the backend + frontend loop for the
Timeline drill-down annotation filter (`?process-type=<lane>`).

**Backend**
- `DataObjectV2Rest.list()`: new `@QueryParam("annotationFilter") String annotationFilter` (8th param, before `SecurityContext`)
- `QueryParamHelper.withAnnotationFilter(String)`: parses `"predicateIri=value"` format; silently ignores malformed input (no `=`)
- `QueryParamHelper.getAnnotationFilterPredicateIri()` / `getAnnotationFilterValue()` + `hasAnnotationFilter()` getters
- `DataObjectDAO.findByCollectionByShepardIds()` + `countByCollectionByShepardIds()`: appends `MATCH (d)-[:ANNOTATED_WITH]->(anno:SemanticAnnotation {predicateIri: $annoIri, objectLiteral: $annoVal})` when filter is active

**Backend-client** (`backend-client/src/apis/DataObjectsApi.ts`, hand-edited)
- `ListDataObjectsRequest`: new `annotationFilter?: string` field (with doc comment)
- `listDataObjectsRaw()`: serialises `annotationFilter` into query params

**Frontend**
- `usePagedDataObjects`: new `annotationFilter?: Ref<string | undefined>` option; watches it; passes to `listDataObjectsRaw`
- `CollectionDataObjectsPanel.vue`: reads `route.query['process-type']`, derives `urn:shepard:mffd:process-type=<lane>` filter, resets page on filter change; shows dismissible filter chip badge when a lane is active; clear chip removes query param via `router.replace`

**Tests**
- 3 new `DataObjectV2RestTest` cases: `listPassesAnnotationFilterToDAO`, `listIgnoresMalformedAnnotationFilter`, `listNullAnnotationFilterIsIgnored`
- 49/49 `DataObjectV2RestTest` pass ✓
- Pre-existing 27 `SemanticAnnotationV2RestTest` NPE failures are the known `EntityIdResolver` bug introduced by commit `f9ecbd8f`, being fixed by PR #2035; unrelated to this slice

## Gates

| Gate | Result |
|---|---|
| `mvn verify -f backend/pom.xml` | BUILD FAILURE — 27 pre-existing `SemanticAnnotationV2RestTest` NPE (PR #2035 fix pending); `DataObjectV2RestTest` 49/49 PASS ✓ |
| `npm run lint` | 0 errors, 17 warnings (all pre-existing) ✓ |
| `npm run test` | 1 flaky perf test (`lineageLayout` 30.3s vs 30s budget on shared runner, pre-existing flake); 2149/2150 PASS ✓ |
| `npm run typecheck` | PASS ✓ |

**Blocked on #2035** — once the `EntityIdResolver` NPE fix merges, this PR's CI will go green.

## Test plan

- [ ] Merge #2035 first (unblocks CI)
- [ ] Verify `GET /v2/collections/{appId}/data-objects?annotationFilter=urn:shepard:mffd:process-type=afp-course` returns only DataObjects annotated with that process type
- [ ] Verify malformed `?annotationFilter=noequals` returns 200 (no crash)
- [ ] In UI: click a process-type lane in the timeline → DataObject list filters + chip appears → click × on chip → filter clears

COLL-TIMELINE-DRILLDOWN-FILTER-2 / fire-156

---
_Generated by [Claude Code](https://claude.ai/code/session_015M7uxk52qpag23NXxt9TtE)_