### PR TITLE
docs(APISIMP-PROVENANCE-CURSOR-UNDOCUMENTED): document time-cursor pagination on ProvenanceRest

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
@@ -86,8 +86,13 @@ public class ProvenanceRest {
   @Operation(
     summary = "List provenance activities (most recent first).",
     description = "Filterable by agent / target / time window. Casual users see only their own " +
-    "rows; instance-admins see all. Caps at 1000 rows per response — paginate via " +
-    "narrowing the time window."
+    "rows; instance-admins see all. Caps at 1000 rows per response.\n\n" +
+    "**Pagination:** This endpoint uses time-cursor pagination (`since`/`until` epoch ms), " +
+    "not page-offset. Offset pagination produces inconsistent results as new Activities land " +
+    "concurrently (append-only event stream — a new row shifts all subsequent offsets). To " +
+    "walk a large window: record the oldest `startedAt` value in the current page and pass it " +
+    "as `until` on the next request. The `?page=` query parameter is not supported and is " +
+    "silently ignored if supplied."
   )
   @APIResponse(
     responseCode = "200",
@@ -229,7 +234,10 @@ public class ProvenanceRest {
     summary = "Provenance trail for a single entity (most recent first).",
     description = "Returns every captured Activity whose targetAppId matches the supplied entity. " +
     "Casual users see only rows whose acting Agent is themselves; instance-admins see all rows " +
-    "targeting the entity. Honours ?profile=metadata|relations|all from V2S1a. Caps at 1000 rows."
+    "targeting the entity. Honours ?profile=metadata|relations|all from V2S1a. Caps at 1000 rows.\n\n" +
+    "**Pagination:** Uses time-cursor pagination (`since`/`until` epoch ms) — see " +
+    "`GET /v2/provenance/activities` for the full rationale. The `?page=` parameter is not " +
+    "supported and is silently ignored."
   )
   @APIResponse(
     responseCode = "200",


### PR DESCRIPTION
## Summary

`aidocs/16` row **APISIMP-PROVENANCE-CURSOR-UNDOCUMENTED** — fire-201, XS slice.

Two `@Operation` descriptions updated in `ProvenanceRest.java` to explicitly document
why the provenance endpoints use **time-cursor pagination** (`since`/`until` epoch ms)
rather than the `page`+`pageSize` convention used by every other v2 list endpoint.

### What changed

- `GET /v2/provenance/activities` — added pagination rationale: the activity stream is
  append-only, so offset pagination drifts under concurrent writes (a new row shifts all
  subsequent offsets). Documents the correct walk pattern: record oldest `startedAt` from
  the current page, pass it as `until` on the next request.
- `GET /v2/provenance/activities/{entityAppId}` — added cross-reference to the rationale
  on the sibling endpoint; notes cap at 1000 rows and `?page=` is silently ignored.

### No runtime changes

Pure OpenAPI documentation — no logic, no wire-shape, no schema changes. Safe to merge
without backend restart concern.

### Checklist

- [x] `/shepard/api/` v1 surface untouched
- [x] No new `@Path(Constants.SHEPARD_API + ...)` 
- [x] `appId` used throughout (no numeric Neo4j IDs)
- [x] Secondary write / fire-and-forget pattern N/A (doc-only)
- [x] `aidocs/16` row to be updated on main post-merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoYY4w5CmEHQcM6FZnxFBm)_