### PR TITLE
APISIMP-MISSING-OPERATIONID-P3: add operationId to 4 v2 method sites

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/mappings/resources/MappingsMaterializeRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/mappings/resources/MappingsMaterializeRest.java
@@ -96,6 +96,7 @@ public class MappingsMaterializeRest {
   @Path("/{templateAppId}/materialize")
   @RolesAllowed("authenticated")
   @org.eclipse.microprofile.openapi.annotations.Operation(
+    operationId = "materialize",
     summary = "Materialize a MAPPING_RECIPE template into a derived output.",
     description = "Binds the supplied input reference appIds through the recipe's shape and runs the " +
     "registered TransformExecutor, returning a derived reference appId or a played view-model. " +

--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserAvatarByAppIdRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserAvatarByAppIdRest.java
@@ -38,7 +38,7 @@ public class UserAvatarByAppIdRest {
 
   @GET
   @Produces("image/*")
-  @Operation(summary = "Get a user's avatar. No authentication required; returns 404 if none uploaded.")
+  @Operation(operationId = "getUserAvatar", summary = "Get a user's avatar. No authentication required; returns 404 if none uploaded.")
   @APIResponse(responseCode = "200", description = "Avatar bytes.")
   @APIResponse(responseCode = "404", description = "No avatar for this user.")
   public Response getAvatar(@PathParam("appId") String appId) {

--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserAvatarRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserAvatarRest.java
@@ -60,7 +60,7 @@ public class UserAvatarRest {
   @PUT
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(summary = "Upload or replace the caller's avatar (max 2 MB; JPEG/PNG/GIF/WebP).")
+  @Operation(operationId = "uploadMyAvatar", summary = "Upload or replace the caller's avatar (max 2 MB; JPEG/PNG/GIF/WebP).")
   @APIResponse(responseCode = "204", description = "Avatar stored.")
   @APIResponse(responseCode = "400", description = "Missing file part, unsupported type, or file exceeds 2 MB.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
@@ -110,7 +110,7 @@ public class UserAvatarRest {
 
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
-  @Operation(summary = "Remove the caller's avatar.")
+  @Operation(operationId = "deleteMyAvatar", summary = "Remove the caller's avatar.")
   @APIResponse(responseCode = "204", description = "Avatar removed (or was already absent).")
   @APIResponse(responseCode = "401", description = "Authentication required.")
   public Response deleteAvatar(@Context SecurityContext securityContext) {


### PR DESCRIPTION
## Summary

Three v2 REST files were missed by the fire-341 wave (APISIMP-MISSING-OPERATIONID, PR #2213), which passed a file if *any* method documented `operationId`. All four affected method sites had `@Operation(summary=...)` but no `operationId`, breaking generated client method naming and OpenAPI spec completeness.

**Changes (annotation-only; zero wire shape change):**

| File | Method | `operationId` added |
|---|---|---|
| `MappingsMaterializeRest.java` | `POST /v2/mappings/{templateAppId}/materialize` | `"materialize"` |
| `UserAvatarByAppIdRest.java` | `GET /v2/users/{appId}/avatar` | `"getUserAvatar"` |
| `UserAvatarRest.java` | `PUT /v2/users/me/avatar` | `"uploadMyAvatar"` |
| `UserAvatarRest.java` | `DELETE /v2/users/me/avatar` | `"deleteMyAvatar"` |

## Acceptance criteria

- All 4 method sites have `operationId` in the generated OpenAPI spec
- `mvn verify -pl backend` green

## References

- Backlog row: `APISIMP-MISSING-OPERATIONID-P3` in `aidocs/16-dispatcher-backlog.md`
- Sweep report: `aidocs/agent-findings/apisimp-sweep-fire351-2026-07-01.md §F1`
- Prior wave: PR #2213 (fire-341, 22 sites)


---
_Generated by [Claude Code](https://claude.ai/code/session_011C6jmCenztuRdBmPxoVXBk)_