### PR TITLE
fix(BUG-USER-PROVISION-EMAIL-COLLISION): email fallback in createOrUpdateUser + getCurrentUser

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/auth/security/AuthenticationContext.java
+++ b/backend/src/main/java/de/dlr/shepard/auth/security/AuthenticationContext.java
@@ -11,6 +11,16 @@ public class AuthenticationContext {
     return principal == null ? null : principal.getUsername();
   }
 
+  /**
+   * BUG-USER-PROVISION-EMAIL-COLLISION — returns the {@code email} claim from
+   * the JWT, or {@code null} when absent. Used as a fallback identity in
+   * {@link de.dlr.shepard.auth.users.services.UserService#getCurrentUser()} when
+   * the Neo4j :User lookup by username fails.
+   */
+  public String getCurrentUserEmail() {
+    return principal == null ? null : principal.getEmail();
+  }
+
   /** A0 — exposes the full principal so callers can read roles. */
   public JWTPrincipal getPrincipal() {
     return principal;

--- a/backend/src/main/java/de/dlr/shepard/auth/security/JWTPrincipal.java
+++ b/backend/src/main/java/de/dlr/shepard/auth/security/JWTPrincipal.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * The authenticated principal exposed to the request scope by
@@ -44,6 +45,17 @@ public class JWTPrincipal implements Principal {
    * API-key principals that have no {@code iat} claim.
    */
   private long iat;
+
+  /**
+   * BUG-USER-PROVISION-EMAIL-COLLISION — the JWT {@code email} claim, if
+   * present. Used by {@link de.dlr.shepard.auth.security.AuthenticationContext}
+   * as an email-based fallback when the {@code username} (derived from {@code sub}
+   * or {@code preferred_username}) does not match the stored Neo4j username.
+   * Null when the IdP access token does not include an {@code email} claim.
+   * Not part of {@code @AllArgsConstructor} — populated via {@link #setEmail}.
+   */
+  @Setter
+  private String email;
 
   public JWTPrincipal(String username, String keyId) {
     this.audience = null;

--- a/backend/src/main/java/de/dlr/shepard/auth/security/JwtTokenAuthService.java
+++ b/backend/src/main/java/de/dlr/shepard/auth/security/JwtTokenAuthService.java
@@ -253,7 +253,15 @@ public class JwtTokenAuthService {
 
     Set<String> resolvedRoles = resolveDualSourceRoles(username, idpRoles);
 
-    return new JWTPrincipal(audience, issuedFor, username, keyId, resolvedRoles, iat);
+    JWTPrincipal jwtPrincipal = new JWTPrincipal(audience, issuedFor, username, keyId, resolvedRoles, iat);
+    // BUG-USER-PROVISION-EMAIL-COLLISION: carry the email claim so AuthenticationContext
+    // can pass it to UserService.getCurrentUser as a fallback when the stored username
+    // diverges from the token's preferred_username (e.g. service-account UUID vs. "admin").
+    String emailClaim = body.get("email", String.class);
+    if (emailClaim != null && !emailClaim.isBlank()) {
+      jwtPrincipal.setEmail(emailClaim);
+    }
+    return jwtPrincipal;
   }
 
   /**

--- a/backend/src/main/java/de/dlr/shepard/auth/users/services/UserService.java
+++ b/backend/src/main/java/de/dlr/shepard/auth/users/services/UserService.java
@@ -14,6 +14,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 @RequestScoped
@@ -37,28 +38,50 @@ public class UserService {
   public User createOrUpdateUser(User user) {
     Optional<User> oldUserOptional = getUserOptional(user.getUsername());
     if (oldUserOptional.isEmpty()) {
+      // BUG-USER-PROVISION-EMAIL-COLLISION: when the Neo4j username constraint
+      // would collide on email (stored node has a different username), fall back
+      // to a lookup by email so the blind create doesn't throw
+      // ConstraintValidationFailed and 500-storm every subsequent request.
+      if (user.getEmail() != null && !user.getEmail().isBlank()) {
+        Optional<User> byEmail = userDAO.findByEmail(user.getEmail());
+        if (byEmail.isPresent()) {
+          User existingNode = byEmail.get();
+          Log.warnf(
+            "BUG-USER-PROVISION-EMAIL-COLLISION: token username '%s' does not match stored " +
+            "username '%s' for email '%s'. Adopting existing node without rename — ensure the " +
+            "OIDC preferred_username claim is stable or set shepard.oidc.username-claim.",
+            user.getUsername(),
+            existingNode.getUsername(),
+            user.getEmail()
+          );
+          return mergeProfileFields(existingNode, user);
+        }
+      }
       Log.infof("The user %s does not exist, creating...", user.getUsername());
       return userDAO.createOrUpdate(user);
     }
     User oldUser = oldUserOptional.get();
+    return mergeProfileFields(oldUser, user);
+  }
 
-    String firstName = user.getFirstName() != null ? user.getFirstName() : oldUser.getFirstName();
-    String lastName = user.getLastName() != null ? user.getLastName() : oldUser.getLastName();
-    String email = user.getEmail() != null ? user.getEmail() : oldUser.getEmail();
+  private User mergeProfileFields(User target, User source) {
+    String firstName = source.getFirstName() != null ? source.getFirstName() : target.getFirstName();
+    String lastName = source.getLastName() != null ? source.getLastName() : target.getLastName();
+    String email = source.getEmail() != null ? source.getEmail() : target.getEmail();
 
     if (
-      !firstName.equals(oldUser.getFirstName()) ||
-      !lastName.equals(oldUser.getLastName()) ||
-      !email.equals(oldUser.getEmail())
+      !Objects.equals(firstName, target.getFirstName()) ||
+      !Objects.equals(lastName, target.getLastName()) ||
+      !Objects.equals(email, target.getEmail())
     ) {
-      oldUser.setFirstName(firstName);
-      oldUser.setLastName(lastName);
-      oldUser.setEmail(email);
-      Log.infof("Update user %s", oldUser);
-      return userDAO.createOrUpdate(oldUser);
+      target.setFirstName(firstName);
+      target.setLastName(lastName);
+      target.setEmail(email);
+      Log.infof("Update user %s", target);
+      return userDAO.createOrUpdate(target);
     }
 
-    return oldUser;
+    return target;
   }
 
   /**
@@ -91,6 +114,24 @@ public class UserService {
     User currentUser = userDAO.find(authenticationContext.getCurrentUserName());
 
     if (currentUser == null) {
+      // BUG-USER-PROVISION-EMAIL-COLLISION: when the stored Neo4j username diverges
+      // from the token's preferred_username (e.g. importer service-account UUID vs.
+      // interactive "admin"), the username lookup misses. Fall back to email if the
+      // JWT carried the email claim, so the request can proceed with the correct node.
+      String email = authenticationContext.getCurrentUserEmail();
+      if (email != null && !email.isBlank()) {
+        Optional<User> byEmail = userDAO.findByEmail(email);
+        if (byEmail.isPresent()) {
+          Log.warnf(
+            "BUG-USER-PROVISION-EMAIL-COLLISION: getCurrentUser by username '%s' failed; " +
+            "resolved via email '%s' to stored username '%s'.",
+            authenticationContext.getCurrentUserName(),
+            email,
+            byEmail.get().getUsername()
+          );
+          return byEmail.get();
+        }
+      }
       String errorMsg = "Could not determine current user";
       Log.error(errorMsg);
       throw new InvalidRequestException(errorMsg);

--- a/backend/src/test/java/de/dlr/shepard/auth/users/services/UserServiceTest.java
+++ b/backend/src/test/java/de/dlr/shepard/auth/users/services/UserServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.dlr.shepard.auth.apikey.entities.ApiKey;
+import de.dlr.shepard.auth.security.AuthenticationContext;
 import de.dlr.shepard.auth.users.daos.UserDAO;
 import de.dlr.shepard.auth.users.entities.User;
 import de.dlr.shepard.common.exceptions.InvalidRequestException;
@@ -19,6 +20,7 @@ import io.quarkus.test.component.QuarkusComponentTest;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,6 +30,9 @@ public class UserServiceTest {
 
   @InjectMock
   UserDAO dao;
+
+  @InjectMock
+  AuthenticationContext authCtx;
 
   @Inject
   UserService service;
@@ -236,5 +241,85 @@ public class UserServiceTest {
     ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
     verify(dao).createOrUpdate(captor.capture());
     assertNull(captor.getValue().getPreferencesJson(), "preferencesJson must be null when map is empty");
+  }
+
+  // ── BUG-USER-PROVISION-EMAIL-COLLISION regression tests ──────────────────
+
+  /**
+   * When find-by-username misses but find-by-email hits (stored node has a
+   * different username), createOrUpdateUser must return the existing node
+   * without throwing and without creating a duplicate.
+   *
+   * <p>Scenario: importer service created a node with username = "uuid-service"
+   * and email = "admin@demo.shepard.local". Interactive admin login arrives with
+   * username = "admin", same email. Old code → blind create → email unique
+   * constraint violation → 500.  Fixed code → email fallback → returns existing
+   * node.
+   */
+  @Test
+  public void createOrUpdateUser_emailCollision_returnsExistingNode() {
+    var existingNode = new User("uuid-service", "Admin", "User", "admin@demo.shepard.local");
+    var tokenUser = new User("admin", "Admin", "User", "admin@demo.shepard.local");
+
+    when(dao.find("admin")).thenReturn(null);
+    when(dao.findByEmail("admin@demo.shepard.local")).thenReturn(Optional.of(existingNode));
+
+    var result = service.createOrUpdateUser(tokenUser);
+
+    assertEquals(existingNode, result, "must return the email-matched node, not create a new one");
+    verify(dao, never()).createOrUpdate(tokenUser);
+  }
+
+  /**
+   * With the email-collision fix, profile fields are updated on the existing
+   * node (found by email) just like they are when found by username.
+   */
+  @Test
+  public void createOrUpdateUser_emailCollision_updatesProfileOnExistingNode() {
+    var existingNode = new User("uuid-service", "Old", "Name", "admin@demo.shepard.local");
+    var tokenUser = new User("admin", "Admin", "User", "admin@demo.shepard.local");
+
+    when(dao.find("admin")).thenReturn(null);
+    when(dao.findByEmail("admin@demo.shepard.local")).thenReturn(Optional.of(existingNode));
+    when(dao.createOrUpdate(existingNode)).thenReturn(existingNode);
+
+    service.createOrUpdateUser(tokenUser);
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    verify(dao).createOrUpdate(captor.capture());
+    assertEquals("Admin", captor.getValue().getFirstName());
+    assertEquals("User", captor.getValue().getLastName());
+  }
+
+  /**
+   * getCurrentUser must succeed via email fallback when the stored username
+   * diverges from the token's username (cached-path scenario: no provision
+   * runs, but the node carries a different username key).
+   */
+  @Test
+  public void getCurrentUser_emailFallback_succeedsWhenUsernameMissesButEmailHits() {
+    var storedNode = new User("uuid-service", "Admin", "User", "admin@demo.shepard.local");
+
+    when(authCtx.getCurrentUserName()).thenReturn("admin");
+    when(authCtx.getCurrentUserEmail()).thenReturn("admin@demo.shepard.local");
+    when(dao.find("admin")).thenReturn(null);
+    when(dao.findByEmail("admin@demo.shepard.local")).thenReturn(Optional.of(storedNode));
+
+    var result = service.getCurrentUser();
+
+    assertEquals(storedNode, result, "email fallback must return the stored node");
+  }
+
+  /**
+   * getCurrentUser must still throw when both username and email lookups miss.
+   */
+  @Test
+  public void getCurrentUser_throwsWhenNeitherUsernameNorEmailMatch() {
+    when(authCtx.getCurrentUserName()).thenReturn("ghost");
+    when(authCtx.getCurrentUserEmail()).thenReturn("ghost@nowhere.example");
+    when(dao.find("ghost")).thenReturn(null);
+    when(dao.findByEmail("ghost@nowhere.example")).thenReturn(Optional.empty());
+
+    assertThrows(InvalidRequestException.class, () -> service.getCurrentUser());
   }
 }


### PR DESCRIPTION
## Summary

**Severity: HIGH** — 500 storm on every request for any user whose Neo4j `:User` node was created by an importer service account (UUID username) but who also logs in interactively with a human-readable `preferred_username` sharing the same email.

### Root cause

`UserService.createOrUpdateUser` did `find(username)` → null → blind `createOrUpdate` → Neo4j email uniqueness constraint violation (V81 `user_email_unique`) → `ConstraintValidationFailed` → 500. Because `UserLastSeenCache` has a 30-minute TTL, `getCurrentUser` also hit the same miss on every cached request.

### Fix

Two fallback paths — both **adopt the existing node without renaming**:

1. **`createOrUpdateUser`**: when `find(username)` misses and the JWT carries an `email` claim, call `findByEmail(email)`. If found, merge profile fields into the existing node (preserving its Neo4j `@Id` username). No rename.
2. **`getCurrentUser`**: same pattern — when `find(username)` misses, try `findByEmail` via the JWT email claim threaded through `JWTPrincipal → AuthenticationContext`.

Rename is intentionally avoided: Neo4j OGM `@Id String username` means `setUsername()` + `createOrUpdate` creates a **new** node rather than renaming the existing one, and the 30-min `UserLastSeenCache` means `getCurrentUser` would keep hitting the stale key and returning null after any rename attempt.

### Changed files

| File | Change |
|------|--------|
| `JWTPrincipal.java` | `@Setter String email` field (not `@AllArgsConstructor` — preserves all existing constructors) |
| `AuthenticationContext.java` | `getCurrentUserEmail()` delegates to `principal.getEmail()` |
| `JwtTokenAuthService.java` | Extracts `"email"` claim in `parsePrincipalFromAccessToken` and sets it on the minted principal |
| `UserService.java` | Email fallback in both `createOrUpdateUser` and `getCurrentUser`; new `mergeProfileFields` helper (null-safe via `Objects.equals`) used by both the normal update path and the collision path |
| `UserServiceTest.java` | 4 new regression tests covering both collision scenarios |

### New regression tests (all green — 19/19 pass)

- `createOrUpdateUser_emailCollision_returnsExistingNode` — no exception; returns email-matched node
- `createOrUpdateUser_emailCollision_updatesProfileOnExistingNode` — profile fields merged on email-matched node
- `getCurrentUser_emailFallback_succeedsWhenUsernameMissesButEmailHits` — cached-request path works via email
- `getCurrentUser_throwsWhenNeitherUsernameNorEmailMatch` — still throws when both username and email miss

### Dependencies

Builds on NEO-AUDIT-010 (`UserDAO.findByEmail`, `countDuplicateEmails`, V81 migration) already merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTm5rzDnqAk5ZPmzejEjyp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTm5rzDnqAk5ZPmzejEjyp)_