### PR TITLE
RESEED-MICROSECTIONS-UPDATE: migrate seed to v2 semantic annotations

### DIFF
--- a/examples/microsections-showcase/seed.py
+++ b/examples/microsections-showcase/seed.py
@@ -59,6 +59,24 @@ COLLECTION_DESCRIPTION = (
     "This is the JupyterHub-integration showcase (task J2 in `aidocs/16`)."
 )
 
+# Semantic annotation predicates — urn:shepard:microsections namespace.
+# All metadata travels as SemanticAnnotations, not the legacy attributes bag.
+_A = "urn:shepard:microsections:"
+ANNOTATION_PREDICATES: dict[str, str] = {
+    "sample_series":   _A + "sample-series",
+    "specimen_kind":   _A + "specimen-kind",
+    "imaging_method":  _A + "imaging-method",
+    "image_format":    _A + "image-format",
+    "analysis_method": _A + "analysis-method",
+    "analysis_kit":    _A + "analysis-kit",
+    "phases_detected": _A + "phases-detected",
+    "metric_computed": _A + "metric-computed",
+    "research_domain": _A + "research-domain",
+    "audit_relevance": _A + "audit-relevance",
+    "sample_id":       _A + "sample-id",
+    "fiber_type":      _A + "fiber-type",
+}
+
 # Per-sample analysis variants.  Sample 01 has two notebooks (carbon vs flax);
 # samples 02-07 each have a single notebook.
 SAMPLE_VARIANTS: list[tuple[str, str, str]] = [
@@ -202,8 +220,6 @@ def find_or_create_data_object(
     api: Api,
     collection_app_id: str,
     name: str,
-    *,
-    attributes: dict,
 ) -> dict:
     listing = api.get(
         f"/v2/collections/{collection_app_id}/data-objects",
@@ -216,10 +232,47 @@ def find_or_create_data_object(
             return do
     created = api.post(
         f"/v2/collections/{collection_app_id}/data-objects",
-        json_body={"name": name, "attributes": attributes},
+        json_body={"name": name},
     )
     _log("OK", name, "DataObject", created["appId"])
     return created
+
+
+def apply_annotations(api: Api, subject_app_id: str, attrs: dict) -> None:
+    """Write key/value pairs as SemanticAnnotations on a DataObject.
+
+    Idempotent: fetches existing predicateIris for the subject and skips
+    any that are already present.  Unknown keys (not in ANNOTATION_PREDICATES)
+    are silently skipped rather than written to the legacy attributes bag.
+    """
+    try:
+        resp = api.get("/v2/annotations", params={
+            "subjectAppId": subject_app_id,
+            "pageSize": 200,
+        })
+        items = resp.get("items", resp) if isinstance(resp, dict) else (resp or [])
+        existing_iris = {
+            a.get("predicateIri") or a.get("propertyIri")
+            for a in (items or [])
+            if a
+        }
+    except Exception:
+        existing_iris = set()
+
+    for key, value in attrs.items():
+        pred_iri = ANNOTATION_PREDICATES.get(key)
+        if not pred_iri:
+            continue
+        if pred_iri in existing_iris:
+            _log("SKIP", f"{key}={value!r}", "Annotation (exists)")
+            continue
+        api.post("/v2/annotations", json_body={
+            "subjectAppId": subject_app_id,
+            "subjectKind": "DataObject",
+            "predicateIri": pred_iri,
+            "objectLiteral": str(value),
+        })
+        _log("OK", f"{key}={value!r}", "Annotation", pred_iri)
 
 
 def upload_singleton_if_absent(
@@ -280,12 +333,14 @@ def seed(api: Api, raw_dir: Path, *, reset: bool) -> None:
             _log("MISS", notebook_filename, "notebook not found — skipping sample")
             continue
 
-        attrs = {
+        do = find_or_create_data_object(api, coll_id, sample_id)
+
+        # Write per-sample metadata as SemanticAnnotations (not attributes bag).
+        apply_annotations(api, do["appId"], {
             **SAMPLE_ATTRIBUTES_COMMON,
             "sample_id": tif_stem,
             "fiber_type": fiber_type,
-        }
-        do = find_or_create_data_object(api, coll_id, sample_id, attributes=attrs)
+        })
 
         # Attach the TIF as a singleton FileReference directly on the DO.
         # The name carries the .tif extension so the frontend classifier


### PR DESCRIPTION
## Summary

Modernises `examples/microsections-showcase/seed.py` to current v2 API surfaces per `RESEED-MICROSECTIONS-UPDATE` (aidocs/16).

The script was writing sample metadata via the legacy `attributes` bag on DataObject creation (`json_body={"name": ..., "attributes": {...}}`). The `attributes` property bag is write-disabled for new code (`AttributesMapHasNoNewWritersTest` guards this); all new metadata must travel as `SemanticAnnotation` nodes.

**Changes:**
- Add `ANNOTATION_PREDICATES` dict mapping snake_case keys → `urn:shepard:microsections:*` IRIs
- Remove `attributes` kwarg from `find_or_create_data_object`; POST body now carries only `{"name": ...}`
- Add `apply_annotations(api, subject_app_id, attrs)` — idempotent annotation writer: fetches existing `predicateIri`s for the subject, skips already-present ones, POSTs the rest via `POST /v2/annotations`
- Call `apply_annotations()` after each DataObject is found/created in `seed()`

**Already correct (no change):**
- FR1b singleton FileReference pattern via `POST /v2/files?parentDataObjectAppId=...` ✓
- `/v2/collections` and `/v2/collections/{id}/data-objects` endpoints ✓
- `appId`-only addressing throughout ✓

## Acceptance

```
POST /v2/annotations   ← 12 annotations per DataObject (10 common + sample_id + fiber_type)
GET  /v2/annotations?subjectAppId=<do>   ← returns 12 AnnotationIO rows
mvn verify -pl backend   ← green (no Java changes)
```

## Test plan

- [ ] Dry-read confirms no `attributes` key appears in any POST body
- [ ] `apply_annotations()` idempotency: re-running produces SKIP lines, not duplicate annotations
- [ ] `mvn verify -pl backend` green (no Java changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ4Grz2CoujDkwnm1qe3cc

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZ4Grz2CoujDkwnm1qe3cc)_