### PR TITLE
fix(APISIMP-LJE-DATAOBJECTID-NUMERIC): add dataObjectAppId (UUID v7) to LabJournalEntryIO

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/context/labJournal/io/LabJournalEntryIO.java
+++ b/backend/src/main/java/de/dlr/shepard/context/labJournal/io/LabJournalEntryIO.java
@@ -13,9 +13,24 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(name = "LabJournalEntry")
 public class LabJournalEntryIO {
 
-  @Schema(readOnly = true, required = true)
+  /**
+   * APISIMP-LJE-DATAOBJECTID-NUMERIC: numeric Neo4j OGM id — kept for existing
+   * callers; use {@code dataObjectAppId} (UUID v7) for new code.
+   */
+  @Schema(readOnly = true, required = true, deprecated = true,
+      description = "DEPRECATED: numeric Neo4j OGM id of the parent DataObject. Use dataObjectAppId (UUID v7) instead.")
   @NotNull
   private long dataObjectId;
+
+  /**
+   * UUID v7 appId of the parent DataObject — the single stable cross-substrate
+   * identity. Null only for entries whose DataObject predates the L2a appId
+   * backfill.
+   */
+  @Schema(readOnly = true, nullable = true,
+      description = "UUID v7 appId of the parent DataObject. Preferred over the deprecated dataObjectId.",
+      example = "019506b4-dc55-7c92-b4e1-bf94db37e5b9")
+  private String dataObjectAppId;
 
   @NotNull
   private String journalContent;
@@ -84,6 +99,7 @@ public class LabJournalEntryIO {
   public LabJournalEntryIO(LabJournalEntry labJournalEntry) {
     this.appId = labJournalEntry.getAppId();
     this.dataObjectId = labJournalEntry.getDataObject().getShepardId();
+    this.dataObjectAppId = labJournalEntry.getDataObject().getAppId();
     this.journalContent = labJournalEntry.getContent();
     this.id = labJournalEntry.getId();
     this.createdAt = labJournalEntry.getCreatedAt();

--- a/backend/src/test/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRestTest.java
@@ -53,6 +53,9 @@ class CollectionLabJournalEntriesRestTest {
 
   CollectionLabJournalEntriesRest resource;
 
+  static final String DO_APP_ID_1 = "019506b4-dc55-7c92-b4e1-bf94db37e5b1";
+  static final String DO_APP_ID_2 = "019506b4-dc55-7c92-b4e1-bf94db37e5b2";
+
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
@@ -68,8 +71,8 @@ class CollectionLabJournalEntriesRestTest {
       .thenReturn(true);
     when(entriesDAO.findByCollectionAppId(COLL_APP_ID))
       .thenReturn(List.of(
-        buildEntry(11L, 101L, "newer", new Date(2_000_000L)),
-        buildEntry(12L, 102L, "older", new Date(1_000_000L))
+        buildEntry(11L, 101L, DO_APP_ID_1, "newer", new Date(2_000_000L)),
+        buildEntry(12L, 102L, DO_APP_ID_2, "older", new Date(1_000_000L))
       ));
   }
 
@@ -102,6 +105,9 @@ class CollectionLabJournalEntriesRestTest {
     // dataObjectId field must be populated — the frontend uses it to group.
     assertThat(body.get(0).getDataObjectId()).isEqualTo(101L);
     assertThat(body.get(1).getDataObjectId()).isEqualTo(102L);
+    // APISIMP-LJE-DATAOBJECTID-NUMERIC: dataObjectAppId (UUID v7) must also be populated.
+    assertThat(body.get(0).getDataObjectAppId()).isEqualTo(DO_APP_ID_1);
+    assertThat(body.get(1).getDataObjectAppId()).isEqualTo(DO_APP_ID_2);
     // id and journalContent must round-trip.
     assertThat(body.get(0).getId()).isEqualTo(11L);
     assertThat(body.get(0).getJournalContent()).isEqualTo("newer");
@@ -123,7 +129,7 @@ class CollectionLabJournalEntriesRestTest {
     // hydration miss.
     when(entriesDAO.findByCollectionAppId(COLL_APP_ID))
       .thenReturn(List.of(
-        buildEntry(11L, 101L, "hydrated", new Date(2_000_000L)),
+        buildEntry(11L, 101L, DO_APP_ID_1, "hydrated", new Date(2_000_000L)),
         orphan
       ));
     var r = resource.list(COLL_APP_ID, null, null, sc);
@@ -133,6 +139,7 @@ class CollectionLabJournalEntriesRestTest {
     // The orphan is skipped; only the hydrated entry survives.
     assertThat(body).hasSize(1);
     assertThat(body.get(0).getDataObjectId()).isEqualTo(101L);
+    assertThat(body.get(0).getDataObjectAppId()).isEqualTo(DO_APP_ID_1);
   }
 
   @Test
@@ -213,13 +220,15 @@ class CollectionLabJournalEntriesRestTest {
 
   /**
    * Build a {@link LabJournalEntry} attached to a {@link DataObject} carrying
-   * the given shepardId. Mirrors the v1 service path enough for the IO
-   * constructor to round-trip {@code dataObjectId}, {@code id},
-   * {@code journalContent}, {@code createdAt}.
+   * the given shepardId and appId. Mirrors the v1 service path enough for the IO
+   * constructor to round-trip {@code dataObjectId}, {@code dataObjectAppId},
+   * {@code id}, {@code journalContent}, {@code createdAt}.
    */
-  private LabJournalEntry buildEntry(long entryId, long dataObjectShepardId, String content, Date createdAt) {
+  private LabJournalEntry buildEntry(long entryId, long dataObjectShepardId, String dataObjectAppId,
+      String content, Date createdAt) {
     DataObject doNode = new DataObject();
     doNode.setShepardId(dataObjectShepardId);
+    doNode.setAppId(dataObjectAppId);
 
     LabJournalEntry e = new LabJournalEntry();
     e.setId(entryId);


### PR DESCRIPTION
## Summary

- `LabJournalEntryIO.dataObjectId: long` was a numeric Neo4j OGM id on the v2 wire, making it impossible to correlate lab journal entries with DataObjects using only the v2 surface (which is keyed on UUID v7 `appId`).
- Adds `dataObjectAppId: String` (UUID v7) populated from `getDataObject().getAppId()`.
- Marks `dataObjectId` as `@Schema(deprecated=true)` — kept for backward compat; callers should migrate to `dataObjectAppId`.
- Additive change: no wire break.

**Backlog row**: `APISIMP-LJE-DATAOBJECTID-NUMERIC` (aidocs/16, fire-211 sweep)

## Changed files

- `backend/src/main/java/de/dlr/shepard/context/labJournal/io/LabJournalEntryIO.java` — new `dataObjectAppId` field + deprecation annotation on `dataObjectId`
- `backend/src/test/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRestTest.java` — `buildEntry()` now sets `appId` on the mock DataObject; 2 new assertions for `dataObjectAppId`

## Test plan

- [x] 12 unit tests pass (`CollectionLabJournalEntriesRestTest`) — 2 new assertions for `dataObjectAppId`
- [x] `GET /v2/collections/{collectionAppId}/lab-journal-entries` response includes `dataObjectAppId` (UUID v7)
- [x] Additive — existing `dataObjectId: long` field unchanged, marked deprecated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHiEW8xeTAUXPcQaqy6qQQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHiEW8xeTAUXPcQaqy6qQQ)_