### PR TITLE
APISIMP-TEMPLATE-TAGS-CAP: add LIMIT 500 to listDistinctTags Cypher

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/template/daos/ShepardTemplateDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/template/daos/ShepardTemplateDAO.java
@@ -221,10 +221,14 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
     }
   }
 
+  /** Hard cap on distinct tags returned by {@link #listDistinctTags}. */
+  static final int TAGS_MAX = 500;
+
   /**
    * Distinct list of tags across all non-retired templates, sorted
    * ascending. Used by the picker UI's tag-autocomplete dropdown.
    * Optionally narrows to one {@code templateKind}.
+   * Capped at {@value #TAGS_MAX} entries.
    */
   public List<String> listDistinctTags(String templateKind) {
     StringBuilder cypher = new StringBuilder(
@@ -235,7 +239,7 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
       cypher.append(" AND t.templateKind = $kind");
       params.put("kind", templateKind);
     }
-    cypher.append(" UNWIND coalesce(t.tags, []) AS tag RETURN DISTINCT tag ORDER BY tag");
+    cypher.append(" UNWIND coalesce(t.tags, []) AS tag RETURN DISTINCT tag ORDER BY tag LIMIT " + TAGS_MAX);
     var result = session.query(cypher.toString(), params);
     List<String> out = new ArrayList<>();
     for (Map<String, Object> row : result.queryResults()) {

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
@@ -286,11 +286,12 @@ public class ShepardTemplateRest {
   @Path("/tags")
   @Operation(
     summary = "Distinct list of tags across all non-retired templates.",
-    description = "Used by the picker UI's tag-autocomplete. Optionally narrow to one templateKind."
+    description = "Used by the picker UI's tag-autocomplete. Optionally narrow to one templateKind. " +
+    "Server-side cap: at most 500 distinct tags are returned (alphabetically first 500)."
   )
   @APIResponse(
     responseCode = "200",
-    description = "Distinct tag list, sorted ascending.",
+    description = "Distinct tag list, sorted ascending. Capped at 500 entries.",
     content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = String.class))
   )
   @APIResponse(responseCode = "401", description = "Authentication required.")

--- a/backend/src/test/java/de/dlr/shepard/template/daos/ShepardTemplateDAOIconKeyTest.java
+++ b/backend/src/test/java/de/dlr/shepard/template/daos/ShepardTemplateDAOIconKeyTest.java
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.Test;
  * canonical edit shape per aidocs/54 §7; without an explicit
  * pass-through, an admin editing a description would silently strip
  * the icon — the failure mode aidocs/integrations/122 §5.1 calls out.
+ *
+ * Also covers APISIMP-TEMPLATE-TAGS-CAP: verifies the TAGS_MAX constant
+ * is 500 (the value baked into the LIMIT clause of listDistinctTags).
  */
 class ShepardTemplateDAOIconKeyTest {
 
@@ -39,5 +42,12 @@ class ShepardTemplateDAOIconKeyTest {
     ShepardTemplate next = dao.nextVersionOf(prior);
 
     assertNull(next.getIconKey());
+  }
+
+  @Test
+  void tagsCapConstantIs500() {
+    // APISIMP-TEMPLATE-TAGS-CAP: the constant must stay 500.
+    // Changing it without updating this test is intentional — bump the test.
+    assertEquals(500, ShepardTemplateDAO.TAGS_MAX);
   }
 }


### PR DESCRIPTION
## Summary

`GET /v2/templates/tags?kind=` is used by the picker UI's tag-autocomplete. The underlying `ShepardTemplateDAO.listDistinctTags()` executed a Cypher query with no `LIMIT` clause, returning all distinct tag strings across every non-retired template. In a large deployment this is unbounded.

**Fix:** add `LIMIT 500` (via a `TAGS_MAX = 500` constant) to the Cypher `RETURN DISTINCT tag ORDER BY tag` clause. 500 distinct tags would be extraordinary in practice; the cap prevents pathological response sizes without affecting normal use.

**Changes:**
- `ShepardTemplateDAO`: add `static final int TAGS_MAX = 500`; append `LIMIT 500` to the Cypher string in `listDistinctTags()`
- `ShepardTemplateRest.tags()`: update `@Operation` + `@APIResponse` description to document the 500-item cap
- `ShepardTemplateDAOIconKeyTest`: add `tagsCapConstantIs500()` regression test to pin the constant value

**Ref:** `aidocs/16` row 3829 (`APISIMP-TEMPLATE-TAGS-CAP`); sweep report `aidocs/agent-findings/apisimp-sweep-2026-06-28-fire283.md` §Finding 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRjUvMLaEp7KC6Rj6yQ2dM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRjUvMLaEp7KC6Rj6yQ2dM)_