### PR TITLE
feat(SVDX-CHANNEL-CHART-VUE-2026-06-29): wire svdx-channel-chart renderer into /shapes/render

### DIFF
--- a/frontend/components/shapes/SvdxChannelChartView.vue
+++ b/frontend/components/shapes/SvdxChannelChartView.vue
@@ -1,0 +1,221 @@
+<script setup lang="ts">
+/**
+ * SvdxChannelChartView — catalogue view for the SvdxChannelChartShape VIEW_RECIPE.
+ *
+ * The backend SvdxChannelChartRenderer (plugins/fileformat-svdx) returns a
+ * channelBindings array where each entry's channelSelector is a JSON object:
+ *   { channelName?, symbolName?, dataType?, amsNetId?, port?, manifest? }
+ *
+ * This component groups bindings by dataType (the default svdx-ui:groupBy knob),
+ * renders a per-channel catalogue table, and highlights MISSING bindings.
+ *
+ * No timeseries data fetch is needed — this is a pure manifest catalogue view.
+ * The resolved.channelRef (FileReference appId for the .svdx file) is
+ * available in the raw binding but not needed here.
+ *
+ * Backlog: SVDX-CHANNEL-CHART-VUE-2026-06-29 (aidocs/16-dispatcher-backlog.md).
+ */
+import {
+  parseSvdxSelector,
+  groupSvdxBindingsByDataType,
+  extractManifest,
+  type SvdxBindingRow,
+  type SvdxManifestInfo,
+} from "~/utils/svdxChannelChart";
+
+interface RawBinding {
+  role: string;
+  status: string;
+  channelSelector: string;
+  unit: string | null;
+  required: boolean;
+}
+
+const props = defineProps<{
+  bindings: RawBinding[];
+}>();
+
+const rows = computed<SvdxBindingRow[]>(() =>
+  props.bindings.map(b => ({
+    role: b.role,
+    status: b.status,
+    selector: parseSvdxSelector(b.channelSelector),
+  })),
+);
+
+const manifest = computed<SvdxManifestInfo | null>(() => extractManifest(rows.value));
+
+const groups = computed(() => {
+  const m = groupSvdxBindingsByDataType(rows.value);
+  // REAL32 first (most common TwinCAT float type), then alphabetical
+  return [...m.entries()].sort(([a], [b]) => {
+    if (a === "REAL32") return -1;
+    if (b === "REAL32") return 1;
+    return a.localeCompare(b);
+  });
+});
+
+const channelCount = computed(() => rows.value.filter(r => r.role.startsWith("channel-")).length);
+const acquisitionCount = computed(() => rows.value.filter(r => r.role.startsWith("acquisition-")).length);
+const missingCount = computed(() => rows.value.filter(r => r.status === "MISSING").length);
+const okCount = computed(() => rows.value.filter(r => r.status === "OK").length);
+</script>
+
+<template>
+  <v-card variant="outlined" data-testid="svdx-channel-chart-view">
+    <!-- ── header ── -->
+    <v-card-title class="d-flex align-center ga-2 flex-wrap py-3">
+      <v-icon size="small" color="primary">mdi-waveform</v-icon>
+      <span>SVDX Channel Catalogue</span>
+      <v-chip v-if="channelCount > 0" size="x-small" variant="tonal" color="primary">
+        {{ channelCount }} channels
+      </v-chip>
+      <v-chip v-if="acquisitionCount > 0" size="x-small" variant="tonal" color="secondary">
+        {{ acquisitionCount }} acquisitions
+      </v-chip>
+      <v-chip v-if="missingCount > 0" size="x-small" variant="tonal" color="warning">
+        {{ missingCount }} missing
+      </v-chip>
+      <v-chip v-if="okCount > 0" size="x-small" variant="tonal" color="success">
+        {{ okCount }} resolved
+      </v-chip>
+    </v-card-title>
+
+    <!-- ── manifest summary ── -->
+    <v-card-text v-if="manifest" class="pt-0 pb-2">
+      <div class="d-flex flex-wrap ga-2">
+        <v-chip
+          v-if="manifest.projectName"
+          size="x-small"
+          prepend-icon="mdi-folder-outline"
+          variant="outlined"
+        >
+          {{ manifest.projectName }}
+        </v-chip>
+        <v-chip
+          v-if="manifest.channelCount"
+          size="x-small"
+          prepend-icon="mdi-chart-line"
+          variant="outlined"
+        >
+          {{ manifest.channelCount }} ch
+        </v-chip>
+        <v-chip
+          v-if="manifest.acquisitionCount"
+          size="x-small"
+          prepend-icon="mdi-record-circle-outline"
+          variant="outlined"
+        >
+          {{ manifest.acquisitionCount }} acq
+        </v-chip>
+        <v-chip
+          v-if="manifest.amsNetIds"
+          size="x-small"
+          prepend-icon="mdi-lan"
+          variant="outlined"
+        >
+          AMS {{ manifest.amsNetIds }}
+        </v-chip>
+        <v-chip
+          v-if="manifest.ports"
+          size="x-small"
+          prepend-icon="mdi-ethernet"
+          variant="outlined"
+        >
+          :{{ manifest.ports }}
+        </v-chip>
+        <v-chip
+          v-if="manifest.dataTypes"
+          size="x-small"
+          prepend-icon="mdi-code-braces"
+          variant="outlined"
+        >
+          {{ manifest.dataTypes }}
+        </v-chip>
+      </div>
+    </v-card-text>
+
+    <v-divider v-if="manifest" />
+
+    <!-- ── per-dataType groups ── -->
+    <v-card-text class="pt-2">
+      <template v-for="[dataType, groupRows] in groups" :key="dataType">
+        <div class="d-flex align-center ga-2 mb-1 mt-2">
+          <v-chip size="x-small" color="primary" variant="tonal" label>
+            {{ dataType }}
+          </v-chip>
+          <span class="text-caption text-medium-emphasis">{{ groupRows.length }} entries</span>
+        </div>
+
+        <v-table density="compact" class="mb-3" data-testid="svdx-channel-table">
+          <thead>
+            <tr>
+              <th class="text-caption">Role</th>
+              <th class="text-caption">Channel / Symbol</th>
+              <th class="text-caption">AMS Net ID</th>
+              <th class="text-caption">Port</th>
+              <th class="text-caption">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="row in groupRows"
+              :key="row.role"
+              :data-testid="`svdx-row-${row.role}`"
+            >
+              <td><code class="text-caption">{{ row.role }}</code></td>
+              <td class="text-caption">
+                <span v-if="row.selector?.channelName">{{ row.selector.channelName }}</span>
+                <span v-else-if="row.selector?.symbolName" class="text-medium-emphasis font-italic">
+                  {{ row.selector.symbolName }}
+                </span>
+                <span v-else class="text-disabled">—</span>
+              </td>
+              <td class="text-caption" style="font-family: monospace">
+                {{ row.selector?.amsNetId ?? "—" }}
+              </td>
+              <td class="text-caption" style="font-family: monospace">
+                {{ row.selector?.port ?? "—" }}
+              </td>
+              <td>
+                <v-chip
+                  size="x-small"
+                  :color="row.status === 'OK' ? 'success' : row.status === 'MISSING' ? 'warning' : 'default'"
+                  variant="tonal"
+                >
+                  {{ row.status }}
+                </v-chip>
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
+      </template>
+
+      <!-- MISSING binding explanatory alert -->
+      <v-alert
+        v-if="missingCount > 0"
+        type="warning"
+        variant="tonal"
+        density="compact"
+        class="mt-2"
+        data-testid="svdx-missing-alert"
+      >
+        {{ missingCount }} binding{{ missingCount !== 1 ? "s" : "" }} could not be resolved —
+        the focus entity may not have an associated <code>.svdx</code> file reference.
+      </v-alert>
+
+      <v-alert
+        v-if="rows.length === 0"
+        type="info"
+        variant="tonal"
+        density="compact"
+        class="mt-2"
+        data-testid="svdx-empty-alert"
+      >
+        No channel bindings returned. Check that the template has
+        <code>svdx-ui:groupBy</code> and that the focus entity carries a
+        <code>.svdx</code> file reference.
+      </v-alert>
+    </v-card-text>
+  </v-card>
+</template>

--- a/frontend/pages/shapes/render.vue
+++ b/frontend/pages/shapes/render.vue
@@ -39,6 +39,7 @@ import TemplateAutocomplete from "~/components/context/templates/TemplateAutocom
 import CollectionPrefillableInput from "~/components/context/search/input-components/CollectionPrefillableInput.vue";
 import DataObjectPrefillableInput from "~/components/context/search/input-components/DataObjectPrefillableInput.vue";
 import type { DataObject } from "@dlr-shepard/backend-client";
+import SvdxChannelChartView from "~/components/shapes/SvdxChannelChartView.vue";
 
 useHead({ title: "Shape render playground | shepard" });
 
@@ -482,12 +483,13 @@ const colormapOptions: ColormapName[] = ["inferno", "viridis", "plasma"];
 
 // ── renderer dispatch helpers ─────────────────────────────────────────────────
 
-const rendererKind = computed<"trace-3d" | "urdf" | "thermography" | "table" | "unknown">(() => {
+const rendererKind = computed<"trace-3d" | "urdf" | "thermography" | "table" | "svdx-channel-chart" | "unknown">(() => {
   const r = renderer.value?.toLowerCase() ?? "";
   if (r === "trace-3d" || r === "tresjs") return "trace-3d";
   if (r === "urdf")                        return "urdf";
   if (r === "thermography")                return "thermography";
   if (r === "table")                       return "table";
+  if (r === "svdx-channel-chart")          return "svdx-channel-chart";
   return "unknown";
 });
 
@@ -807,8 +809,17 @@ onMounted(() => {
       </ClientOnly>
     </template>
 
+    <!-- ── SVDX channel catalogue ───────────────────────────────────────────
+         Pure manifest catalogue from the SvdxChannelChartShape VIEW_RECIPE.
+         No TS container ID or time-window needed — the backend resolves the
+         channel list from the .svdx annotations on the focus entity.
+         Backlog: SVDX-CHANNEL-CHART-VUE-2026-06-29. -->
+    <template v-if="rendererKind === 'svdx-channel-chart'">
+      <SvdxChannelChartView :bindings="bindings" />
+    </template>
+
     <!-- ── binding declarations ───────────────────────────────────────────── -->
-    <template v-if="bindings.length > 0 && rendererKind !== 'urdf' && rendererKind !== 'thermography'">
+    <template v-if="bindings.length > 0 && rendererKind !== 'urdf' && rendererKind !== 'thermography' && rendererKind !== 'svdx-channel-chart'">
       <v-card variant="outlined" class="mb-4">
         <v-card-title class="text-subtitle-1 d-flex align-center ga-2">
           <v-icon>mdi-link-variant</v-icon>
@@ -991,7 +1002,7 @@ onMounted(() => {
         <v-alert v-else type="warning" variant="tonal" class="mt-2" density="compact">
           <strong>Unsupported renderer: <code>{{ renderer ?? "(none)" }}</code></strong>
           — {{ tracePoints.length }} points were fetched but no frontend component handles this renderer hint yet.
-          Supported renderers: <code>trace-3d</code>, <code>tresjs</code>, <code>table</code>.
+          Supported renderers: <code>trace-3d</code>, <code>tresjs</code>, <code>table</code>, <code>svdx-channel-chart</code>.
         </v-alert>
 
       </template>

--- a/frontend/tests/unit/svdxChannelChart.test.ts
+++ b/frontend/tests/unit/svdxChannelChart.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSvdxSelector,
+  groupSvdxBindingsByDataType,
+  extractManifest,
+  type SvdxBindingRow,
+} from "~/utils/svdxChannelChart";
+
+// ── parseSvdxSelector ─────────────────────────────────────────────────────────
+
+describe("parseSvdxSelector", () => {
+  it("parses a full channel selector", () => {
+    const json = JSON.stringify({
+      channelName: "TC_CH1",
+      symbolName: undefined,
+      dataType: "REAL32",
+      amsNetId: "1.2.3.4.1.1",
+      port: "851",
+      manifest: {
+        channelCount: "10",
+        acquisitionCount: "2",
+        projectName: "StatorTest",
+        dataTypes: "REAL32,INT16",
+        amsNetIds: "1.2.3.4.1.1",
+        ports: "851",
+      },
+    });
+    const result = parseSvdxSelector(json);
+    expect(result?.channelName).toBe("TC_CH1");
+    expect(result?.dataType).toBe("REAL32");
+    expect(result?.amsNetId).toBe("1.2.3.4.1.1");
+    expect(result?.port).toBe("851");
+    expect(result?.manifest?.projectName).toBe("StatorTest");
+    expect(result?.manifest?.channelCount).toBe("10");
+  });
+
+  it("parses an acquisition selector (symbolName present, channelName absent)", () => {
+    const json = JSON.stringify({
+      symbolName: "ACQ_SYM1",
+      dataType: "INT16",
+      amsNetId: "1.2.3.4.1.1",
+      port: "851",
+    });
+    const result = parseSvdxSelector(json);
+    expect(result?.symbolName).toBe("ACQ_SYM1");
+    expect(result?.channelName).toBeUndefined();
+    expect(result?.dataType).toBe("INT16");
+  });
+
+  it("parses a MISSING binding selector (anchorAppId + reason)", () => {
+    const json = JSON.stringify({
+      anchorAppId: "019603ab-dead-7fff-beef-000000000001",
+      reason: "no .svdx FileReference found on DataObject",
+    });
+    const result = parseSvdxSelector(json);
+    expect(result?.anchorAppId).toBe("019603ab-dead-7fff-beef-000000000001");
+    expect(result?.reason).toMatch(/no .svdx/);
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseSvdxSelector("{invalid}")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseSvdxSelector("")).toBeNull();
+  });
+
+  it("returns null for null input", () => {
+    expect(parseSvdxSelector(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(parseSvdxSelector(undefined)).toBeNull();
+  });
+});
+
+// ── groupSvdxBindingsByDataType ───────────────────────────────────────────────
+
+describe("groupSvdxBindingsByDataType", () => {
+  it("groups bindings by dataType", () => {
+    const rows: SvdxBindingRow[] = [
+      { role: "channel-0", status: "OK", selector: { dataType: "REAL32" } },
+      { role: "channel-1", status: "OK", selector: { dataType: "REAL32" } },
+      { role: "channel-2", status: "OK", selector: { dataType: "INT16" } },
+    ];
+    const groups = groupSvdxBindingsByDataType(rows);
+    expect(groups.get("REAL32")?.length).toBe(2);
+    expect(groups.get("INT16")?.length).toBe(1);
+  });
+
+  it("preserves insertion order within each group", () => {
+    const rows: SvdxBindingRow[] = [
+      { role: "channel-0", status: "OK", selector: { dataType: "REAL32", channelName: "A" } },
+      { role: "channel-1", status: "OK", selector: { dataType: "REAL32", channelName: "B" } },
+    ];
+    const group = groupSvdxBindingsByDataType(rows).get("REAL32")!;
+    expect(group[0]?.selector?.channelName).toBe("A");
+    expect(group[1]?.selector?.channelName).toBe("B");
+  });
+
+  it("uses (unknown) for rows with no dataType", () => {
+    const rows: SvdxBindingRow[] = [
+      {
+        role: "channel-0",
+        status: "MISSING",
+        selector: { anchorAppId: "abc", reason: "no svdx found" },
+      },
+    ];
+    const groups = groupSvdxBindingsByDataType(rows);
+    expect(groups.has("(unknown)")).toBe(true);
+    expect(groups.get("(unknown)")?.length).toBe(1);
+  });
+
+  it("uses (unknown) for rows with null selector", () => {
+    const rows: SvdxBindingRow[] = [{ role: "channel-0", status: "MISSING", selector: null }];
+    const groups = groupSvdxBindingsByDataType(rows);
+    expect(groups.has("(unknown)")).toBe(true);
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(groupSvdxBindingsByDataType([]).size).toBe(0);
+  });
+
+  it("handles mixed REAL32 and unknown in one call", () => {
+    const rows: SvdxBindingRow[] = [
+      { role: "channel-0", status: "OK", selector: { dataType: "REAL32" } },
+      { role: "channel-1", status: "MISSING", selector: null },
+    ];
+    const groups = groupSvdxBindingsByDataType(rows);
+    expect(groups.size).toBe(2);
+    expect(groups.get("REAL32")?.length).toBe(1);
+    expect(groups.get("(unknown)")?.length).toBe(1);
+  });
+});
+
+// ── extractManifest ───────────────────────────────────────────────────────────
+
+describe("extractManifest", () => {
+  it("returns the first manifest found", () => {
+    const rows: SvdxBindingRow[] = [
+      {
+        role: "channel-0",
+        status: "OK",
+        selector: { manifest: { projectName: "P1", channelCount: "5" } },
+      },
+      {
+        role: "channel-1",
+        status: "OK",
+        selector: { manifest: { projectName: "P2" } },
+      },
+    ];
+    const manifest = extractManifest(rows);
+    expect(manifest?.projectName).toBe("P1");
+    expect(manifest?.channelCount).toBe("5");
+  });
+
+  it("skips rows without a manifest before finding one", () => {
+    const rows: SvdxBindingRow[] = [
+      { role: "channel-0", status: "OK", selector: { channelName: "CH1" } },
+      {
+        role: "channel-1",
+        status: "OK",
+        selector: { manifest: { projectName: "Found" } },
+      },
+    ];
+    expect(extractManifest(rows)?.projectName).toBe("Found");
+  });
+
+  it("returns null when no binding carries a manifest", () => {
+    const rows: SvdxBindingRow[] = [
+      { role: "channel-0", status: "OK", selector: { channelName: "CH1" } },
+    ];
+    expect(extractManifest(rows)).toBeNull();
+  });
+
+  it("returns null for null selectors", () => {
+    const rows: SvdxBindingRow[] = [{ role: "channel-0", status: "MISSING", selector: null }];
+    expect(extractManifest(rows)).toBeNull();
+  });
+
+  it("returns null for empty rows", () => {
+    expect(extractManifest([])).toBeNull();
+  });
+});

--- a/frontend/utils/svdxChannelChart.ts
+++ b/frontend/utils/svdxChannelChart.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure helpers for the SvdxChannelChartView component.
+ *
+ * Parses the `channelSelector` JSON emitted by SvdxChannelChartRenderer and
+ * provides grouping / manifest-extraction utilities that the Vue component can
+ * use directly, and that Vitest can exercise without mounting Vue.
+ *
+ * Backlog: SVDX-CHANNEL-CHART-VUE-2026-06-29 (aidocs/16-dispatcher-backlog.md).
+ */
+
+export interface SvdxManifestInfo {
+  channelCount?: string;
+  acquisitionCount?: string;
+  projectName?: string;
+  dataTypes?: string;
+  amsNetIds?: string;
+  ports?: string;
+}
+
+/** JSON shape of `channelSelector` as emitted by SvdxChannelChartRenderer. */
+export interface SvdxChannelSelector {
+  /** Present for channel-N roles; absent for acquisition-N and MISSING rows. */
+  channelName?: string;
+  /** Present for acquisition-N roles; absent for channel-N rows. */
+  symbolName?: string;
+  /** TwinCAT data type, e.g. "REAL32", "INT16". File-level, same for all channels in one .svdx. */
+  dataType?: string;
+  /** AMS Net ID of the PLC, e.g. "1.2.3.4.1.1". File-level. */
+  amsNetId?: string;
+  /** ADS port, e.g. "851". File-level. */
+  port?: string;
+  /** File-level summary present on every binding. */
+  manifest?: SvdxManifestInfo;
+  /** Only present on MISSING bindings — appId of the entity that was probed. */
+  anchorAppId?: string;
+  /** Only present on MISSING bindings — human-readable reason. */
+  reason?: string;
+}
+
+/** Parsed representation of one binding row, ready for the Vue template. */
+export interface SvdxBindingRow {
+  role: string;
+  status: string;
+  /** null when channelSelector is absent or unparseable (MISSING rows may still have JSON). */
+  selector: SvdxChannelSelector | null;
+}
+
+/** Try to parse a raw channelSelector string; returns null on any failure. */
+export function parseSvdxSelector(
+  channelSelector: string | null | undefined,
+): SvdxChannelSelector | null {
+  if (!channelSelector) return null;
+  try {
+    return JSON.parse(channelSelector) as SvdxChannelSelector;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Group binding rows by their `dataType` field (the default `svdx-ui:groupBy` knob).
+ * Rows with no dataType land under the key `"(unknown)"`.
+ */
+export function groupSvdxBindingsByDataType(
+  rows: SvdxBindingRow[],
+): Map<string, SvdxBindingRow[]> {
+  const map = new Map<string, SvdxBindingRow[]>();
+  for (const row of rows) {
+    const key = row.selector?.dataType ?? "(unknown)";
+    const bucket = map.get(key) ?? [];
+    bucket.push(row);
+    map.set(key, bucket);
+  }
+  return map;
+}
+
+/**
+ * Extract the shared manifest metadata from the first binding that carries one.
+ * Returns null when none of the rows has a manifest (e.g. all MISSING).
+ */
+export function extractManifest(rows: SvdxBindingRow[]): SvdxManifestInfo | null {
+  for (const row of rows) {
+    if (row.selector?.manifest) return row.selector.manifest;
+  }
+  return null;
+}


### PR DESCRIPTION
## What

Ships the missing frontend component for the `SvdxChannelChartShape` VIEW_RECIPE recipe (backlog row `SVDX-CHANNEL-CHART-VUE-2026-06-29`).

The backend `SvdxChannelChartRenderer` (in `plugins/fileformat-svdx`) was already emitting `channelBindings` with full SVDX manifest metadata (`channelName`, `symbolName`, `dataType`, `amsNetId`, `port`, file-level `manifest`). The `/shapes/render` playground was falling through to the unsupported-renderer warning alert. This PR closes that gap.

## Changes

| File | Change |
|------|--------|
| `frontend/utils/svdxChannelChart.ts` | Pure helpers: `parseSvdxSelector`, `groupSvdxBindingsByDataType`, `extractManifest` — no Vue deps, fully Vitest-testable |
| `frontend/components/shapes/SvdxChannelChartView.vue` | New renderer component: groups bindings by `dataType`, shows per-channel catalogue table (channelName/symbolName/amsNetId/port/status), renders manifest summary chip row, warns on MISSING bindings |
| `frontend/tests/unit/svdxChannelChart.test.ts` | 19 new Vitest tests (parseSvdxSelector × 7, groupSvdxBindingsByDataType × 6, extractManifest × 5) |
| `frontend/pages/shapes/render.vue` | Adds `"svdx-channel-chart"` to `rendererKind` union; dispatches to `SvdxChannelChartView`; excludes it from the TS-binding/controls block |

## Design notes

- **No TS container ID needed** — `SvdxChannelChartView` is a pure catalogue view. All data comes from the `channelSelector` JSON already in the binding response. No `renderTrace()` call, no time-window picker.
- Follows the existing renderer dispatch pattern (`urdf`, `thermography`) — SVDX is excluded from the generic binding-declarations + TS-controls block, and gets its own `<template v-if="rendererKind === 'svdx-channel-chart'">` block.
- Groups default to `dataType` (matching the backend `svdx-ui:groupBy` knob default). `REAL32` sorts first (most common TwinCAT float type), then alphabetical.
- MISSING bindings render in the `(unknown)` group with a `"MISSING"` warning chip and an explanatory alert below the tables.

## Acceptance gates

- `npm run lint` — ✅ 0 errors (18 pre-existing warnings unchanged)
- `npm run test` — ✅ 2544 tests pass across 220 files (up from 2525/219)
- `npm run typecheck` — ✅ clean

Backend gates N/A (frontend-only change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLdT8RhBR1nDc7oefCHDhr)_