### PR TITLE
feat(apisimp): APISIMP-V1COMPAT-STATS-TOPN-PARAM — document topN param + wire v1-compat into CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Plugin unit tests
         run: |
           set -e
-          for p in kip minter-local minter-datacite minter-epic spatiotemporal hdf5 git file-s3; do
+          for p in kip minter-local minter-datacite minter-epic spatiotemporal hdf5 git file-s3 v1-compat; do
             echo "::group::test plugin $p"
             ( cd "plugins/$p" && mvn -B test )
             echo "::endgroup::"

--- a/plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/resources/LegacyV1StatsAdminRest.java
+++ b/plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/resources/LegacyV1StatsAdminRest.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -60,7 +61,13 @@ public class LegacyV1StatsAdminRest {
     content = @Content(schema = @Schema(implementation = LegacyV1StatsIO.class))
   )
   @APIResponse(responseCode = "403", description = "Caller lacks the instance-admin role.")
-  public Response getStats(@QueryParam("topN") Integer topN) {
+  public Response getStats(
+    @Parameter(
+      description = "Maximum number of entity-type and principal buckets to return, ranked by hit count. " +
+      "Default 50. Values below 1 are clamped to 1; values above " + MAX_TOP_N + " are clamped to " + MAX_TOP_N + ". " +
+      "Pass a small value (e.g. 10) for a concise admin overview; pass " + MAX_TOP_N + " to see the full tail."
+    )
+    @QueryParam("topN") Integer topN) {
     int effective = topN == null ? LegacyV1StatsService.DEFAULT_TOP_N : Math.min(Math.max(1, topN), MAX_TOP_N);
     return Response.ok(stats.snapshot(effective)).build();
   }

--- a/plugins/v1-compat/src/test/java/de/dlr/shepard/plugins/v1compat/resources/LegacyV1StatsAdminRestTest.java
+++ b/plugins/v1-compat/src/test/java/de/dlr/shepard/plugins/v1compat/resources/LegacyV1StatsAdminRestTest.java
@@ -7,8 +7,12 @@ import static org.mockito.Mockito.when;
 
 import de.dlr.shepard.plugins.v1compat.io.LegacyV1StatsIO;
 import de.dlr.shepard.plugins.v1compat.services.LegacyV1StatsService;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -65,5 +69,24 @@ class LegacyV1StatsAdminRestTest {
     rest.getStats(-5);
 
     verify(stats, org.mockito.Mockito.times(2)).snapshot(1);
+  }
+
+  // ─── APISIMP-V1COMPAT-STATS-TOPN-PARAM regression ───────────────────────
+
+  @Test
+  void getStats_topNParamIsDocumented() throws NoSuchMethodException {
+    Method method = LegacyV1StatsAdminRest.class.getMethod("getStats", Integer.class);
+    String desc = Arrays.stream(method.getParameters())
+      .filter(p -> p.getAnnotation(QueryParam.class) != null
+        && "topN".equals(p.getAnnotation(QueryParam.class).value()))
+      .map(p -> {
+        Parameter ann = p.getAnnotation(Parameter.class);
+        return ann != null ? ann.description() : "";
+      })
+      .findFirst()
+      .orElse("");
+    assertThat(desc)
+      .as("@Parameter description must be present and non-blank on @QueryParam(\"topN\") — APISIMP-V1COMPAT-STATS-TOPN-PARAM")
+      .isNotBlank();
   }
 }


### PR DESCRIPTION
## Summary

**Row:** `APISIMP-V1COMPAT-STATS-TOPN-PARAM` (fire-173)

`LegacyV1StatsAdminRest.getStats()` at `GET /v2/admin/legacy/v1/stats` accepted `@QueryParam("topN") Integer topN` with no `@Parameter` annotation. OpenAPI callers had no way to know the param is optional, defaults to 50, is clamped to `[1, 1000]`, or what it controls.

**Changes:**
- `LegacyV1StatsAdminRest.java` — add `@Parameter(description=…)` to `topN` (imports `org.eclipse.microprofile.openapi.annotations.parameters.Parameter`)
- `LegacyV1StatsAdminRestTest.java` — add `getStats_topNParamIsDocumented()` reflection regression test (checks `@Parameter` description is non-blank on the `@QueryParam("topN")` param)
- `.github/workflows/ci.yml` — add `v1-compat` to the "Plugin unit tests" loop so the regression test actually runs in CI (v1-compat was previously installed but not tested)
- `aidocs/16` — row status updated

No runtime behaviour change.

## Test plan

- [x] `LegacyV1StatsAdminRestTest` — existing 4 tests + new `getStats_topNParamIsDocumented()` pass
- [x] CI "Plugin unit tests" now runs v1-compat tests
- [x] `mvn verify -pl backend` green (backend unaffected)
- [x] No runtime change: `getStats()` logic is untouched

## Backlog

- `aidocs/16` `APISIMP-V1COMPAT-STATS-TOPN-PARAM` → `in-progress (fire-173)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSq5B5yGZmG1NzwHsUVU9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSq5B5yGZmG1NzwHsUVU9o)_