### PR TITLE
feat(config): FTOGGLE-QS-1 — quality-scoring enabled+batchSize runtime-mutable

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/context/references/timeseriesreference/services/TimeseriesQualityScoringJob.java
+++ b/backend/src/main/java/de/dlr/shepard/context/references/timeseriesreference/services/TimeseriesQualityScoringJob.java
@@ -8,6 +8,7 @@ import de.dlr.shepard.data.timeseries.model.TimeseriesDataPoint;
 import de.dlr.shepard.data.timeseries.model.TimeseriesDataPointsQueryParams;
 import de.dlr.shepard.data.timeseries.repositories.TimeseriesDataPointRepository;
 import de.dlr.shepard.data.timeseries.repositories.TimeseriesRepository;
+import de.dlr.shepard.v2.admin.qualityscoring.services.TimeseriesQualityScoringConfigService;
 import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -15,7 +16,6 @@ import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * AI1c — background job that emits {@code qualityScore} +
@@ -76,11 +76,8 @@ public class TimeseriesQualityScoringJob {
   @Inject
   TimeseriesDataPointRepository timeseriesDataPointRepository;
 
-  @ConfigProperty(name = "shepard.timeseries.quality-scoring.enabled", defaultValue = "false")
-  boolean enabled;
-
-  @ConfigProperty(name = "shepard.timeseries.quality-scoring.batch-size", defaultValue = "100")
-  int batchSize;
+  @Inject
+  TimeseriesQualityScoringConfigService qualityScoringConfigService;
 
   /**
    * Periodic run. {@code @Scheduled.every} resolves the interval
@@ -89,11 +86,11 @@ public class TimeseriesQualityScoringJob {
    */
   @Scheduled(every = "{shepard.timeseries.quality-scoring.interval}")
   public void runScoring() {
-    if (!enabled) {
-      Log.debug("AI1c quality scoring skipped — shepard.timeseries.quality-scoring.enabled=false");
+    if (!qualityScoringConfigService.isEnabled()) {
+      Log.debug("AI1c quality scoring skipped — enabled=false (runtime config)");
       return;
     }
-    int capped = clampBatchSize(batchSize);
+    int capped = clampBatchSize(qualityScoringConfigService.effectiveBatchSize());
     long now = currentTimeMillis();
     long staleCutoff = now - RESCORING_INTERVAL_MILLIS;
 

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/config/descriptors/TimeseriesQualityScoringConfigDescriptor.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/config/descriptors/TimeseriesQualityScoringConfigDescriptor.java
@@ -1,0 +1,88 @@
+package de.dlr.shepard.v2.admin.config.descriptors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import de.dlr.shepard.v2.admin.config.spi.ConfigDescriptor;
+import de.dlr.shepard.v2.admin.config.spi.ConfigPatchException;
+import de.dlr.shepard.v2.admin.qualityscoring.io.TimeseriesQualityScoringConfigIO;
+import de.dlr.shepard.v2.admin.qualityscoring.services.TimeseriesQualityScoringConfigService;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * FTOGGLE-QS-1 — {@link ConfigDescriptor} for the AI1c quality-scoring
+ * runtime config, exposed via
+ * {@code GET|PATCH /v2/admin/config/timeseries-quality-scoring}.
+ *
+ * <p>Makes {@code shepard.timeseries.quality-scoring.enabled} and
+ * {@code shepard.timeseries.quality-scoring.batch-size} runtime-mutable
+ * without a restart. The scheduling interval is intentionally excluded —
+ * Quarkus evaluates {@code @Scheduled.every} at startup so it cannot be
+ * changed at runtime (CLAUDE.md "Pre-startup ordering invariants" exception).
+ *
+ * <p>Patchable fields:
+ * <ul>
+ *   <li>{@code enabled} (boolean) — absent = leave alone, null = revert to
+ *       deploy-time default (false), value = replace.</li>
+ *   <li>{@code batchSize} (int) — absent = leave alone, null = revert to
+ *       deploy-time default (100), value = replace. Must be ≥ 1.</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class TimeseriesQualityScoringConfigDescriptor
+  implements ConfigDescriptor<TimeseriesQualityScoringConfigIO> {
+
+  static final String PROBLEM_TYPE_INVALID_BATCH_SIZE =
+    "/problems/timeseries-quality-scoring.invalid-batch-size";
+
+  @Inject
+  TimeseriesQualityScoringConfigService service;
+
+  @Override
+  public String featureName() {
+    return "timeseries-quality-scoring";
+  }
+
+  @Override
+  public String description() {
+    return "AI1c timeseries quality-scoring job runtime config: enabled flag and per-tick batch size.";
+  }
+
+  @Override
+  public TimeseriesQualityScoringConfigIO currentShape() {
+    return service.getConfig();
+  }
+
+  @Override
+  public TimeseriesQualityScoringConfigIO applyMergePatch(JsonNode patch) throws ConfigPatchException {
+    var current = service.current();
+
+    Boolean effectiveEnabled = patch.has("enabled")
+      ? (patch.get("enabled").isNull() ? null : patch.get("enabled").booleanValue())
+      : current.getEnabled();
+
+    Integer effectiveBatchSize;
+    if (patch.has("batchSize")) {
+      if (patch.get("batchSize").isNull()) {
+        effectiveBatchSize = null;
+      } else {
+        effectiveBatchSize = patch.get("batchSize").intValue();
+        if (effectiveBatchSize < 1) {
+          throw ConfigPatchException.badRequest(
+            PROBLEM_TYPE_INVALID_BATCH_SIZE,
+            "Invalid batchSize",
+            "batchSize must be ≥ 1, got: " + effectiveBatchSize);
+        }
+      }
+    } else {
+      effectiveBatchSize = current.getBatchSize();
+    }
+
+    TimeseriesQualityScoringConfigIO updated = service.patch(effectiveEnabled, effectiveBatchSize);
+    Log.infof(
+      "FTOGGLE-QS-1: PATCH /v2/admin/config/timeseries-quality-scoring "
+        + "→ enabled=%s batchSize=%s",
+      updated.enabled(), updated.batchSize());
+    return updated;
+  }
+}

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/qualityscoring/daos/TimeseriesQualityScoringConfigDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/qualityscoring/daos/TimeseriesQualityScoringConfigDAO.java
@@ -1,0 +1,65 @@
+package de.dlr.shepard.v2.admin.qualityscoring.daos;
+
+import de.dlr.shepard.common.identifier.AppIdGenerator;
+import de.dlr.shepard.common.neo4j.NeoConnector;
+import de.dlr.shepard.common.neo4j.daos.GenericDAO;
+import de.dlr.shepard.v2.admin.qualityscoring.entities.TimeseriesQualityScoringConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.neo4j.ogm.session.Session;
+
+/**
+ * FTOGGLE-QS-1 — DAO for the {@link TimeseriesQualityScoringConfig} singleton.
+ *
+ * <p>Mirrors the {@code ThermographyConfigDAO} / {@code JupyterConfigDAO}
+ * shape — fresh OGM session per call to avoid startup-ordering races.
+ */
+@ApplicationScoped
+public class TimeseriesQualityScoringConfigDAO extends GenericDAO<TimeseriesQualityScoringConfig> {
+
+  @Override
+  public Class<TimeseriesQualityScoringConfig> getEntityType() {
+    return TimeseriesQualityScoringConfig.class;
+  }
+
+  /**
+   * Load the singleton, returning {@link Optional#empty()} when none has
+   * been seeded yet. Uses a fresh OGM session to avoid startup-ordering
+   * races.
+   */
+  public Optional<TimeseriesQualityScoringConfig> findSingleton() {
+    Session live = NeoConnector.getInstance().getNeo4jSession();
+    if (live == null) {
+      return Optional.empty();
+    }
+    Collection<TimeseriesQualityScoringConfig> all = live.loadAll(
+      TimeseriesQualityScoringConfig.class, 1);
+    if (all == null || all.isEmpty()) {
+      return Optional.empty();
+    }
+    return List.copyOf(all)
+      .stream()
+      .min((a, b) -> Long.compare(
+        a.getId() == null ? 0L : a.getId(),
+        b.getId() == null ? 0L : b.getId()));
+  }
+
+  /**
+   * Persist the entity using a fresh OGM session. Mints an appId when absent.
+   */
+  @Override
+  public TimeseriesQualityScoringConfig createOrUpdate(TimeseriesQualityScoringConfig entity) {
+    Session live = NeoConnector.getInstance().getNeo4jSession();
+    if (live == null) {
+      throw new IllegalStateException(
+        "Neo4j session unavailable — cannot persist :TimeseriesQualityScoringConfig");
+    }
+    if (entity.getAppId() == null) {
+      entity.setAppId(AppIdGenerator.next());
+    }
+    live.save(entity, 1);
+    return entity;
+  }
+}

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/qualityscoring/entities/TimeseriesQualityScoringConfig.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/qualityscoring/entities/TimeseriesQualityScoringConfig.java
@@ -1,0 +1,84 @@
+package de.dlr.shepard.v2.admin.qualityscoring.entities;
+
+import de.dlr.shepard.common.identifier.HasAppId;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Property;
+
+/**
+ * FTOGGLE-QS-1 — runtime-mutable config singleton for the AI1c
+ * quality-scoring background job.
+ *
+ * <p>Single-instance Neo4j node following the A3b / N1c2 / UH1a /
+ * MFFD-NDT-ADMIN-CONFIG-1 pattern. One {@code :TimeseriesQualityScoringConfig}
+ * node is seeded on first startup from the deploy-time defaults in
+ * {@code application.properties}; subsequent PATCH calls via
+ * {@code PATCH /v2/admin/config/timeseries-quality-scoring} mutate this
+ * node in place.
+ *
+ * <p>Runtime-mutable fields:
+ * <ul>
+ *   <li>{@link #enabled} — whether the scoring job fires. {@code null} →
+ *       fall back to the deploy-time default ({@code false}).</li>
+ *   <li>{@link #batchSize} — max references scored per tick. {@code null} →
+ *       fall back to the deploy-time default (100). Clamped to [1, 10 000]
+ *       by the job itself.</li>
+ * </ul>
+ *
+ * <p>The scheduling interval ({@code shepard.timeseries.quality-scoring.interval})
+ * is Quarkus-evaluated at startup and stays deploy-time-only per the
+ * CLAUDE.md "Pre-startup ordering invariants" exception.
+ *
+ * <p><b>Constraint.</b> V115 migration adds
+ * {@code REQUIRE n.appId IS UNIQUE} on {@code :TimeseriesQualityScoringConfig}.
+ */
+@NodeEntity
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class TimeseriesQualityScoringConfig implements HasAppId {
+
+  @Id
+  @GeneratedValue
+  private Long id;
+
+  @Property("appId")
+  private String appId;
+
+  /**
+   * Whether the quality-scoring job is active. {@code null} means
+   * "use the deploy-time default (false)".
+   */
+  @Property("enabled")
+  private Boolean enabled;
+
+  /**
+   * Max references scored per tick. {@code null} means "use the
+   * deploy-time default (100)". The job clamps to [1, 10 000].
+   */
+  @Property("batchSize")
+  private Integer batchSize;
+
+  public TimeseriesQualityScoringConfig(long id) {
+    this.id = id;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(appId);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj instanceof TimeseriesQualityScoringConfig other)) return false;
+    return Objects.equals(appId, other.appId);
+  }
+}

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/qualityscoring/io/TimeseriesQualityScoringConfigIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/qualityscoring/io/TimeseriesQualityScoringConfigIO.java
@@ -1,0 +1,40 @@
+package de.dlr.shepard.v2.admin.qualityscoring.io;
+
+import de.dlr.shepard.v2.admin.qualityscoring.entities.TimeseriesQualityScoringConfig;
+
+/**
+ * FTOGGLE-QS-1 — JSON shape for
+ * {@code GET/PATCH /v2/admin/config/timeseries-quality-scoring}.
+ *
+ * <p>All fields are resolved (never null on the wire) — the factory
+ * method applies deploy-time defaults when the singleton carries null.
+ *
+ * <p>Wire names:
+ * <ul>
+ *   <li>{@link #enabled} — whether the AI1c scoring job fires</li>
+ *   <li>{@link #batchSize} — max references scored per tick</li>
+ * </ul>
+ *
+ * <p>Note: {@code interval} (the Quarkus {@code @Scheduled.every} cadence)
+ * is deploy-time-only and is not exposed here — changing it requires a
+ * restart; see CLAUDE.md "Pre-startup ordering invariants" exception.
+ */
+public record TimeseriesQualityScoringConfigIO(
+  boolean enabled,
+  int batchSize
+) {
+
+  /**
+   * Project a {@link TimeseriesQualityScoringConfig} onto the IO record,
+   * resolving {@code null} fields against the deploy-time defaults.
+   */
+  public static TimeseriesQualityScoringConfigIO from(
+    TimeseriesQualityScoringConfig cfg,
+    boolean defaultEnabled,
+    int defaultBatchSize
+  ) {
+    boolean eff = cfg.getEnabled() != null ? cfg.getEnabled() : defaultEnabled;
+    int bs = cfg.getBatchSize() != null ? cfg.getBatchSize() : defaultBatchSize;
+    return new TimeseriesQualityScoringConfigIO(eff, bs);
+  }
+}

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/qualityscoring/services/TimeseriesQualityScoringConfigService.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/qualityscoring/services/TimeseriesQualityScoringConfigService.java
@@ -1,0 +1,112 @@
+package de.dlr.shepard.v2.admin.qualityscoring.services;
+
+import de.dlr.shepard.v2.admin.qualityscoring.daos.TimeseriesQualityScoringConfigDAO;
+import de.dlr.shepard.v2.admin.qualityscoring.entities.TimeseriesQualityScoringConfig;
+import de.dlr.shepard.v2.admin.qualityscoring.io.TimeseriesQualityScoringConfigIO;
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.RequestContextController;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * FTOGGLE-QS-1 — service layer for the {@code :TimeseriesQualityScoringConfig}
+ * singleton. Mirrors the {@code ThermographyConfigService} shape.
+ *
+ * <p>Seeds the singleton on startup from deploy-time defaults; exposes
+ * {@link #isEnabled()} and {@link #effectiveBatchSize()} so the AI1c
+ * {@code TimeseriesQualityScoringJob} can read runtime-mutable values without
+ * re-reading {@code @ConfigProperty} on every tick.
+ */
+@ApplicationScoped
+public class TimeseriesQualityScoringConfigService {
+
+  @Inject
+  TimeseriesQualityScoringConfigDAO dao;
+
+  @Inject
+  RequestContextController requestContextController;
+
+  @ConfigProperty(name = "shepard.timeseries.quality-scoring.enabled", defaultValue = "false")
+  boolean defaultEnabled;
+
+  @ConfigProperty(name = "shepard.timeseries.quality-scoring.batch-size", defaultValue = "100")
+  int defaultBatchSize;
+
+  void onStart(@Observes StartupEvent event) {
+    boolean activated = requestContextController.activate();
+    try {
+      seedIfNeeded();
+    } catch (RuntimeException e) {
+      Log.warnf(e,
+        "FTOGGLE-QS-1: could not seed :TimeseriesQualityScoringConfig on startup; " +
+        "job will use deploy-time defaults");
+    } finally {
+      if (activated) {
+        requestContextController.deactivate();
+      }
+    }
+  }
+
+  public synchronized TimeseriesQualityScoringConfig seedIfNeeded() {
+    return dao.findSingleton().orElseGet(() -> {
+      TimeseriesQualityScoringConfig seed = new TimeseriesQualityScoringConfig();
+      seed.setEnabled(null);
+      seed.setBatchSize(null);
+      TimeseriesQualityScoringConfig saved = dao.createOrUpdate(seed);
+      Log.infof(
+        "FTOGGLE-QS-1: seeded :TimeseriesQualityScoringConfig (appId=%s, " +
+        "enabled=<default %b>, batchSize=<default %d>)",
+        saved.getAppId(), defaultEnabled, defaultBatchSize);
+      return saved;
+    });
+  }
+
+  public TimeseriesQualityScoringConfig current() {
+    return dao.findSingleton().orElseGet(this::seedIfNeeded);
+  }
+
+  /** Effective config IO with all null fields resolved to deploy-time defaults. */
+  public TimeseriesQualityScoringConfigIO getConfig() {
+    return TimeseriesQualityScoringConfigIO.from(current(), defaultEnabled, defaultBatchSize);
+  }
+
+  /** Runtime-effective enabled flag — used by the job. */
+  public boolean isEnabled() {
+    TimeseriesQualityScoringConfig cfg = dao.findSingleton().orElse(null);
+    if (cfg == null || cfg.getEnabled() == null) return defaultEnabled;
+    return cfg.getEnabled();
+  }
+
+  /** Runtime-effective batch size — used by the job. */
+  public int effectiveBatchSize() {
+    TimeseriesQualityScoringConfig cfg = dao.findSingleton().orElse(null);
+    if (cfg == null || cfg.getBatchSize() == null) return defaultBatchSize;
+    return cfg.getBatchSize();
+  }
+
+  /**
+   * Apply a runtime merge-patch. Null arguments revert the field to the
+   * deploy-time default (RFC 7396 semantics).
+   */
+  public synchronized TimeseriesQualityScoringConfigIO patch(Boolean enabled, Integer batchSize) {
+    TimeseriesQualityScoringConfig cfg = current();
+    cfg.setEnabled(enabled);
+    cfg.setBatchSize(batchSize);
+    TimeseriesQualityScoringConfig saved = dao.createOrUpdate(cfg);
+    Log.infof(
+      "FTOGGLE-QS-1: :TimeseriesQualityScoringConfig patched (enabled=%s, batchSize=%s)",
+      saved.getEnabled(), saved.getBatchSize());
+    return TimeseriesQualityScoringConfigIO.from(saved, defaultEnabled, defaultBatchSize);
+  }
+
+  public boolean getDefaultEnabled() {
+    return defaultEnabled;
+  }
+
+  public int getDefaultBatchSize() {
+    return defaultBatchSize;
+  }
+}

--- a/backend/src/main/resources/neo4j/migrations/V115_R__Add_appId_constraint_TimeseriesQualityScoringConfig.cypher
+++ b/backend/src/main/resources/neo4j/migrations/V115_R__Add_appId_constraint_TimeseriesQualityScoringConfig.cypher
@@ -1,0 +1,3 @@
+// FTOGGLE-QS-1 rollback — drop the unique constraint on TimeseriesQualityScoringConfig.appId
+// Safe to re-run: DROP CONSTRAINT … IF EXISTS is idempotent.
+DROP CONSTRAINT TimeseriesQualityScoringConfig_appId_unique IF EXISTS;

--- a/backend/src/main/resources/neo4j/migrations/V115__Add_appId_constraint_TimeseriesQualityScoringConfig.cypher
+++ b/backend/src/main/resources/neo4j/migrations/V115__Add_appId_constraint_TimeseriesQualityScoringConfig.cypher
@@ -1,0 +1,10 @@
+// FTOGGLE-QS-1 — unique constraint on TimeseriesQualityScoringConfig.appId
+// Safe to re-run: CREATE CONSTRAINT … IF NOT EXISTS is idempotent.
+// The singleton invariant (one :TimeseriesQualityScoringConfig node) is enforced by:
+//   (1) TimeseriesQualityScoringConfigService.seedIfNeeded() minting exactly one node on startup
+//   (2) this constraint rejecting any accidental duplicates at the DB boundary
+// Mirrors V114 (:ThermographyConfig), V94 (:JupyterConfig), V43 (:SqlTimeseriesConfig).
+// Operator runbook: runs automatically on backend startup via MigrationsRunner; no manual step.
+// Cross-reference: aidocs/16 FTOGGLE-QS-1.
+CREATE CONSTRAINT TimeseriesQualityScoringConfig_appId_unique IF NOT EXISTS
+FOR (n:TimeseriesQualityScoringConfig) REQUIRE n.appId IS UNIQUE;

--- a/backend/src/test/java/de/dlr/shepard/context/references/timeseriesreference/services/TimeseriesQualityScoringJobTest.java
+++ b/backend/src/test/java/de/dlr/shepard/context/references/timeseriesreference/services/TimeseriesQualityScoringJobTest.java
@@ -19,6 +19,7 @@ import de.dlr.shepard.context.references.timeseriesreference.daos.TimeseriesRefe
 import de.dlr.shepard.context.references.timeseriesreference.model.ReferencedTimeseriesNodeEntity;
 import de.dlr.shepard.context.references.timeseriesreference.model.TimeseriesReference;
 import de.dlr.shepard.data.timeseries.model.Timeseries;
+import de.dlr.shepard.v2.admin.qualityscoring.services.TimeseriesQualityScoringConfigService;
 import de.dlr.shepard.data.timeseries.model.TimeseriesContainer;
 import de.dlr.shepard.data.timeseries.model.TimeseriesDataPoint;
 import de.dlr.shepard.data.timeseries.model.TimeseriesEntity;
@@ -51,6 +52,9 @@ class TimeseriesQualityScoringJobTest {
   @Mock
   TimeseriesDataPointRepository timeseriesDataPointRepository;
 
+  @Mock
+  TimeseriesQualityScoringConfigService configService;
+
   TimeseriesQualityScoringJob job;
   TimeseriesQualityScorer scorer;
 
@@ -65,8 +69,9 @@ class TimeseriesQualityScoringJobTest {
     job.scorer = scorer;
     job.timeseriesRepository = timeseriesRepository;
     job.timeseriesDataPointRepository = timeseriesDataPointRepository;
-    job.enabled = true;
-    job.batchSize = 100;
+    job.qualityScoringConfigService = configService;
+    when(configService.isEnabled()).thenReturn(true);
+    when(configService.effectiveBatchSize()).thenReturn(100);
   }
 
   // ---------------------------------------------------------------
@@ -103,7 +108,7 @@ class TimeseriesQualityScoringJobTest {
 
   @Test
   void runIsNoOpWhenDisabled() {
-    job.enabled = false;
+    when(configService.isEnabled()).thenReturn(false);
     job.runScoring();
     verify(dao, never()).findNeedingScoring(anyLong(), anyInt());
     verify(dao, never()).createOrUpdate(any());
@@ -134,7 +139,7 @@ class TimeseriesQualityScoringJobTest {
 
   @Test
   void runClampsAbsurdlyHighBatchSize() {
-    job.batchSize = 1_000_000;
+    when(configService.effectiveBatchSize()).thenReturn(1_000_000);
     when(dao.findNeedingScoring(anyLong(), anyInt())).thenReturn(List.of());
     job.runScoring();
     ArgumentCaptor<Integer> limit = ArgumentCaptor.forClass(Integer.class);
@@ -144,7 +149,7 @@ class TimeseriesQualityScoringJobTest {
 
   @Test
   void runClampsNegativeBatchSize() {
-    job.batchSize = -5;
+    when(configService.effectiveBatchSize()).thenReturn(-5);
     when(dao.findNeedingScoring(anyLong(), anyInt())).thenReturn(List.of());
     job.runScoring();
     ArgumentCaptor<Integer> limit = ArgumentCaptor.forClass(Integer.class);

--- a/backend/src/test/java/de/dlr/shepard/v2/admin/config/descriptors/TimeseriesQualityScoringConfigDescriptorTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/admin/config/descriptors/TimeseriesQualityScoringConfigDescriptorTest.java
@@ -1,0 +1,196 @@
+package de.dlr.shepard.v2.admin.config.descriptors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import de.dlr.shepard.v2.admin.config.spi.ConfigPatchException;
+import de.dlr.shepard.v2.admin.qualityscoring.entities.TimeseriesQualityScoringConfig;
+import de.dlr.shepard.v2.admin.qualityscoring.io.TimeseriesQualityScoringConfigIO;
+import de.dlr.shepard.v2.admin.qualityscoring.services.TimeseriesQualityScoringConfigService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** FTOGGLE-QS-1 — unit tests for {@link TimeseriesQualityScoringConfigDescriptor}. */
+class TimeseriesQualityScoringConfigDescriptorTest {
+
+  private static final boolean DEFAULT_ENABLED = false;
+  private static final int DEFAULT_BATCH_SIZE = 100;
+
+  private TimeseriesQualityScoringConfigService service;
+  private TimeseriesQualityScoringConfigDescriptor descriptor;
+
+  private static TimeseriesQualityScoringConfig cfg(Boolean enabled, Integer batchSize) {
+    TimeseriesQualityScoringConfig c = new TimeseriesQualityScoringConfig();
+    c.setEnabled(enabled);
+    c.setBatchSize(batchSize);
+    return c;
+  }
+
+  @BeforeEach
+  void setUp() {
+    service = mock(TimeseriesQualityScoringConfigService.class);
+    when(service.getDefaultEnabled()).thenReturn(DEFAULT_ENABLED);
+    when(service.getDefaultBatchSize()).thenReturn(DEFAULT_BATCH_SIZE);
+    when(service.current()).thenReturn(cfg(null, null));
+    when(service.getConfig()).thenReturn(
+      new TimeseriesQualityScoringConfigIO(DEFAULT_ENABLED, DEFAULT_BATCH_SIZE));
+    descriptor = new TimeseriesQualityScoringConfigDescriptor();
+    descriptor.service = service;
+  }
+
+  @Test
+  void featureNameIsTimeseriesQualityScoring() {
+    assertEquals("timeseries-quality-scoring", descriptor.featureName());
+  }
+
+  @Test
+  void descriptionIsNonEmpty() {
+    assertNotNull(descriptor.description());
+    assertFalse(descriptor.description().isBlank());
+  }
+
+  @Test
+  void currentShapeDelegatesToService() {
+    TimeseriesQualityScoringConfigIO result = descriptor.currentShape();
+    assertFalse(result.enabled());
+    assertEquals(DEFAULT_BATCH_SIZE, result.batchSize());
+  }
+
+  @Test
+  void patchEnabled_setsTrue_leavesBatchAlone() throws Exception {
+    when(service.current()).thenReturn(cfg(null, 50));
+    when(service.patch(eq(true), eq(50)))
+      .thenReturn(new TimeseriesQualityScoringConfigIO(true, 50));
+
+    ObjectNode patch = JsonNodeFactory.instance.objectNode().put("enabled", true);
+    TimeseriesQualityScoringConfigIO out = descriptor.applyMergePatch(patch);
+
+    assertTrue(out.enabled());
+    assertEquals(50, out.batchSize());
+    verify(service).patch(true, 50);
+  }
+
+  @Test
+  void patchBatchSize_leavesEnabledAlone() throws Exception {
+    when(service.current()).thenReturn(cfg(true, null));
+    when(service.patch(eq(true), eq(200)))
+      .thenReturn(new TimeseriesQualityScoringConfigIO(true, 200));
+
+    ObjectNode patch = JsonNodeFactory.instance.objectNode().put("batchSize", 200);
+    TimeseriesQualityScoringConfigIO out = descriptor.applyMergePatch(patch);
+
+    assertTrue(out.enabled());
+    assertEquals(200, out.batchSize());
+  }
+
+  @Test
+  void patchBothFields_updatesAll() throws Exception {
+    when(service.current()).thenReturn(cfg(false, 100));
+    when(service.patch(eq(true), eq(500)))
+      .thenReturn(new TimeseriesQualityScoringConfigIO(true, 500));
+
+    ObjectNode patch = JsonNodeFactory.instance.objectNode()
+      .put("enabled", true)
+      .put("batchSize", 500);
+    TimeseriesQualityScoringConfigIO out = descriptor.applyMergePatch(patch);
+
+    assertTrue(out.enabled());
+    assertEquals(500, out.batchSize());
+    verify(service).patch(true, 500);
+  }
+
+  @Test
+  void patchNullEnabled_revertsToDefault() throws Exception {
+    when(service.current()).thenReturn(cfg(true, 200));
+    when(service.patch(isNull(), eq(200)))
+      .thenReturn(new TimeseriesQualityScoringConfigIO(DEFAULT_ENABLED, 200));
+
+    ObjectNode patch = JsonNodeFactory.instance.objectNode();
+    patch.putNull("enabled");
+    TimeseriesQualityScoringConfigIO out = descriptor.applyMergePatch(patch);
+
+    assertFalse(out.enabled());
+    verify(service).patch(null, 200);
+  }
+
+  @Test
+  void patchNullBatchSize_revertsToDefault() throws Exception {
+    when(service.current()).thenReturn(cfg(true, 500));
+    when(service.patch(eq(true), isNull()))
+      .thenReturn(new TimeseriesQualityScoringConfigIO(true, DEFAULT_BATCH_SIZE));
+
+    ObjectNode patch = JsonNodeFactory.instance.objectNode();
+    patch.putNull("batchSize");
+    TimeseriesQualityScoringConfigIO out = descriptor.applyMergePatch(patch);
+
+    assertEquals(DEFAULT_BATCH_SIZE, out.batchSize());
+    verify(service).patch(true, null);
+  }
+
+  @Test
+  void emptyPatch_leavesAllFieldsAlone() throws Exception {
+    when(service.current()).thenReturn(cfg(true, 300));
+    when(service.patch(eq(true), eq(300)))
+      .thenReturn(new TimeseriesQualityScoringConfigIO(true, 300));
+
+    ObjectNode patch = JsonNodeFactory.instance.objectNode();
+    TimeseriesQualityScoringConfigIO out = descriptor.applyMergePatch(patch);
+
+    assertTrue(out.enabled());
+    assertEquals(300, out.batchSize());
+  }
+
+  @Test
+  void zeroBatchSize_throws() {
+    when(service.current()).thenReturn(cfg(false, 100));
+    ConfigPatchException ex = assertThrows(
+      ConfigPatchException.class,
+      () -> descriptor.applyMergePatch(
+        JsonNodeFactory.instance.objectNode().put("batchSize", 0)));
+    assertEquals(
+      TimeseriesQualityScoringConfigDescriptor.PROBLEM_TYPE_INVALID_BATCH_SIZE,
+      ex.getProblemType());
+  }
+
+  @Test
+  void negativeBatchSize_throws() {
+    when(service.current()).thenReturn(cfg(false, 100));
+    ConfigPatchException ex = assertThrows(
+      ConfigPatchException.class,
+      () -> descriptor.applyMergePatch(
+        JsonNodeFactory.instance.objectNode().put("batchSize", -5)));
+    assertEquals(
+      TimeseriesQualityScoringConfigDescriptor.PROBLEM_TYPE_INVALID_BATCH_SIZE,
+      ex.getProblemType());
+  }
+
+  @Test
+  void configIO_from_resolvesNullsAgainstDefaults() {
+    TimeseriesQualityScoringConfig c = new TimeseriesQualityScoringConfig();
+    TimeseriesQualityScoringConfigIO io =
+      TimeseriesQualityScoringConfigIO.from(c, DEFAULT_ENABLED, DEFAULT_BATCH_SIZE);
+    assertFalse(io.enabled());
+    assertEquals(DEFAULT_BATCH_SIZE, io.batchSize());
+  }
+
+  @Test
+  void configIO_from_runtimeValuesWinOverDefaults() {
+    TimeseriesQualityScoringConfig c = new TimeseriesQualityScoringConfig();
+    c.setEnabled(true);
+    c.setBatchSize(777);
+    TimeseriesQualityScoringConfigIO io =
+      TimeseriesQualityScoringConfigIO.from(c, DEFAULT_ENABLED, DEFAULT_BATCH_SIZE);
+    assertTrue(io.enabled());
+    assertEquals(777, io.batchSize());
+  }
+}


### PR DESCRIPTION
## Summary

FEATURE-TOGGLES-AS-PLUGINS MIGRATE sub-task 2 of 4.

Makes `shepard.timeseries.quality-scoring.enabled` (boolean) and `shepard.timeseries.quality-scoring.batch-size` (int) **runtime-mutable** via the established `:*Config` singleton + `ConfigDescriptor` SPI pattern (V2CONV-A4). Operators no longer need a restart to enable/disable the AI1c quality-scoring job or adjust its batch size.

### New files
- `TimeseriesQualityScoringConfig` — Neo4j `HasAppId` singleton entity
- `TimeseriesQualityScoringConfigDAO` — fresh-session singleton DAO (mirrors `ThermographyConfigDAO`)
- `TimeseriesQualityScoringConfigService` — seeds on `StartupEvent`; exposes `isEnabled()` / `effectiveBatchSize()` + RFC 7396 `patch()`
- `TimeseriesQualityScoringConfigIO` — wire record `{enabled, batchSize}`
- `TimeseriesQualityScoringConfigDescriptor` — `ConfigDescriptor<IO>`, `featureName="timeseries-quality-scoring"`, validates `batchSize ≥ 1`
- `V115__Add_appId_constraint_TimeseriesQualityScoringConfig.cypher` (idempotent) + rollback twin

### Modified
- `TimeseriesQualityScoringJob` — injects `TimeseriesQualityScoringConfigService` instead of two `@ConfigProperty` fields. `@Scheduled.every` interval stays deploy-time (Quarkus evaluates at startup — CLAUDE.md "pre-startup ordering invariants" exception).
- `TimeseriesQualityScoringJobTest` — updated to mock the config service.

### Exposed endpoint
`GET /v2/admin/config/timeseries-quality-scoring` — current config  
`PATCH /v2/admin/config/timeseries-quality-scoring` — runtime flip (RFC 7396)

```json
{ "enabled": true, "batchSize": 500 }
```

### Tests
- 13 unit tests in `TimeseriesQualityScoringConfigDescriptorTest` (all pass)
- 16 unit tests in `TimeseriesQualityScoringJobTest` (all pass; 3 test cases updated for service mock)

## Test plan
- [ ] `mvn -DnoPlugins -DbootstrapTestjar -Dtest="TimeseriesQualityScoringConfigDescriptorTest,TimeseriesQualityScoringJobTest" test` — 29/29 pass
- [ ] CI: unit tests + coverage gate green
- [ ] `PATCH /v2/admin/config/timeseries-quality-scoring {"enabled":true}` → job fires next tick
- [ ] `PATCH /v2/admin/config/timeseries-quality-scoring {"batchSize":0}` → 400 Bad Request

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsY14Unt2EzoHCySWRcRSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsY14Unt2EzoHCySWRcRSz)_