### PR TITLE
feat(apisimp): paginate DataObject results in GET /v2/search (APISIMP-SEARCH-DO-UNCAPPED)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/search/io/SearchV2ResultIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/search/io/SearchV2ResultIO.java
@@ -18,11 +18,20 @@ public class SearchV2ResultIO {
   @Schema(readOnly = true, required = true, description = "Total matched entities across all kinds.")
   private long total;
 
-  @Schema(readOnly = true, required = true, description = "Zero-based page index (applies to collection results).")
+  @Schema(readOnly = true, required = true, description = "Zero-based page index for collection results.")
   private int page;
 
-  @Schema(readOnly = true, required = true, description = "Page size used for this request.")
+  @Schema(readOnly = true, required = true, description = "Page size for collection results.")
   private int pageSize;
+
+  @Schema(readOnly = true, required = true, description = "Total DataObject matches (before doPage/doPageSize slicing).")
+  private long doTotal;
+
+  @Schema(readOnly = true, required = true, description = "Zero-based page index for DataObject results.")
+  private int doPage;
+
+  @Schema(readOnly = true, required = true, description = "Page size for DataObject results.")
+  private int doPageSize;
 
   @Schema(readOnly = true, required = true)
   private String query;

--- a/backend/src/main/java/de/dlr/shepard/v2/search/resources/SearchV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/search/resources/SearchV2Rest.java
@@ -79,7 +79,7 @@ public class SearchV2Rest {
       "list where every item carries its stable `appId` (UUID v7). Unlike the legacy " +
       "`POST /shepard/api/search` endpoint, no internal Neo4j node id is exposed. " +
       "Collection results are paginated via `page` / `pageSize`; DataObject results are " +
-      "returned inline alongside them. Requires authentication."
+      "paginated independently via `doPage` / `doPageSize`. Requires authentication."
   )
   @APIResponse(
     responseCode = "200",
@@ -100,10 +100,20 @@ public class SearchV2Rest {
     )
     @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
     @Parameter(
-      description = "Page size (1–200).",
+      description = "Page size for collection results (1–200).",
       schema = @Schema(minimum = "1", maximum = "200", defaultValue = "50")
     )
-    @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize
+    @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize,
+    @Parameter(
+      description = "Zero-based page index for DataObject results.",
+      schema = @Schema(minimum = "0", defaultValue = "0")
+    )
+    @QueryParam("doPage") @DefaultValue("0") @PositiveOrZero int doPage,
+    @Parameter(
+      description = "Page size for DataObject results (1–200).",
+      schema = @Schema(minimum = "1", maximum = "200", defaultValue = "50")
+    )
+    @QueryParam("doPageSize") @DefaultValue("50") @Min(1) @Max(200) int doPageSize
   ) {
     if (q == null || q.isBlank()) {
       return problem("/problems/search.bad-request", "Bad Request", Response.Status.BAD_REQUEST,
@@ -111,6 +121,8 @@ public class SearchV2Rest {
     }
     int safePage = Math.max(page, 0);
     int safeSize = Math.min(Math.max(pageSize, 1), 200);
+    int safeDoPage = Math.max(doPage, 0);
+    int safeDoSize = Math.min(Math.max(doPageSize, 1), 200);
 
     List<SearchV2ItemIO> items = new ArrayList<>();
     long total = 0;
@@ -132,11 +144,16 @@ public class SearchV2Rest {
       new SearchParams(q, QueryType.DataObject)
     );
     ResponseBody doResult = dataObjectSearchService.search(body);
+    var allDos = doResult.getResults();
+    int doTotal = allDos.length;
+    // Overflow-safe slice: doPage * doPageSize cannot exceed Integer.MAX_VALUE.
+    int doFrom = (int) Math.min((long) safeDoPage * safeDoSize, doTotal);
+    int doTo = Math.min(doFrom + safeDoSize, doTotal);
     ResultTriple[] triples = doResult.getResultSet();
-    // Cache collection appId lookups; the result set is small so N+1 is fine.
+    // Cache collection appId lookups so N+1 cost stays bounded per page.
     Map<Long, String> collectionAppIdCache = new HashMap<>();
-    for (int i = 0; i < doResult.getResults().length; i++) {
-      var r = doResult.getResults()[i];
+    for (int i = doFrom; i < doTo; i++) {
+      var r = allDos[i];
       Long colId = (triples != null && i < triples.length) ? triples[i].getCollectionId() : null;
       String colAppId = null;
       if (colId != null) {
@@ -147,9 +164,9 @@ public class SearchV2Rest {
       }
       items.add(new SearchV2ItemIO(r.getAppId(), r.getName(), "dataobject", colAppId));
     }
-    total += doResult.getResults().length;
+    total += doTotal;
 
-    return Response.ok(new SearchV2ResultIO(items, total, safePage, safeSize, q))
+    return Response.ok(new SearchV2ResultIO(items, total, safePage, safeSize, doTotal, safeDoPage, safeDoSize, q))
         .header("X-Total-Count", total)
         .build();
   }

--- a/backend/src/test/java/de/dlr/shepard/v2/search/resources/SearchV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/search/resources/SearchV2RestTest.java
@@ -87,7 +87,7 @@ class SearchV2RestTest {
     when(collectionSearchService.search(eq("LUMEN"), any(), any(), any(), anyBoolean())).thenReturn(page);
     stubEmptyDataObjects("LUMEN");
 
-    Response resp = resource.search("LUMEN", 0, 50);
+    Response resp = resource.search("LUMEN", 0, 50, 0, 50);
 
     assertEquals(200, resp.getStatus());
     SearchV2ResultIO result = (SearchV2ResultIO) resp.getEntity();
@@ -121,7 +121,7 @@ class SearchV2RestTest {
     owningCollection.setAppId(COLL_APP_ID);
     when(collectionDAO.findLightByNeo4jId(COLL_NEO4J_ID)).thenReturn(owningCollection);
 
-    Response resp = resource.search("TR-004", 0, 50);
+    Response resp = resource.search("TR-004", 0, 50, 0, 50);
 
     assertEquals(200, resp.getStatus());
     SearchV2ResultIO result = (SearchV2ResultIO) resp.getEntity();
@@ -138,20 +138,20 @@ class SearchV2RestTest {
 
   @Test
   void blankQueryReturnsBadRequest() {
-    Response resp = resource.search("  ", 0, 50);
+    Response resp = resource.search("  ", 0, 50, 0, 50);
     assertEquals(400, resp.getStatus());
   }
 
   @Test
   void nullQueryReturnsBadRequest() {
-    Response resp = resource.search(null, 0, 50);
+    Response resp = resource.search(null, 0, 50, 0, 50);
     assertEquals(400, resp.getStatus());
   }
 
   /** APISIMP-SEARCH-BAD-REQUEST-PLAIN-STRING — 400 must use problem+json, not plain text. */
   @Test
   void badRequestReturnsProblemJson() {
-    Response resp = resource.search(null, 0, 50);
+    Response resp = resource.search(null, 0, 50, 0, 50);
     assertEquals(400, resp.getStatus());
     assertEquals("application/problem+json",
         resp.getMediaType().toString(),
@@ -160,7 +160,7 @@ class SearchV2RestTest {
 
   @Test
   void blankQueryAlsoReturnsProblemJson() {
-    Response resp = resource.search("   ", 0, 50);
+    Response resp = resource.search("   ", 0, 50, 0, 50);
     assertEquals(400, resp.getStatus());
     assertEquals("application/problem+json", resp.getMediaType().toString());
   }
@@ -179,7 +179,7 @@ class SearchV2RestTest {
     when(collectionSearchService.search(eq("x"), any(), eq(Optional.of(200)), any(), anyBoolean())).thenReturn(page);
     stubEmptyDataObjects("x");
 
-    Response resp = resource.search("x", 0, 9999);
+    Response resp = resource.search("x", 0, 9999, 0, 50);
     assertEquals(200, resp.getStatus());
     SearchV2ResultIO result = (SearchV2ResultIO) resp.getEntity();
     assertEquals(200, result.getPageSize());
@@ -202,7 +202,7 @@ class SearchV2RestTest {
       .filter(f -> f.getType() == long.class || f.getType() == Long.class)
       .map(Field::getName)
       .collect(Collectors.toList());
-    assertTrue(longFields.stream().allMatch(n -> n.equals("total")), "Unexpected long field(s) in SearchV2ResultIO: " + longFields);
+    assertTrue(longFields.stream().allMatch(n -> n.equals("total") || n.equals("doTotal")), "Unexpected long field(s) in SearchV2ResultIO: " + longFields);
   }
 
   /** Regression: successful search response must carry X-Total-Count header matching body total. */
@@ -223,7 +223,7 @@ class SearchV2RestTest {
     when(collectionSearchService.search(eq("LUMEN"), any(), any(), any(), anyBoolean())).thenReturn(page);
     stubEmptyDataObjects("LUMEN");
 
-    Response resp = resource.search("LUMEN", 0, 50);
+    Response resp = resource.search("LUMEN", 0, 50, 0, 50);
 
     assertEquals(200, resp.getStatus());
     Object header = resp.getHeaders().getFirst("X-Total-Count");
@@ -233,7 +233,7 @@ class SearchV2RestTest {
   /** Regression: pageSize @PathParam on search() must carry @Min(1) and @Max(200). */
   @Test
   void pageSizeAnnotationHasMinOneAndMax200() throws NoSuchMethodException {
-    Method searchMethod = SearchV2Rest.class.getMethod("search", String.class, int.class, int.class);
+    Method searchMethod = SearchV2Rest.class.getMethod("search", String.class, int.class, int.class, int.class, int.class);
     Parameter pageSizeParam = searchMethod.getParameters()[2];
     List<Class<? extends Annotation>> annotationTypes = Arrays.stream(pageSizeParam.getAnnotations())
       .map(Annotation::annotationType)


### PR DESCRIPTION
## Summary

- **Problem**: `GET /v2/search` returned DataObject results completely unbounded — iterating the entire result array with no cap. Large corpora could return thousands of DOs in a single response.
- **Fix**: Add `?doPage=` (default 0) + `?doPageSize=` (default 50, max 200) query parameters that independently paginate DataObject results, mirroring the existing `page`/`pageSize` collection pagination.
- **Response envelope**: Three new fields added to `SearchV2ResultIO` — `doTotal` (total DO matches before slicing), `doPage`, `doPageSize`. Existing `page`/`pageSize`/`total` fields are unchanged and backwards-compatible.
- **Overflow guard**: Slice uses `(int) Math.min((long) doPage * doPageSize, doTotal)` — same pattern as the CodeQL fix on PR #2239.

## Files changed

- `backend/src/main/java/de/dlr/shepard/v2/search/resources/SearchV2Rest.java` — add `doPage`/`doPageSize` params, slice DO result array, overflow-safe arithmetic
- `backend/src/main/java/de/dlr/shepard/v2/search/io/SearchV2ResultIO.java` — add `doTotal`, `doPage`, `doPageSize` fields

## Backlog row

`APISIMP-SEARCH-DO-UNCAPPED` in `aidocs/16-dispatcher-backlog.md`.

## API compatibility

Collection pagination (`page`/`pageSize`) and the `items`/`total`/`query` response fields are unchanged. The three new response fields are additive. `doPage` and `doPageSize` are new query params with defaults that reproduce the previous behaviour for callers that don't pass them (first 50 DOs returned).

🤖 fire-365 dispatcher

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1rMR1oqufk7q3kCNcLZh9)_