### PR TITLE
fix: remove two compile blockers — duplicate @Parameter description + missing return statement

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticSparqlRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticSparqlRest.java
@@ -207,16 +207,11 @@ public class SemanticSparqlRest {
     @Parameter(
       required = true,
       description =
-        "SPARQL 1.1 SELECT or ASK query string. " +
-        "Mutation forms (CONSTRUCT, INSERT, DELETE, UPDATE) return 400. " +
-        "Minimum 1 character."
-      description =
         "URL-encoded SPARQL 1.1 SELECT or ASK query string. Must be non-empty — null or blank " +
         "returns 400. Only `SELECT` and `ASK` query forms are accepted; any mutation form " +
         "(`CONSTRUCT`, `INSERT`, `DELETE`, `UPDATE`, …) is rejected with 400 before reaching " +
         "the backend. For queries longer than ~2 KB prefer the POST form variant " +
-        "(`application/x-www-form-urlencoded`, field name `query`) to avoid proxy URL-length limits.",
-      required = true
+        "(`application/x-www-form-urlencoded`, field name `query`) to avoid proxy URL-length limits."
     )
     @QueryParam("query") String query,
     @Context SecurityContext sc

--- a/backend/src/test/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2RestTest.java
@@ -813,6 +813,13 @@ class SemanticAnnotationV2RestTest {
     java.lang.reflect.Method method = SemanticAnnotationV2Rest.class.getMethod(
         "list", String.class, String.class, String.class, String.class,
         int.class, int.class, SecurityContext.class);
+    return java.util.Arrays.stream(method.getParameters())
+        .filter(p -> {
+          var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class);
+          return qp != null && queryParamName.equals(qp.value());
+        })
+        .findFirst()
+        .orElse(null);
   }
 
   private static java.lang.reflect.Parameter findFindParam(String queryParamName)


### PR DESCRIPTION
## Summary

**Two compile blockers found and fixed — both blocked all backend CI.**

### Fix 1 — duplicate `@Parameter` description (introduced by #2010)

`SemanticSparqlRest.queryGet()` had two `description =` assignments inside the same `@Parameter` annotation. Java disallows duplicate annotation element names, causing:

```
[ERROR] SemanticSparqlRest.java:[212,31] ')' expected
[ERROR] SemanticSparqlRest.java:[213,18]  expected
[ERROR] SemanticSparqlRest.java:[222,13] ';' expected
```

**Fix:** Remove the first (shorter, partial) `description` field and the duplicate `required = true`, keeping the complete second description.

### Fix 2 — missing `return` statement in test helper (introduced by #2035)

`SemanticAnnotationV2RestTest.findListParam()` obtained the method via reflection but never returned the matching parameter. This caused `testCompile` to fail:

```
[ERROR] SemanticAnnotationV2RestTest.java:[816,3] missing return statement
```

**Fix:** Add the missing `return java.util.Arrays.stream(...)` body (mirrors the existing `findFindParam` helper pattern).

Together these two defects blocked every open backend PR (~30 PRs including #2066, #1997, and all NPE-red PRs waiting for rebase).

## Test plan

- [x] `mvn compile test-compile -f backend/pom.xml -DnoPlugins` produces no errors on `SemanticSparqlRest.java` or `SemanticAnnotationV2RestTest.java`
- [x] No logic change — annotation-only fix + test helper completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWqKa7kmANw9o9Wp2t3hHg