### PR TITLE
fix(APISIMP-CONTAINERS-PERMS-IO-NUMERIC): deprecate numeric group IDs on PATCH /v2/containers permissions

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/auth/permission/io/PermissionsIO.java
+++ b/backend/src/main/java/de/dlr/shepard/auth/permission/io/PermissionsIO.java
@@ -1,5 +1,6 @@
 package de.dlr.shepard.auth.permission.io;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import de.dlr.shepard.auth.permission.model.Permissions;
 import de.dlr.shepard.auth.users.entities.User;
 import de.dlr.shepard.auth.users.entities.UserGroup;
@@ -15,7 +16,10 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(name = "Permissions")
 public class PermissionsIO {
 
-  @Schema(readOnly = true, required = true)
+  @Schema(readOnly = true, required = true, deprecated = true,
+      description = "DEPRECATED (APISIMP-CONTAINERS-PERMS-IO-NUMERIC): internal Neo4j node ID. " +
+        "Use the container's appId for all v2 operations; this field will be removed in a future sweep.")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private long entityId;
 
   private String owner;
@@ -31,21 +35,27 @@ public class PermissionsIO {
   @Schema(required = true)
   private String[] writer;
 
+  @Schema(deprecated = true,
+      description = "DEPRECATED (APISIMP-CONTAINERS-PERMS-IO-NUMERIC): numeric Neo4j OGM group IDs. " +
+        "Use readerGroupAppIds (UUID v7) to set reader groups; this field is output-only.")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private long[] readerGroupIds = {};
 
+  @Schema(deprecated = true,
+      description = "DEPRECATED (APISIMP-CONTAINERS-PERMS-IO-NUMERIC): numeric Neo4j OGM group IDs. " +
+        "Use writerGroupAppIds (UUID v7) to set writer groups; this field is output-only.")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private long[] writerGroupIds = {};
 
   @Schema(
-    readOnly = true,
     nullable = true,
-    description = "Application identifiers (UUID v7) of reader groups, parallel to readerGroupIds."
+    description = "Application identifiers (UUID v7) of reader groups. Use in PATCH body to set reader groups."
   )
   private String[] readerGroupAppIds = {};
 
   @Schema(
-    readOnly = true,
     nullable = true,
-    description = "Application identifiers (UUID v7) of writer groups, parallel to writerGroupIds."
+    description = "Application identifiers (UUID v7) of writer groups. Use in PATCH body to set writer groups."
   )
   private String[] writerGroupAppIds = {};
 

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -2,6 +2,7 @@ package de.dlr.shepard.v2.containers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import de.dlr.shepard.auth.permission.io.PermissionsIO;
+import de.dlr.shepard.auth.users.services.UserGroupService;
 import de.dlr.shepard.auth.permission.model.Roles;
 import de.dlr.shepard.auth.permission.services.PermissionsService;
 import de.dlr.shepard.common.exceptions.ProblemJson;
@@ -119,6 +120,9 @@ public class ContainersV2Rest {
 
   @Inject
   PermissionsService permissionsService;
+
+  @Inject
+  UserGroupService userGroupService;
 
   // ─── create ────────────────────────────────────────────────────────────
 
@@ -1292,11 +1296,28 @@ public class ContainersV2Rest {
     if (patch.containsKey("manager") && patch.get("manager") instanceof java.util.List<?> managerList) {
       current.setManager(managerList.stream().map(Object::toString).toArray(String[]::new));
     }
-    if (patch.containsKey("readerGroupIds") && patch.get("readerGroupIds") instanceof java.util.List<?> rgl) {
-      current.setReaderGroupIds(rgl.stream().mapToLong(v -> Long.parseLong(v.toString())).toArray());
+    // APISIMP-CONTAINERS-PERMS-IO-NUMERIC: numeric group IDs are deprecated write input.
+    if (patch.containsKey("readerGroupIds") && !patch.containsKey("readerGroupAppIds")) {
+      return problem(PROBLEM_TYPE_BAD_REQUEST, "Deprecated field", Response.Status.BAD_REQUEST,
+        "readerGroupIds is deprecated; use readerGroupAppIds (UUID v7) to set reader groups");
     }
-    if (patch.containsKey("writerGroupIds") && patch.get("writerGroupIds") instanceof java.util.List<?> wgl) {
-      current.setWriterGroupIds(wgl.stream().mapToLong(v -> Long.parseLong(v.toString())).toArray());
+    if (patch.containsKey("writerGroupIds") && !patch.containsKey("writerGroupAppIds")) {
+      return problem(PROBLEM_TYPE_BAD_REQUEST, "Deprecated field", Response.Status.BAD_REQUEST,
+        "writerGroupIds is deprecated; use writerGroupAppIds (UUID v7) to set writer groups");
+    }
+    if (patch.containsKey("readerGroupAppIds") && patch.get("readerGroupAppIds") instanceof java.util.List<?> rgl) {
+      long[] ids = rgl.stream()
+        .map(Object::toString)
+        .mapToLong(groupAppId -> userGroupService.getUserGroupByAppId(groupAppId).getId())
+        .toArray();
+      current.setReaderGroupIds(ids);
+    }
+    if (patch.containsKey("writerGroupAppIds") && patch.get("writerGroupAppIds") instanceof java.util.List<?> wgl) {
+      long[] ids = wgl.stream()
+        .map(Object::toString)
+        .mapToLong(groupAppId -> userGroupService.getUserGroupByAppId(groupAppId).getId())
+        .toArray();
+      current.setWriterGroupIds(ids);
     }
     var updated = permissionsService.updatePermissionsByNeo4jId(current, id);
     return Response.ok(new PermissionsIO(updated)).build();

--- a/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
@@ -20,6 +20,8 @@ import de.dlr.shepard.auth.permission.model.Permissions;
 import de.dlr.shepard.auth.permission.model.Roles;
 import de.dlr.shepard.auth.permission.services.PermissionsService;
 import de.dlr.shepard.auth.users.entities.User;
+import de.dlr.shepard.auth.users.entities.UserGroup;
+import de.dlr.shepard.auth.users.services.UserGroupService;
 import de.dlr.shepard.common.util.AccessType;
 import de.dlr.shepard.common.util.PermissionType;
 import de.dlr.shepard.data.file.entities.FileContainer;
@@ -57,6 +59,9 @@ class ContainersV2RestTest {
   PermissionsService permissionsService;
 
   @Mock
+  UserGroupService userGroupService;
+
+  @Mock
   ContainerKindHandler handler;
 
   @Mock
@@ -74,6 +79,7 @@ class ContainersV2RestTest {
     resource = new ContainersV2Rest();
     resource.containersService = containersService;
     resource.permissionsService = permissionsService;
+    resource.userGroupService = userGroupService;
     when(securityContext.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn(CALLER);
   }
@@ -413,6 +419,66 @@ class ContainersV2RestTest {
       .thenReturn(Optional.empty());
     var r = resource.patchPermissions(APP_ID, om.readTree("{\"permissionType\":\"Private\"}"), securityContext);
     assertEquals(404, r.getStatus());
+  }
+
+  // APISIMP-CONTAINERS-PERMS-IO-NUMERIC: numeric group IDs rejected; appIds accepted
+
+  @Test
+  void patchPermissions_returns400WhenOnlyReaderGroupIdsProvidedWithoutAppIds() throws Exception {
+    when(containersService.resolveByAppId(APP_ID)).thenReturn(Optional.of(resolved()));
+    when(permissionsService.isAccessTypeAllowedForUser(eq(CONTAINER_NEO_ID), eq(AccessType.Manage), eq(CALLER)))
+      .thenReturn(true);
+    when(permissionsService.getPermissionsOfEntityOptional(CONTAINER_NEO_ID))
+      .thenReturn(Optional.of(permissions()));
+    var r = resource.patchPermissions(APP_ID,
+      om.readTree("{\"readerGroupIds\":[10,11]}"), securityContext);
+    assertEquals(400, r.getStatus());
+  }
+
+  @Test
+  void patchPermissions_returns400WhenOnlyWriterGroupIdsProvidedWithoutAppIds() throws Exception {
+    when(containersService.resolveByAppId(APP_ID)).thenReturn(Optional.of(resolved()));
+    when(permissionsService.isAccessTypeAllowedForUser(eq(CONTAINER_NEO_ID), eq(AccessType.Manage), eq(CALLER)))
+      .thenReturn(true);
+    when(permissionsService.getPermissionsOfEntityOptional(CONTAINER_NEO_ID))
+      .thenReturn(Optional.of(permissions()));
+    var r = resource.patchPermissions(APP_ID,
+      om.readTree("{\"writerGroupIds\":[20]}"), securityContext);
+    assertEquals(400, r.getStatus());
+  }
+
+  @Test
+  void patchPermissions_returns200WhenReaderGroupAppIdsProvided() throws Exception {
+    when(containersService.resolveByAppId(APP_ID)).thenReturn(Optional.of(resolved()));
+    when(permissionsService.isAccessTypeAllowedForUser(eq(CONTAINER_NEO_ID), eq(AccessType.Manage), eq(CALLER)))
+      .thenReturn(true);
+    when(permissionsService.getPermissionsOfEntityOptional(CONTAINER_NEO_ID))
+      .thenReturn(Optional.of(permissions()));
+    UserGroup g = new UserGroup(77L);
+    g.setAppId("group-app-77");
+    when(userGroupService.getUserGroupByAppId("group-app-77")).thenReturn(g);
+    when(permissionsService.updatePermissionsByNeo4jId(any(PermissionsIO.class), eq(CONTAINER_NEO_ID)))
+      .thenReturn(permissions());
+    var r = resource.patchPermissions(APP_ID,
+      om.readTree("{\"readerGroupAppIds\":[\"group-app-77\"]}"), securityContext);
+    assertEquals(200, r.getStatus());
+  }
+
+  @Test
+  void patchPermissions_returns200WhenWriterGroupAppIdsProvided() throws Exception {
+    when(containersService.resolveByAppId(APP_ID)).thenReturn(Optional.of(resolved()));
+    when(permissionsService.isAccessTypeAllowedForUser(eq(CONTAINER_NEO_ID), eq(AccessType.Manage), eq(CALLER)))
+      .thenReturn(true);
+    when(permissionsService.getPermissionsOfEntityOptional(CONTAINER_NEO_ID))
+      .thenReturn(Optional.of(permissions()));
+    UserGroup g = new UserGroup(88L);
+    g.setAppId("group-app-88");
+    when(userGroupService.getUserGroupByAppId("group-app-88")).thenReturn(g);
+    when(permissionsService.updatePermissionsByNeo4jId(any(PermissionsIO.class), eq(CONTAINER_NEO_ID)))
+      .thenReturn(permissions());
+    var r = resource.patchPermissions(APP_ID,
+      om.readTree("{\"writerGroupAppIds\":[\"group-app-88\"]}"), securityContext);
+    assertEquals(200, r.getStatus());
   }
 
   // ─── listVersions (APISIMP-PV-UNIFY) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- `PermissionsIO.readerGroupIds` / `writerGroupIds` were the only write-input numeric fields left on the `PATCH /v2/containers/{appId}/permissions` handler — callers had to know internal Neo4j OGM group IDs to update group permissions.
- `entityId` was also leaking as a numeric OGM ID on the response, with no deprecation marker.
- `readerGroupAppIds` / `writerGroupAppIds` existed as output-only fields (`readOnly=true`) but were not accepted as write input.

**Changes:**
- Mark `entityId`, `readerGroupIds`, `writerGroupIds` as `@Schema(deprecated=true)` + `@JsonProperty(READ_ONLY)` — output-only from now on.
- Remove `readOnly=true` from `readerGroupAppIds` / `writerGroupAppIds` so they appear as writable in the OpenAPI spec.
- PATCH handler now accepts `readerGroupAppIds` / `writerGroupAppIds` (UUID v7) to set reader/writer groups; sending only the deprecated `readerGroupIds` / `writerGroupIds` returns 400.
- Inject `UserGroupService` into `ContainersV2Rest` to resolve group appIds → numeric IDs for the existing `convertPermissionsIO` path.
- Additive on the response wire — deprecated fields still appear in the response for backward compat.

**Backlog row**: `APISIMP-CONTAINERS-PERMS-IO-NUMERIC` (aidocs/16, fire-211 sweep)

## Changed files

- `PermissionsIO.java` — deprecated annotations + `@JsonProperty(READ_ONLY)` on numeric fields; writable appId fields
- `ContainersV2Rest.java` — `UserGroupService` injection; new appId-based group patch handling; 400 on numeric-only input
- `ContainersV2RestTest.java` — `@Mock UserGroupService`; 4 new tests for the numeric-only 400 and appId 200 paths

## Test plan

- [x] 75 unit tests pass (`ContainersV2RestTest` + `PermissionsIOTest`)
- [x] `patchPermissions_returns400WhenOnlyReaderGroupIdsProvidedWithoutAppIds` — 400 on deprecated numeric-only
- [x] `patchPermissions_returns400WhenOnlyWriterGroupIdsProvidedWithoutAppIds` — 400 on deprecated numeric-only
- [x] `patchPermissions_returns200WhenReaderGroupAppIdsProvided` — 200 with UUID v7 reader groups
- [x] `patchPermissions_returns200WhenWriterGroupAppIdsProvided` — 200 with UUID v7 writer groups
- [x] Additive — existing `readerGroupIds` / `writerGroupIds` still appear in response (deprecated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHiEW8xeTAUXPcQaqy6qQQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHiEW8xeTAUXPcQaqy6qQQ)_