### PR TITLE
feat(apisimp): paginate AAS registrations list endpoint (row 3828)

### DIFF
--- a/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/resources/AasRegistrationAdminRest.java
+++ b/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/resources/AasRegistrationAdminRest.java
@@ -5,19 +5,23 @@ import de.dlr.shepard.plugins.aas.services.AasRegistryOutboxService;
 import de.dlr.shepard.common.util.Constants;
 import de.dlr.shepard.plugins.aas.admin.io.AasRegistrationIO;
 import de.dlr.shepard.plugins.aas.admin.io.AasSyncResultIO;
+import de.dlr.shepard.v2.common.io.PagedResponseIO;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -46,26 +50,37 @@ public class AasRegistrationAdminRest {
   @Inject
   AasRegistryOutboxService outboxService;
 
+  static final int MAX_PAGE_SIZE = 200;
+
   @GET
   @Operation(
     operationId = "listAasRegistrations",
-    summary = "List all AAS registry outbox rows.",
+    summary = "List AAS registry outbox rows (paginated).",
     description = "Returns one row per (shell, registry-url) pair tracked in the " +
     ":AasRegistration outbox. Status is PENDING, SYNCED, or FAILED. " +
+    "Results are cursor-stable: sorted by shellAppId, registryUrl. " +
     "Gated on the instance-admin role."
   )
   @APIResponse(
     responseCode = "200",
-    description = "All outbox rows (may be empty if no collections exist or no registry is configured).",
+    description = "Paged outbox rows (may be empty if no collections exist or no registry is configured).",
     content = @Content(schema = @Schema(implementation = AasRegistrationIO.class))
   )
   @APIResponse(responseCode = "403", description = "Caller lacks the instance-admin role.")
-  public Response listRegistrations() {
-    List<AasRegistrationIO> rows = registrationDAO.listAll()
+  public Response listRegistrations(
+    @Parameter(description = "0-based page index. Default 0.")
+    @QueryParam("page") @DefaultValue("0") int page,
+    @Parameter(description = "Page size. Default 50, max " + MAX_PAGE_SIZE + ".")
+    @QueryParam("pageSize") @DefaultValue("50") int pageSize
+  ) {
+    int safePage = Math.max(page, 0);
+    int safeSize = Math.min(Math.max(pageSize, 1), MAX_PAGE_SIZE);
+    long total = registrationDAO.countAll();
+    List<AasRegistrationIO> rows = registrationDAO.listAll(safePage, safeSize)
       .stream()
       .map(AasRegistrationIO::from)
       .toList();
-    return Response.ok(rows).build();
+    return Response.ok(new PagedResponseIO<>(rows, total, safePage, safeSize)).build();
   }
 
   @POST

--- a/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/daos/AasRegistrationDAO.java
+++ b/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/daos/AasRegistrationDAO.java
@@ -35,11 +35,32 @@ public class AasRegistrationDAO extends GenericDAO<AasRegistration> {
   }
 
   /**
-   * List every outbox row across all registries. Used by the admin listing
-   * endpoint {@code GET /v2/admin/aas/registrations} (AAS1-reg Commit 3).
+   * Total count of outbox rows across all registries. Used for the
+   * {@code PagedResponseIO} envelope on
+   * {@code GET /v2/admin/aas/registrations}.
    */
-  public List<AasRegistration> listAll() {
-    return List.copyOf(findAll());
+  public long countAll() {
+    var result = session.query(
+      "MATCH (r:AasRegistration) RETURN count(r) AS total",
+      Map.of()
+    );
+    var it = result.queryResults().iterator();
+    if (!it.hasNext()) return 0L;
+    Object v = it.next().get("total");
+    return v instanceof Number n ? n.longValue() : 0L;
+  }
+
+  /**
+   * Paginated list of every outbox row across all registries. Used by the
+   * admin listing endpoint {@code GET /v2/admin/aas/registrations}.
+   */
+  public List<AasRegistration> listAll(int page, int pageSize) {
+    List<AasRegistration> out = new ArrayList<>();
+    findByQuery(
+      "MATCH (r:AasRegistration) RETURN r ORDER BY r.shellAppId, r.registryUrl SKIP $skip LIMIT $limit",
+      Map.of("skip", (long) page * pageSize, "limit", (long) pageSize)
+    ).forEach(out::add);
+    return out;
   }
 
   /**

--- a/plugins/aas/src/test/java/de/dlr/shepard/plugins/aas/admin/resources/AasRegistrationAdminRestTest.java
+++ b/plugins/aas/src/test/java/de/dlr/shepard/plugins/aas/admin/resources/AasRegistrationAdminRestTest.java
@@ -14,6 +14,7 @@ import de.dlr.shepard.plugins.aas.services.AasRegistryOutboxService;
 import de.dlr.shepard.common.util.Constants;
 import de.dlr.shepard.plugins.aas.admin.io.AasRegistrationIO;
 import de.dlr.shepard.plugins.aas.admin.io.AasSyncResultIO;
+import de.dlr.shepard.v2.common.io.PagedResponseIO;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
@@ -59,29 +60,35 @@ class AasRegistrationAdminRestTest {
   // --- GET /v2/admin/aas/registrations ---
 
   @Test
-  void listRegistrationsReturnsEmptyListWhenNoRows() {
-    when(registrationDAO.listAll()).thenReturn(List.of());
+  void listRegistrationsReturnsEmptyPagedEnvelopeWhenNoRows() {
+    when(registrationDAO.countAll()).thenReturn(0L);
+    when(registrationDAO.listAll(0, 50)).thenReturn(List.of());
 
-    Response r = rest.listRegistrations();
+    Response r = rest.listRegistrations(0, 50);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
-    List<AasRegistrationIO> body = (List<AasRegistrationIO>) r.getEntity();
-    assertEquals(0, body.size());
+    PagedResponseIO<AasRegistrationIO> body = (PagedResponseIO<AasRegistrationIO>) r.getEntity();
+    assertEquals(0L, body.total());
+    assertEquals(0, body.page());
+    assertEquals(50, body.pageSize());
+    assertEquals(0, body.items().size());
   }
 
   @Test
-  void listRegistrationsReturnsMappedRow() {
+  void listRegistrationsReturnsPagedEnvelopeWithMappedRow() {
     AasRegistration reg = buildReg(SHELL_APP_ID, Status.SYNCED, null);
-    when(registrationDAO.listAll()).thenReturn(List.of(reg));
+    when(registrationDAO.countAll()).thenReturn(1L);
+    when(registrationDAO.listAll(0, 50)).thenReturn(List.of(reg));
 
-    Response r = rest.listRegistrations();
+    Response r = rest.listRegistrations(0, 50);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
-    List<AasRegistrationIO> body = (List<AasRegistrationIO>) r.getEntity();
-    assertEquals(1, body.size());
-    AasRegistrationIO io = body.get(0);
+    PagedResponseIO<AasRegistrationIO> body = (PagedResponseIO<AasRegistrationIO>) r.getEntity();
+    assertEquals(1L, body.total());
+    assertEquals(1, body.items().size());
+    AasRegistrationIO io = body.items().get(0);
     assertEquals(SHELL_APP_ID, io.shellAppId());
     assertEquals(REGISTRY_URL, io.registryUrl());
     assertEquals(Status.SYNCED, io.status());
@@ -90,13 +97,38 @@ class AasRegistrationAdminRestTest {
   @Test
   void listRegistrationsIncludesErrorMessageOnFailedRow() {
     AasRegistration reg = buildReg(SHELL_APP_ID, Status.FAILED, "HTTP 503: Service Unavailable");
-    when(registrationDAO.listAll()).thenReturn(List.of(reg));
+    when(registrationDAO.countAll()).thenReturn(1L);
+    when(registrationDAO.listAll(0, 50)).thenReturn(List.of(reg));
 
-    Response r = rest.listRegistrations();
+    Response r = rest.listRegistrations(0, 50);
 
     @SuppressWarnings("unchecked")
-    List<AasRegistrationIO> body = (List<AasRegistrationIO>) r.getEntity();
-    assertEquals("HTTP 503: Service Unavailable", body.get(0).errorMessage());
+    PagedResponseIO<AasRegistrationIO> body = (PagedResponseIO<AasRegistrationIO>) r.getEntity();
+    assertEquals("HTTP 503: Service Unavailable", body.items().get(0).errorMessage());
+  }
+
+  @Test
+  void pageSizeIsCappedAt200() {
+    when(registrationDAO.countAll()).thenReturn(0L);
+    when(registrationDAO.listAll(0, AasRegistrationAdminRest.MAX_PAGE_SIZE)).thenReturn(List.of());
+
+    Response r = rest.listRegistrations(0, 9999);
+
+    @SuppressWarnings("unchecked")
+    PagedResponseIO<AasRegistrationIO> body = (PagedResponseIO<AasRegistrationIO>) r.getEntity();
+    assertEquals(AasRegistrationAdminRest.MAX_PAGE_SIZE, body.pageSize());
+  }
+
+  @Test
+  void negativePageIsClampedToZero() {
+    when(registrationDAO.countAll()).thenReturn(0L);
+    when(registrationDAO.listAll(0, 50)).thenReturn(List.of());
+
+    Response r = rest.listRegistrations(-5, 50);
+
+    @SuppressWarnings("unchecked")
+    PagedResponseIO<AasRegistrationIO> body = (PagedResponseIO<AasRegistrationIO>) r.getEntity();
+    assertEquals(0, body.page());
   }
 
   // --- POST /v2/admin/aas/registrations/sync ---


### PR DESCRIPTION
## Summary

- `GET /v2/admin/aas/registrations` previously returned a plain `List<AasRegistrationIO>` with no server-side cap — unbounded response per APISIMP row 3828.
- Now returns `PagedResponseIO<AasRegistrationIO>` with `?page` (default 0) and `?pageSize` (default 50, cap 200) query params.
- Adds `countAll()` and paginated `listAll(int page, int pageSize)` to `AasRegistrationDAO`.
- 9 unit tests, all green. Pre-existing failures in `AasPluginManifestTest` and `AasConfigServiceTest` are unrelated and pre-date this change.

## Changed files

| File | Change |
|---|---|
| `plugins/aas/.../AasRegistrationAdminRest.java` | Add `MAX_PAGE_SIZE=200`, `?page`/`?pageSize` params, `PagedResponseIO` envelope |
| `plugins/aas/.../AasRegistrationDAO.java` | Add `countAll()` + paginated `listAll(page, pageSize)` |
| `plugins/aas/.../AasRegistrationAdminRestTest.java` | Update 3 existing tests; add 2 new (cap, negative-page clamp) |

## Backlog row

`aidocs/16` row **APISIMP-AAS-REGISTRATIONS-LIST-ENVELOPE** (3828) — XS, fire-282.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTDHtRfxjxXkjUEV6HxEUB)_