### PR TITLE
fix(APISIMP): add page/pageSize + X-Total-Count to containers and notifications list endpoints

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -378,12 +378,15 @@ public class ContainersV2Rest {
     summary = "List containers of a kind, optionally filtered by name.",
     description =
       "Returns every container of `kind` the caller may read, as ContainerV2IO[]. " +
-      "An optional `name` query param narrows by substring.\n\nAuth: " +
+      "An optional `name` query param narrows by substring.\n\n" +
+      "Pagination (APISIMP-CONTAINERS-LIST-NO-PAGINATION): supply both `page` (0-based) and `pageSize` " +
+      "(1–200) to slice the result. Omitting either returns all containers. " +
+      "`X-Total-Count` header carries the total before paging.\n\nAuth: " +
       "authenticated; per-container Read is enforced by the underlying list query."
   )
   @APIResponse(
     responseCode = "200",
-    description = "List of ContainerV2IO (may be empty).",
+    description = "List of ContainerV2IO (may be empty). Header X-Total-Count = total count before paging.",
     content = @Content(
       mediaType = MediaType.APPLICATION_JSON,
       schema = @Schema(type = SchemaType.ARRAY, implementation = ContainerV2IO.class)
@@ -396,6 +399,10 @@ public class ContainersV2Rest {
     @QueryParam("kind") String kind,
     @Parameter(description = "Optional substring filter on container name. Case-sensitive. Omit to return all containers of the given kind.")
     @QueryParam("name") String name,
+    @Parameter(description = "Zero-based page index for pagination. Effective only when pageSize > 0. Omit to return all containers.")
+    @QueryParam("page") Integer page,
+    @Parameter(description = "Page size for pagination (1–200). Omit to return all containers.")
+    @QueryParam("pageSize") Integer pageSize,
     @Context SecurityContext sc
   ) {
     String caller = callerOrNull(sc);
@@ -404,8 +411,19 @@ public class ContainersV2Rest {
       return problem(PROBLEM_TYPE_BAD_REQUEST, "Missing query parameter", Response.Status.BAD_REQUEST, "kind query parameter is required");
     }
     try {
-      List<ContainerV2IO> containers = containersService.list(kind, name);
-      return Response.ok(containers).build();
+      List<ContainerV2IO> all = containersService.list(kind, name);
+      int total = all.size();
+      List<ContainerV2IO> result;
+      if (pageSize != null && pageSize > 0) {
+        int safeSize = Math.min(pageSize, 200);
+        int safePage = page != null ? page : 0;
+        int from = (int) Math.min((long) safePage * safeSize, total);
+        int to = (int) Math.min((long) from + safeSize, total);
+        result = all.subList(from, to);
+      } else {
+        result = all;
+      }
+      return Response.ok(result).header("X-Total-Count", total).build();
     } catch (BadRequestException bre) {
       return problem(PROBLEM_TYPE_BAD_REQUEST, "Bad request", Response.Status.BAD_REQUEST, bre.getMessage());
     }

--- a/backend/src/main/java/de/dlr/shepard/v2/notifications/resources/NotificationRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/notifications/resources/NotificationRest.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -23,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -45,24 +47,44 @@ public class NotificationRest {
     summary = "List in-app notifications for the authenticated user.",
     description = "Returns all non-expired notifications visible to the caller, ordered most-recent-first. " +
     "Includes notifications addressed to the caller's username, ALL-audience broadcasts, and (when the " +
-    "caller is an instance-admin) INSTANCE_ADMIN-audience broadcasts. Capped at 200 rows."
+    "caller is an instance-admin) INSTANCE_ADMIN-audience broadcasts. Service cap: 200 rows.\n\n" +
+    "Pagination (APISIMP-NOTIFICATIONS-LIST-NO-PAGINATION): supply both `page` (0-based) and `pageSize` " +
+    "(1–200) to slice the result. Omitting either returns all notifications. " +
+    "`X-Total-Count` header carries the total before paging."
   )
   @APIResponse(
     responseCode = "200",
-    description = "List of notifications.",
+    description = "List of notifications. Header X-Total-Count = total count before paging.",
     content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = NotificationIO.class))
   )
   @APIResponse(responseCode = "401", description = "Authentication required.")
-  public Response list(@Context SecurityContext sc) {
+  public Response list(
+    @Parameter(description = "Zero-based page index for pagination. Effective only when pageSize > 0. Omit to return all notifications.")
+    @QueryParam("page") Integer page,
+    @Parameter(description = "Page size for pagination (1–200). Omit to return all notifications.")
+    @QueryParam("pageSize") Integer pageSize,
+    @Context SecurityContext sc
+  ) {
     String username = resolveUsername(sc);
     if (username == null) return problem(PROBLEM_TYPE_UNAUTHORIZED, "Authentication required",
         Response.Status.UNAUTHORIZED, "authentication required");
     boolean isAdmin = sc.isUserInRole("instance-admin");
-    List<NotificationIO> result = service.listForUser(username, isAdmin)
+    List<NotificationIO> all = service.listForUser(username, isAdmin)
       .stream()
       .map(NotificationIO::from)
       .toList();
-    return Response.ok(result).build();
+    int total = all.size();
+    List<NotificationIO> result;
+    if (pageSize != null && pageSize > 0) {
+      int safeSize = Math.min(pageSize, 200);
+      int safePage = page != null ? page : 0;
+      int from = (int) Math.min((long) safePage * safeSize, total);
+      int to = (int) Math.min((long) from + safeSize, total);
+      result = all.subList(from, to);
+    } else {
+      result = all;
+    }
+    return Response.ok(result).header("X-Total-Count", total).build();
   }
 
   @GET

--- a/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
@@ -3,6 +3,7 @@ package de.dlr.shepard.v2.containers.resources;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -573,22 +574,93 @@ class ContainersV2RestTest {
   @Test
   void list_returns200WithNameFilter() {
     when(containersService.list(eq("file"), eq("sca"))).thenReturn(List.of(new ContainerV2IO()));
-    var r = resource.list("file", "sca", securityContext);
+    var r = resource.list("file", "sca", null, null, securityContext);
     assertEquals(200, r.getStatus());
     verify(containersService).list("file", "sca");
   }
 
   @Test
   void list_returns400WhenMissingKind() {
-    var r = resource.list(null, null, securityContext);
+    var r = resource.list(null, null, null, null, securityContext);
     assertEquals(400, r.getStatus());
   }
 
   @Test
   void list_returns401WhenUnauthenticated() {
     when(securityContext.getUserPrincipal()).thenReturn(null);
-    var r = resource.list("file", null, securityContext);
+    var r = resource.list("file", null, null, null, securityContext);
     assertEquals(401, r.getStatus());
+  }
+
+  @Test
+  void list_xTotalCountHeaderIsPresent() {
+    when(containersService.list(eq("file"), isNull())).thenReturn(List.of(new ContainerV2IO(), new ContainerV2IO()));
+    var r = resource.list("file", null, null, null, securityContext);
+    assertEquals(200, r.getStatus());
+    assertEquals("2", r.getHeaderString("X-Total-Count"));
+  }
+
+  @Test
+  void list_paginationReturnsSublistWhenPageAndSizeProvided() {
+    when(containersService.list(eq("file"), isNull()))
+        .thenReturn(List.of(new ContainerV2IO(), new ContainerV2IO(), new ContainerV2IO()));
+    var r = resource.list("file", null, 0, 2, securityContext);
+    assertEquals(200, r.getStatus());
+    assertEquals("3", r.getHeaderString("X-Total-Count"));
+    @SuppressWarnings("unchecked")
+    var body = (List<ContainerV2IO>) r.getEntity();
+    assertEquals(2, body.size());
+  }
+
+  @Test
+  void list_paginationPageBeyondRangeReturnsEmptyList() {
+    when(containersService.list(eq("file"), isNull())).thenReturn(List.of(new ContainerV2IO()));
+    var r = resource.list("file", null, 99, 10, securityContext);
+    assertEquals(200, r.getStatus());
+    @SuppressWarnings("unchecked")
+    var body = (List<ContainerV2IO>) r.getEntity();
+    assertEquals(0, body.size());
+  }
+
+  @Test
+  void list_pageSizeCappedAt200() {
+    var many = java.util.stream.IntStream.range(0, 250)
+        .mapToObj(i -> new ContainerV2IO())
+        .collect(java.util.stream.Collectors.toList());
+    when(containersService.list(eq("file"), isNull())).thenReturn(many);
+    var r = resource.list("file", null, 0, 300, securityContext);
+    assertEquals(200, r.getStatus());
+    @SuppressWarnings("unchecked")
+    var body = (List<ContainerV2IO>) r.getEntity();
+    assertEquals(200, body.size());
+  }
+
+  @Test
+  void list_pageParamIsDocumented() throws NoSuchMethodException {
+    var method = java.util.Arrays.stream(ContainersV2Rest.class.getMethods())
+        .filter(m -> m.getName().equals("list"))
+        .findFirst().orElseThrow();
+    var ann = java.util.Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "page".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class))
+        .findFirst().orElse(null);
+    org.junit.jupiter.api.Assertions.assertNotNull(ann, "list() page @QueryParam must have @Parameter");
+    org.junit.jupiter.api.Assertions.assertFalse(ann.description().isBlank(), "list() page @Parameter description must be non-blank");
+  }
+
+  @Test
+  void list_pageSizeParamIsDocumented() throws NoSuchMethodException {
+    var method = java.util.Arrays.stream(ContainersV2Rest.class.getMethods())
+        .filter(m -> m.getName().equals("list"))
+        .findFirst().orElseThrow();
+    var ann = java.util.Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "pageSize".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> p.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class))
+        .findFirst().orElse(null);
+    org.junit.jupiter.api.Assertions.assertNotNull(ann, "list() pageSize @QueryParam must have @Parameter");
+    org.junit.jupiter.api.Assertions.assertFalse(ann.description().isBlank(), "list() pageSize @Parameter description must be non-blank");
   }
 
   // ─── APISIMP-MAX-POINTS-PARAM-CASE regression ──────────────────────────────

--- a/backend/src/test/java/de/dlr/shepard/v2/notifications/resources/NotificationRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/notifications/resources/NotificationRestTest.java
@@ -1,0 +1,145 @@
+package de.dlr.shepard.v2.notifications.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import de.dlr.shepard.v2.notifications.entities.Notification;
+import de.dlr.shepard.v2.notifications.io.NotificationIO;
+import de.dlr.shepard.v2.notifications.services.NotificationService;
+import jakarta.ws.rs.QueryParam;
+import java.security.Principal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import jakarta.ws.rs.core.SecurityContext;
+
+/**
+ * APISIMP-NOTIFICATIONS-LIST-NO-PAGINATION — Mockito unit tests for
+ * {@link NotificationRest#list}.
+ *
+ * <p>Verifies the pagination contract: 401 unauthenticated → 200 with all when
+ * no pagination params → 200 with sublist + X-Total-Count when page/pageSize
+ * provided → empty list when page beyond range → page-size cap at 200.
+ */
+class NotificationRestTest {
+
+  static final String CALLER = "alice";
+
+  @Mock
+  NotificationService service;
+
+  @Mock
+  SecurityContext sc;
+
+  @Mock
+  Principal principal;
+
+  NotificationRest resource;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    resource = new NotificationRest();
+    resource.service = service;
+
+    when(sc.getUserPrincipal()).thenReturn(principal);
+    when(principal.getName()).thenReturn(CALLER);
+    when(sc.isUserInRole("instance-admin")).thenReturn(false);
+    when(service.listForUser(eq(CALLER), eq(false))).thenReturn(List.of(
+      notif("n1"), notif("n2"), notif("n3")
+    ));
+  }
+
+  @Test
+  void list_returns401WhenUnauthenticated() {
+    when(sc.getUserPrincipal()).thenReturn(null);
+    assertEquals(401, resource.list(null, null, sc).getStatus());
+  }
+
+  @Test
+  void list_returns200WithAllEntriesWhenNoPagination() {
+    var r = resource.list(null, null, sc);
+    assertEquals(200, r.getStatus());
+    @SuppressWarnings("unchecked")
+    var body = (List<NotificationIO>) r.getEntity();
+    assertEquals(3, body.size());
+  }
+
+  @Test
+  void list_xTotalCountHeaderPresent() {
+    var r = resource.list(null, null, sc);
+    assertEquals("3", r.getHeaderString("X-Total-Count"));
+  }
+
+  @Test
+  void list_paginationReturnsSublist() {
+    var r = resource.list(0, 2, sc);
+    assertEquals(200, r.getStatus());
+    assertEquals("3", r.getHeaderString("X-Total-Count"));
+    @SuppressWarnings("unchecked")
+    var body = (List<NotificationIO>) r.getEntity();
+    assertEquals(2, body.size());
+  }
+
+  @Test
+  void list_paginationPageBeyondRangeReturnsEmptyList() {
+    var r = resource.list(99, 10, sc);
+    assertEquals(200, r.getStatus());
+    @SuppressWarnings("unchecked")
+    var body = (List<NotificationIO>) r.getEntity();
+    assertEquals(0, body.size());
+  }
+
+  @Test
+  void list_pageSizeCappedAt200() {
+    var many = java.util.stream.IntStream.range(0, 250)
+        .mapToObj(i -> notif("n" + i))
+        .collect(java.util.stream.Collectors.toList());
+    when(service.listForUser(eq(CALLER), eq(false))).thenReturn(many);
+    var r = resource.list(0, 300, sc);
+    assertEquals(200, r.getStatus());
+    @SuppressWarnings("unchecked")
+    var body = (List<NotificationIO>) r.getEntity();
+    assertEquals(200, body.size());
+  }
+
+  @Test
+  void list_pageParamIsDocumented() throws NoSuchMethodException {
+    var method = NotificationRest.class.getMethod(
+        "list", Integer.class, Integer.class, SecurityContext.class);
+    var ann = java.util.Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "page".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> p.getAnnotation(
+            org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class))
+        .findFirst().orElse(null);
+    org.junit.jupiter.api.Assertions.assertNotNull(ann,
+        "list() page @QueryParam must carry @Parameter");
+    org.junit.jupiter.api.Assertions.assertFalse(ann.description().isBlank(),
+        "list() page @Parameter description must be non-blank");
+  }
+
+  @Test
+  void list_pageSizeParamIsDocumented() throws NoSuchMethodException {
+    var method = NotificationRest.class.getMethod(
+        "list", Integer.class, Integer.class, SecurityContext.class);
+    var ann = java.util.Arrays.stream(method.getParameters())
+        .filter(p -> p.getAnnotation(QueryParam.class) != null
+            && "pageSize".equals(p.getAnnotation(QueryParam.class).value()))
+        .map(p -> p.getAnnotation(
+            org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class))
+        .findFirst().orElse(null);
+    org.junit.jupiter.api.Assertions.assertNotNull(ann,
+        "list() pageSize @QueryParam must carry @Parameter");
+    org.junit.jupiter.api.Assertions.assertFalse(ann.description().isBlank(),
+        "list() pageSize @Parameter description must be non-blank");
+  }
+
+  private static Notification notif(String title) {
+    return new Notification("USER", CALLER, "INFO", "test", title, "", null);
+  }
+}


### PR DESCRIPTION
## Summary

Implements APISIMP-CONTAINERS-LIST-NO-PAGINATION and APISIMP-NOTIFICATIONS-LIST-NO-PAGINATION from the APISIMP smell registry.

- **`GET /v2/containers`** — adds optional `page` (0-based) + `pageSize` (1–200) query params; server caps at 200; returns `X-Total-Count` header with total before slicing. Both params carry `@Parameter(description=…)` for OpenAPI.
- **`GET /v2/notifications`** — same pagination contract applied identically.
- When `pageSize` is omitted or ≤ 0 the full list is returned unchanged (backwards-compatible).
- New unit tests in `ContainersV2RestTest` (6 new cases) and new `NotificationRestTest` (8 cases) cover: 401, full-list with `X-Total-Count`, pagination sublist, page-beyond-range empty list, cap-at-200, and reflection check that both `@QueryParam` params carry `@Parameter` docs.

All 80 backend unit tests pass locally.

## Test plan
- [ ] `mvn -B -P unit-test,-with-plugins -DskipITs test` passes (80 tests, 0 failures)
- [ ] `GET /v2/containers?kind=file` still returns full list + `X-Total-Count`
- [ ] `GET /v2/containers?kind=file&page=0&pageSize=10` returns ≤10 items + correct `X-Total-Count`
- [ ] `GET /v2/notifications` still returns full list + `X-Total-Count`
- [ ] `GET /v2/notifications?page=0&pageSize=5` returns ≤5 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHiEW8xeTAUXPcQaqy6qQQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHiEW8xeTAUXPcQaqy6qQQ)_