### PR TITLE
feat(APISIMP-VOCAB-LIST-ENVELOPE): wrap vocabulary list endpoints in PagedResponseIO

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java
@@ -5,6 +5,7 @@ import de.dlr.shepard.context.semantic.daos.PredicateDAO;
 import de.dlr.shepard.context.semantic.daos.VocabularyDAO;
 import de.dlr.shepard.context.semantic.entities.Predicate;
 import de.dlr.shepard.context.semantic.entities.Vocabulary;
+import de.dlr.shepard.v2.common.io.PagedResponseIO;
 import de.dlr.shepard.v2.semantic.io.PredicateIO;
 import de.dlr.shepard.v2.semantic.io.VocabularyPredicatesIO;
 import de.dlr.shepard.v2.vocabularies.io.VocabularyIO;
@@ -97,7 +98,7 @@ public class VocabularyBrowseRest {
   public Response listVocabularies() {
     List<Vocabulary> all = vocabularyDAO.listAll();
     List<VocabularyIO> out = all.stream().map(VocabularyIO::from).toList();
-    return Response.ok(out).build();
+    return Response.ok(new PagedResponseIO<>(out, out.size(), 0, out.size())).build();
   }
 
   // ─── GET /v2/semantic/vocabularies/{vocabId}/predicates ───────────────────
@@ -186,11 +187,11 @@ public class VocabularyBrowseRest {
     @QueryParam("scope") @DefaultValue("data-object") String scope
   ) {
     if (entityAppId == null || entityAppId.isBlank()) {
-      return Response.ok(List.of()).build();
+      return Response.ok(new PagedResponseIO<>(List.<VocabularyIO>of(), 0, 0, 0)).build();
     }
     List<Vocabulary> used = vocabularyDAO.findVocabulariesUsedByEntity(entityAppId, scope);
     List<VocabularyIO> out = used.stream().map(VocabularyIO::from).toList();
-    return Response.ok(out).build();
+    return Response.ok(new PagedResponseIO<>(out, out.size(), 0, out.size())).build();
   }
 
   // ─── helpers ──────────────────────────────────────────────────────────────

--- a/backend/src/test/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRestTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 
 import de.dlr.shepard.context.semantic.daos.PredicateDAO;
 import de.dlr.shepard.context.semantic.daos.VocabularyDAO;
+import de.dlr.shepard.v2.common.io.PagedResponseIO;
 import de.dlr.shepard.context.semantic.entities.Predicate;
 import de.dlr.shepard.context.semantic.entities.Vocabulary;
 import de.dlr.shepard.v2.semantic.io.PredicateIO;
@@ -77,9 +78,9 @@ class VocabularyBrowseRestTest {
 
     assertEquals(200, response.getStatus());
     @SuppressWarnings("unchecked")
-    List<VocabularyIO> body = (List<VocabularyIO>) response.getEntity();
-    assertNotNull(body);
-    assertTrue(body.isEmpty());
+    PagedResponseIO<VocabularyIO> paged = (PagedResponseIO<VocabularyIO>) response.getEntity();
+    assertNotNull(paged);
+    assertTrue(paged.items().isEmpty());
   }
 
   @Test
@@ -93,10 +94,10 @@ class VocabularyBrowseRestTest {
 
     assertEquals(200, response.getStatus());
     @SuppressWarnings("unchecked")
-    List<VocabularyIO> body = (List<VocabularyIO>) response.getEntity();
-    assertEquals(2, body.size());
-    assertTrue(body.stream().anyMatch(v -> "v-dcterms".equals(v.getAppId()) && v.isEnabled()));
-    assertTrue(body.stream().anyMatch(v -> "v-disabled".equals(v.getAppId()) && !v.isEnabled()));
+    PagedResponseIO<VocabularyIO> paged = (PagedResponseIO<VocabularyIO>) response.getEntity();
+    assertEquals(2, paged.items().size());
+    assertTrue(paged.items().stream().anyMatch(v -> "v-dcterms".equals(v.getAppId()) && v.isEnabled()));
+    assertTrue(paged.items().stream().anyMatch(v -> "v-disabled".equals(v.getAppId()) && !v.isEnabled()));
   }
 
   // ─── listPredicatesForVocabulary ─────────────────────────────────────────
@@ -180,8 +181,8 @@ class VocabularyBrowseRestTest {
     Response response = rest.listVocabulariesUsedBy("  ", "collection");
     assertEquals(200, response.getStatus());
     @SuppressWarnings("unchecked")
-    List<VocabularyIO> body = (List<VocabularyIO>) response.getEntity();
-    assertTrue(body.isEmpty());
+    PagedResponseIO<VocabularyIO> paged = (PagedResponseIO<VocabularyIO>) response.getEntity();
+    assertTrue(paged.items().isEmpty());
     verify(vocabularyDAO, never()).findVocabulariesUsedByEntity("  ", "collection");
   }
 
@@ -190,8 +191,8 @@ class VocabularyBrowseRestTest {
     Response response = rest.listVocabulariesUsedBy(null, "data-object");
     assertEquals(200, response.getStatus());
     @SuppressWarnings("unchecked")
-    List<VocabularyIO> body = (List<VocabularyIO>) response.getEntity();
-    assertTrue(body.isEmpty());
+    PagedResponseIO<VocabularyIO> paged = (PagedResponseIO<VocabularyIO>) response.getEntity();
+    assertTrue(paged.items().isEmpty());
   }
 
   @Test
@@ -205,9 +206,9 @@ class VocabularyBrowseRestTest {
 
     assertEquals(200, response.getStatus());
     @SuppressWarnings("unchecked")
-    List<VocabularyIO> body = (List<VocabularyIO>) response.getEntity();
-    assertEquals(1, body.size());
-    assertEquals("v-dcterms", body.get(0).getAppId());
+    PagedResponseIO<VocabularyIO> paged = (PagedResponseIO<VocabularyIO>) response.getEntity();
+    assertEquals(1, paged.items().size());
+    assertEquals("v-dcterms", paged.items().get(0).getAppId());
     verify(vocabularyDAO).findVocabulariesUsedByEntity(appId, "collection");
   }
 
@@ -220,8 +221,8 @@ class VocabularyBrowseRestTest {
 
     assertEquals(200, response.getStatus());
     @SuppressWarnings("unchecked")
-    List<VocabularyIO> body = (List<VocabularyIO>) response.getEntity();
-    assertTrue(body.isEmpty());
+    PagedResponseIO<VocabularyIO> paged = (PagedResponseIO<VocabularyIO>) response.getEntity();
+    assertTrue(paged.items().isEmpty());
   }
 
   // ─── APISIMP-VOCAB-BROWSE-SCOPE-UNDOCUMENTED: @Parameter regression ───────

--- a/frontend/pages/semantic/vocabularies/index.vue
+++ b/frontend/pages/semantic/vocabularies/index.vue
@@ -66,7 +66,7 @@ async function loadVocabularies() {
       return;
     }
     const body = await res.json();
-    vocabularies.value = Array.isArray(body) ? body : [];
+    vocabularies.value = Array.isArray(body?.items) ? body.items : [];
   } catch (e: unknown) {
     error.value = e instanceof Error ? e.message : String(e);
   } finally {


### PR DESCRIPTION
## What

Wraps the two bare `List<VocabularyIO>` returns in `VocabularyBrowseRest` in the standard `PagedResponseIO` envelope, continuing the APISIMP list-envelope wave.

Affected endpoints:
- `GET /v2/semantic/vocabularies` → `PagedResponseIO<VocabularyIO>`
- `GET /v2/semantic/vocabularies/used-by/{entityAppId}` → `PagedResponseIO<VocabularyIO>`

## Changes

- **`VocabularyBrowseRest`**: both `listVocabularies()` and `listVocabulariesUsedBy()` now return `new PagedResponseIO<>(out, out.size(), 0, out.size())`. The empty early-return path in `listVocabulariesUsedBy` also returns an empty envelope.
- **`VocabularyBrowseRestTest`**: 6 test methods updated to cast to `PagedResponseIO<VocabularyIO>` and access `.items()`.
- **`frontend/pages/semantic/vocabularies/index.vue`**: reads `body.items` instead of treating `body` as an array directly.

## Checklist

- [x] Backend source updated (`VocabularyBrowseRest.java`)
- [x] Unit tests updated (`VocabularyBrowseRestTest.java`)
- [x] Frontend consumer updated (`index.vue` line 69)
- [x] No aidocs changes needed (pure wire-format consistency fix, no new feature)
- [x] Part of APISIMP list-envelope wave (fire-302)

---
_Generated by [Claude Code](https://claude.ai/code/session_013WLF8moeAcCnLcw6W6oqz6)_