### PR TITLE
feat(AI1a-UI): ship AiSettingsPane — replace /me#ai-settings placeholder

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -425,7 +425,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/00-doc-stages.md`](00-doc-stages.md) | 00 — Doc lifecycle stages (taxonomy SSOT) | 2026-05-23 | 2026-06-25 |
 | [`aidocs/00-index.md`](00-index.md) | aidocs — Index | 2026-05-23 | 2026-06-25 |
 | [`aidocs/100-ui-annoyances.md`](100-ui-annoyances.md) | 100 — Shepard UI annoyances (live captured) | 2026-05-23 | 2026-06-25 |
-| [`aidocs/16-dispatcher-backlog.md`](16-dispatcher-backlog.md) | 16 — Dispatcher Backlog | 2026-05-23 | 2026-06-27 |
+| [`aidocs/16-dispatcher-backlog.md`](16-dispatcher-backlog.md) | 16 — Dispatcher Backlog | 2026-05-23 | 2026-06-26 |
 | [`aidocs/34-upstream-upgrade-path.md`](34-upstream-upgrade-path.md) | Upstream upgrade path — `dlr-shepard/shepard 5.2.0` → `noheton/shepard main` | 2026-05-23 | 2026-06-27 |
 | [`aidocs/40-ecosystem.md`](40-ecosystem.md) | 40 — Shepard ecosystem | 2026-05-23 | 2026-06-25 |
 | [`aidocs/41-synergy-sweep.md`](41-synergy-sweep.md) | 41 — Synergy sweep: collapse-where-generalisation-helps | 2026-05-23 | 2026-06-25 |

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -1815,7 +1815,7 @@ SSOT: [`aidocs/agent-findings/no-ui-gap-survey-2026-05-24.md`](agent-findings/no
 
 | ID | Item | Size | Status | Notes |
 |---|---|---|---|---|
-| AI1a-UI | Per-user AI settings frontend — admin REST endpoint not yet shipped; placeholder mounted at `/me#ai-settings` advertises the surface | S | gated-on-AI1a-backend | Survey §1; gate on AI1a admin REST |
+| AI1a-UI | Per-user AI settings frontend — `ai.baseUrl` + `ai.model` editable via preferences API (U1d); `ai.apiKey` locked pending U2 encrypted-secret storage. `PlaceholderFragmentPane` replaced by `AiSettingsPane.vue` (2026-06-26). | S | **partial-shipped (2026-06-26)** — `useAiSettings` composable + `AiSettingsPane.vue` + 6 Vitest tests; full unlock on U2 + AI1a backend. | Survey §1; gate on AI1a admin REST + U2 for apiKey. |
 | PG-COLLAPSE-002-UI | Backup configuration UI — placeholder at `/admin#backup` advertises `:BackupConfig` surface from `aidocs/strategy/105`; promotes when the endpoint ships | S | gated-on-PG-COLLAPSE-002 | Survey §2 |
 | AI1b-UI | "Detect anomalies" button on TimeseriesReference page wiring `POST /v2/timeseries-references/{}/detect-anomalies` | XS | **✓ shipped (2026-05-27)** | Survey §3; button + `DetectAnomaliesDialog.vue` (parametrized window/threshold/createAnnotations, inline results table) were already implemented by a prior agent session; row marked shipped on audit confirmation. |
 | AI1c-UI | `qualityScore` badge on TimeseriesReference cards + detail page | XS | **✓ already shipped** (fire-243 audit) — `QualityScoreChip.vue` exists and is rendered in 3+ FE files; row was stale. | Survey §4; sibling of task #62 |

--- a/frontend/components/context/user/AiSettingsPane.vue
+++ b/frontend/components/context/user/AiSettingsPane.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { useAiSettings } from "~/composables/context/useAiSettings";
+
+const { baseUrl, model, isSaving, save } = useAiSettings();
+
+const localBaseUrl = ref(baseUrl.value);
+const localModel = ref(model.value);
+const saved = ref(false);
+
+// Keep local copies in sync if another caller mutates the singletons.
+watch(baseUrl, (v) => { localBaseUrl.value = v; });
+watch(model, (v) => { localModel.value = v; });
+
+async function handleSave() {
+  await save(localBaseUrl.value, localModel.value);
+  if (!isSaving.value) {
+    saved.value = true;
+    setTimeout(() => { saved.value = false; }, 2500);
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="top-row">
+      <h4 class="text-h4">AI Settings</h4>
+    </div>
+    <p class="text-body-2 mb-4">
+      Per-user LLM provider configuration. When set, these values override the
+      instance-wide defaults configured by your administrator. The API key field
+      requires encrypted secret storage (U2) which has not yet shipped — it will
+      unlock in a future release.
+    </p>
+
+    <v-text-field
+      v-model="localBaseUrl"
+      label="Provider Base URL"
+      placeholder="https://api.openai.com/v1"
+      hint="Base URL for the LLM HTTP API. Leave blank to use the instance default."
+      persistent-hint
+      clearable
+      :disabled="isSaving"
+      class="mb-4"
+    />
+    <v-text-field
+      v-model="localModel"
+      label="Model"
+      placeholder="gpt-4o"
+      hint="Model name or ID. Leave blank to use the instance default."
+      persistent-hint
+      clearable
+      :disabled="isSaving"
+      class="mb-4"
+    />
+
+    <!-- API key is locked until U2 (encrypted-at-rest secret storage) ships. -->
+    <v-text-field
+      label="API Key"
+      model-value=""
+      placeholder="Requires secure settings (U2) — not yet available"
+      prepend-inner-icon="mdi-lock-outline"
+      disabled
+      class="mb-4"
+    />
+    <v-alert type="info" variant="tonal" density="compact" class="mb-6">
+      The API key field will become editable once the encrypted secret storage
+      feature ships. Until then, your administrator can configure a
+      shared API key at the instance level.
+    </v-alert>
+
+    <div class="d-flex align-center gap-3">
+      <v-btn
+        variant="flat"
+        color="primary"
+        :loading="isSaving"
+        :disabled="isSaving"
+        @click="handleSave"
+      >
+        Save
+      </v-btn>
+      <v-fade-transition>
+        <span v-if="saved" class="text-body-2 text-medium-emphasis">
+          <v-icon icon="mdi-check-circle-outline" size="small" class="mr-1" />
+          Saved
+        </span>
+      </v-fade-transition>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.top-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.gap-3 {
+  gap: 12px;
+}
+</style>

--- a/frontend/composables/context/useAiSettings.ts
+++ b/frontend/composables/context/useAiSettings.ts
@@ -1,0 +1,57 @@
+import { MeApi } from "@dlr-shepard/backend-client";
+import { useV2ShepardApi } from "../common/api/useV2ShepardApi";
+import { handleError } from "~/utils/errorBus";
+
+const PREF_BASE_URL = "ai.baseUrl";
+const PREF_MODEL = "ai.model";
+
+// Module-level singletons so all callers share one API fetch.
+const baseUrl = ref("");
+const model = ref("");
+const isSaving = ref(false);
+let loaded = false;
+
+export function useAiSettings() {
+  const api = useV2ShepardApi(MeApi);
+
+  async function load() {
+    if (loaded) return;
+    loaded = true;
+    try {
+      const prefs = (await api.value.getPreferences()) as Record<string, string>;
+      baseUrl.value = prefs[PREF_BASE_URL] ?? "";
+      model.value = prefs[PREF_MODEL] ?? "";
+    } catch {
+      // leave defaults; backend unreachable is not fatal here
+    }
+  }
+
+  async function save(newBaseUrl: string, newModel: string) {
+    const prevBaseUrl = baseUrl.value;
+    const prevModel = model.value;
+    baseUrl.value = newBaseUrl;
+    model.value = newModel;
+    isSaving.value = true;
+    // Safety valve: never spin forever if the response never arrives.
+    const safety = setTimeout(() => {
+      isSaving.value = false;
+    }, 5000);
+    try {
+      await api.value.patchPreferences({
+        // null = RFC 7396 remove; empty string cleared by the user means remove
+        [PREF_BASE_URL]: newBaseUrl.trim() || null,
+        [PREF_MODEL]: newModel.trim() || null,
+      });
+    } catch (error) {
+      baseUrl.value = prevBaseUrl;
+      model.value = prevModel;
+      handleError(error, "saving AI settings");
+    } finally {
+      clearTimeout(safety);
+      isSaving.value = false;
+    }
+  }
+
+  load();
+  return { baseUrl, model, isSaving, save };
+}

--- a/frontend/composables/context/useSettingDescriptor.ts
+++ b/frontend/composables/context/useSettingDescriptor.ts
@@ -19,6 +19,9 @@ export interface SettingDescriptor<T = unknown> {
 /** Well-known setting keys — extend as new preferences are introduced. */
 export const SETTING_KEYS = {
   UI_ADVANCED_MODE: "ui.advancedMode",
+  AI_BASE_URL: "ai.baseUrl",
+  AI_MODEL: "ai.model",
+  // ai.apiKey is intentionally absent: requires U2 encrypted secret storage.
 } as const;
 
 // Descriptors for the above keys — typed and validated in the future U1c layer.
@@ -35,6 +38,18 @@ export const SETTING_DESCRIPTORS: SettingDescriptor[] = [
     description: "Shows advanced features like container management and low-level data views.",
     type: "boolean",
     defaultValue: false,
+  },
+  {
+    key: SETTING_KEYS.AI_BASE_URL,
+    label: "AI provider base URL",
+    description: "Base URL for the LLM HTTP API. Overrides the instance default when set.",
+    type: "string",
+  },
+  {
+    key: SETTING_KEYS.AI_MODEL,
+    label: "AI model",
+    description: "Model name or ID. Overrides the instance default when set.",
+    type: "string",
   },
 ];
 

--- a/frontend/pages/me/index.vue
+++ b/frontend/pages/me/index.vue
@@ -6,7 +6,7 @@ import {
 import SubscriptionsPane from "~/components/context/user/SubscriptionsPane.vue";
 import GitCredentialsPane from "~/components/context/user/GitCredentialsPane.vue";
 import McpPane from "~/components/context/user/McpPane.vue";
-import PlaceholderFragmentPane from "~/components/common/placeholder/PlaceholderFragmentPane.vue";
+import AiSettingsPane from "~/components/context/user/AiSettingsPane.vue";
 import SemanticPane from "~/components/context/user/SemanticPane.vue";
 import MyTemplatesPane from "~/components/context/user/MyTemplatesPane.vue";
 import SectionIndexLanding from "~/components/layout/SectionIndexLanding.vue";
@@ -54,7 +54,7 @@ const landingCards = [
     fragment: UserFragments.AI_SETTINGS,
     icon: "mdi-robot-outline",
     title: "AI Settings",
-    description: "Personal LLM provider config — base URL, model, API key (placeholder).",
+    description: "Per-user LLM provider config — base URL and model. API key unlocks with U2.",
   },
   // ----- SEMA-NAV-PLACEMENT-DECISION option (b) 2026-05-24 -----
   {
@@ -86,11 +86,8 @@ const landingCards = [
     <McpPane v-if="routeFragment === UserFragments.MCP" />
     <SubscriptionsPane v-if="routeFragment === UserFragments.SUBSCRIPTIONS" />
     <GitCredentialsPane v-if="routeFragment === UserFragments.GIT_CREDENTIALS" />
-    <!-- placeholder pane (no-UI-gap roll-out 2026-05-24) -->
-    <PlaceholderFragmentPane
-      v-if="routeFragment === UserFragments.AI_SETTINGS"
-      slug="ai-settings"
-    />
+    <!-- PLACEHOLDER-ai-settings shipped 2026-06-26 -->
+    <AiSettingsPane v-if="routeFragment === UserFragments.AI_SETTINGS" />
     <!-- SEMA-NAV-PLACEMENT-DECISION option (b) 2026-05-24 — moved from top-level header -->
     <SemanticPane v-if="routeFragment === UserFragments.SEMANTIC" />
     <!-- TPL-ME-BROWSE-1 (2026-05-31) — non-admin browse-mine surface -->

--- a/frontend/tests/unit/useAiSettings.test.ts
+++ b/frontend/tests/unit/useAiSettings.test.ts
@@ -1,0 +1,91 @@
+/**
+ * PLACEHOLDER-ai-settings (2026-06-26) — proves `useAiSettings()` reads
+ * `ai.baseUrl` and `ai.model` from the preferences bag and writes them back
+ * via `patchPreferences`. Also verifies optimistic revert on error and that
+ * clearing a field sends `null` (RFC 7396 remove).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+const mockGetPreferences = vi.fn().mockResolvedValue({
+  "ai.baseUrl": "https://api.example.com/v1",
+  "ai.model": "gpt-4o",
+  "ui.advancedMode": "false",
+});
+const mockPatchPreferences = vi.fn().mockResolvedValue({});
+
+vi.mock("~/composables/common/api/useV2ShepardApi", () => ({
+  useV2ShepardApi: () => ({
+    value: {
+      getPreferences: mockGetPreferences,
+      patchPreferences: mockPatchPreferences,
+    },
+  }),
+}));
+
+// useAiSettings holds module-level singletons; re-import fresh each suite.
+let useAiSettings: typeof import("~/composables/context/useAiSettings").useAiSettings;
+
+describe("useAiSettings — PLACEHOLDER-ai-settings", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const mod = await import("~/composables/context/useAiSettings");
+    useAiSettings = mod.useAiSettings;
+  });
+
+  it("loads baseUrl and model from preferences on first call", async () => {
+    const { baseUrl, model } = useAiSettings();
+    await flush();
+    expect(mockGetPreferences).toHaveBeenCalledOnce();
+    expect(baseUrl.value).toBe("https://api.example.com/v1");
+    expect(model.value).toBe("gpt-4o");
+  });
+
+  it("does not re-fetch on second call (singleton guard)", async () => {
+    useAiSettings();
+    useAiSettings();
+    await flush();
+    expect(mockGetPreferences).toHaveBeenCalledOnce();
+  });
+
+  it("save() patches preferences with trimmed values", async () => {
+    const { save } = useAiSettings();
+    await flush();
+    await save("  https://ollama.local/v1  ", "llama3");
+    expect(mockPatchPreferences).toHaveBeenCalledWith({
+      "ai.baseUrl": "https://ollama.local/v1",
+      "ai.model": "llama3",
+    });
+  });
+
+  it("save() sends null for empty fields (RFC 7396 remove)", async () => {
+    const { save } = useAiSettings();
+    await flush();
+    await save("", "");
+    expect(mockPatchPreferences).toHaveBeenCalledWith({
+      "ai.baseUrl": null,
+      "ai.model": null,
+    });
+  });
+
+  it("save() reverts optimistic update on error", async () => {
+    mockPatchPreferences.mockRejectedValueOnce(new Error("network error"));
+    const { baseUrl, model, save } = useAiSettings();
+    await flush();
+    const originalBase = baseUrl.value;
+    const originalModel = model.value;
+    await save("https://bad.example.com", "bad-model");
+    expect(baseUrl.value).toBe(originalBase);
+    expect(model.value).toBe(originalModel);
+  });
+
+  it("falls back silently when getPreferences throws", async () => {
+    mockGetPreferences.mockRejectedValueOnce(new Error("500 Internal Server Error"));
+    const { baseUrl, model } = useAiSettings();
+    await flush();
+    expect(baseUrl.value).toBe("");
+    expect(model.value).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the `PlaceholderFragmentPane` stub at `/me#ai-settings` with a functional per-user AI settings pane, using the already-shipped preferences API (U1d, `PATCH /v2/users/me/preferences`).

- **`ai.baseUrl`** and **`ai.model`** — editable text fields; values stored in the preferences bag as plain strings
- **`ai.apiKey`** — displayed as a locked, read-only field with explanatory alert; unlocks when U2 (encrypted-at-rest secret storage) ships
- Follows the `useAdvancedMode` pattern: module-level singleton, optimistic update with revert on error, 5 s safety timeout

## Changes

| File | Change |
|---|---|
| `frontend/composables/context/useAiSettings.ts` | New composable; load + save via `MeApi.patchPreferences()` |
| `frontend/components/context/user/AiSettingsPane.vue` | Functional pane with two editable fields + locked apiKey section |
| `frontend/composables/context/useSettingDescriptor.ts` | Add `AI_BASE_URL` and `AI_MODEL` to `SETTING_KEYS` + `SETTING_DESCRIPTORS` |
| `frontend/pages/me/index.vue` | Wire `AiSettingsPane`, drop `PlaceholderFragmentPane` for this fragment |
| `frontend/tests/unit/useAiSettings.test.ts` | 6 Vitest tests: load, singleton guard, save, null-for-empty, revert-on-error, silent-fallback |
| `aidocs/16-dispatcher-backlog.md` | AI1a-UI → partial-shipped (2026-06-26) |
| `aidocs/01-doc-stage-index.md` | Regenerated |

## Gates

- lint: ✓ (no new violations)  
- typecheck: ✓ (`vue-tsc --noEmit`)  
- vitest: ✓ 6/6 tests pass

## Context

- Backlog row: `AI1a-UI` in `aidocs/16-dispatcher-backlog.md`  
- Placeholder registry entry: `slug: "ai-settings"`, `surface: "profile"`, `backend: "designed"`  
- Full unlock path: AI1a backend (LlmClient + `/v2/admin/ai/capabilities`) gated on U2 secret-class settings infra


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pn7HCJdntuDKDDXENH8qXK)_