### PR TITLE
feat(APISIMP-SNAPSHOT-DIFF-UNCAPPED): add ?maxItems= cap to snapshot diff endpoint

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/context/snapshot/io/SnapshotDiffIO.java
+++ b/backend/src/main/java/de/dlr/shepard/context/snapshot/io/SnapshotDiffIO.java
@@ -18,9 +18,13 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
  * </ul>
  *
  * <p>All lists are sorted by {@code entityAppId} ascending for deterministic,
- * diff-friendly output.
+ * diff-friendly output. When the diff exceeds the {@code ?maxItems} cap, each list
+ * is capped at {@code ceil(maxItems/3)} entries and {@code truncated} is set to
+ * {@code true}. The {@code totalAdded}, {@code totalRemoved}, and
+ * {@code totalChanged} counts always reflect the full uncapped diff.
  *
- * <p>Cross-references: {@code aidocs/41} §7; {@code aidocs/16} V2e.
+ * <p>Cross-references: {@code aidocs/41} §7; {@code aidocs/16} V2e,
+ * {@code APISIMP-SNAPSHOT-DIFF-UNCAPPED}.
  */
 @Schema(name = "SnapshotDiff")
 public record SnapshotDiffIO(
@@ -36,17 +40,29 @@ public record SnapshotDiffIO(
   @Schema(description = "Epoch milliseconds at which snapshot B was captured.")
   long snapshotBCapturedAtMs,
 
-  @Schema(description = "entityAppIds present in B but not in A (created between snapshots). Sorted ascending.")
+  @Schema(description = "entityAppIds present in B but not in A (created between snapshots). Sorted ascending. Capped at ceil(?maxItems/3) entries when truncated=true.")
   List<String> added,
 
-  @Schema(description = "entityAppIds present in A but not in B (deleted or out of scope in B). Sorted ascending.")
+  @Schema(description = "entityAppIds present in A but not in B (deleted or out of scope in B). Sorted ascending. Capped at ceil(?maxItems/3) entries when truncated=true.")
   List<String> removed,
 
-  @Schema(description = "Entities present in both snapshots with different revision values. Sorted by entityAppId ascending.")
+  @Schema(description = "Entities present in both snapshots with different revision values. Sorted by entityAppId ascending. Capped at ceil(?maxItems/3) entries when truncated=true.")
   List<DiffEntry> changed,
 
   @Schema(description = "Count of entities present in both snapshots with identical revisions (not listed to avoid large payloads).")
-  int unchangedCount
+  int unchangedCount,
+
+  @Schema(description = "Total count of added entities in the full diff (before capping). Always accurate even when truncated=true.")
+  int totalAdded,
+
+  @Schema(description = "Total count of removed entities in the full diff (before capping). Always accurate even when truncated=true.")
+  int totalRemoved,
+
+  @Schema(description = "Total count of changed entities in the full diff (before capping). Always accurate even when truncated=true.")
+  int totalChanged,
+
+  @Schema(description = "True when the diff exceeded the ?maxItems cap and one or more lists were truncated. Use totalAdded/totalRemoved/totalChanged to know the full scope.")
+  boolean truncated
 ) {
 
   /**

--- a/backend/src/main/java/de/dlr/shepard/v2/mcp/SnapshotMcpTools.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/mcp/SnapshotMcpTools.java
@@ -289,7 +289,11 @@ public class SnapshotMcpTools {
         added,
         removed,
         changed,
-        unchangedCount
+        unchangedCount,
+        added.size(),
+        removed.size(),
+        changed.size(),
+        false
       );
       return support.toJson(diff);
     });

--- a/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotDiffRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotDiffRest.java
@@ -7,11 +7,15 @@ import de.dlr.shepard.context.snapshot.io.SnapshotDiffIO.DiffEntry;
 import de.dlr.shepard.context.snapshot.services.SnapshotService;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -22,6 +26,7 @@ import java.util.Map;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -33,6 +38,12 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
  * added, removed, or changed in revision between them. Entities with identical
  * revisions are counted but not listed (the set can be arbitrarily large).
  *
+ * <p>Server-side cap: each of the {@code added}, {@code removed}, and {@code changed}
+ * lists is capped at {@code ceil(?maxItems / 3)} entries (default {@code ?maxItems=5000},
+ * max {@code 20000}). When any list is capped, {@code truncated=true} is set and the
+ * {@code totalAdded}/{@code totalRemoved}/{@code totalChanged} counts reflect the full
+ * uncapped diff.
+ *
  * <p>Auth: authenticated caller required (401 when unauthenticated). In v1 no
  * additional per-collection permission gate is applied — snapshots are metadata
  * only; a stricter per-collection gate can be added in a future revision when
@@ -41,14 +52,16 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
  * <p>Error conditions:
  * <ul>
  *   <li>401 — unauthenticated caller.</li>
- *   <li>400 — {@code aAppId} equals {@code bAppId} (self-diff is meaningless).</li>
+ *   <li>400 — {@code aAppId} equals {@code bAppId} (self-diff is meaningless),
+ *       or {@code ?maxItems} is outside [1, 20000].</li>
  *   <li>404 — snapshot A or snapshot B not found or soft-deleted.</li>
  * </ul>
  *
  * <p>All result lists are sorted by {@code entityAppId} ascending for
  * deterministic output.
  *
- * <p>Cross-references: {@code aidocs/41} §7; {@code aidocs/16} V2e;
+ * <p>Cross-references: {@code aidocs/41} §7; {@code aidocs/16} V2e,
+ * {@code APISIMP-SNAPSHOT-DIFF-UNCAPPED};
  * API-version policy (CLAUDE.md — all new endpoints under {@code /v2/}).
  */
 @Produces(MediaType.APPLICATION_JSON)
@@ -57,6 +70,12 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @RequestScoped
 @Tag(name = "Snapshots")
 public class SnapshotDiffRest {
+
+  /** Default cap across all three diff lists (added + removed + changed). */
+  static final int DEFAULT_MAX_ITEMS = 5000;
+
+  /** Hard upper bound on ?maxItems to protect response budget. */
+  static final int HARD_MAX_ITEMS = 20000;
 
   @Inject
   SnapshotService snapshotService;
@@ -72,11 +91,16 @@ public class SnapshotDiffRest {
   /**
    * Diff two snapshots.
    *
-   * @param aAppId the application-level identifier of snapshot A (base).
-   * @param bAppId the application-level identifier of snapshot B (head).
-   * @param sc     the JAX-RS security context.
-   * @return 200 with a {@link SnapshotDiffIO}; 400 when A and B are the same;
-   *         401 unauthenticated; 404 when either snapshot is unknown or deleted.
+   * @param aAppId    the application-level identifier of snapshot A (base).
+   * @param bAppId    the application-level identifier of snapshot B (head).
+   * @param sc        the JAX-RS security context.
+   * @param maxItems  server-side cap on the total number of diff items returned across all
+   *                  three lists (default 5000, max 20000). Each list is capped at
+   *                  {@code ceil(maxItems/3)} entries; {@code truncated} is set to
+   *                  {@code true} when any list is capped.
+   * @return 200 with a {@link SnapshotDiffIO}; 400 when A and B are the same or
+   *         {@code maxItems} is out of range; 401 unauthenticated; 404 when either
+   *         snapshot is unknown or deleted.
    */
   @GET
   @Operation(
@@ -88,6 +112,9 @@ public class SnapshotDiffRest {
       "(in A, not in B), or changed revision (present in both with different revision), " +
       "plus a count of unchanged entities (same revision in both). " +
       "All lists are sorted by entityAppId ascending. " +
+      "Each list is capped at ceil(?maxItems/3) entries (default maxItems=5000, max 20000); " +
+      "when any list is capped, truncated=true and totalAdded/totalRemoved/totalChanged " +
+      "reflect the full uncapped counts. " +
       "Requires an authenticated caller; no per-collection permission gate in v1."
   )
   @APIResponse(
@@ -97,7 +124,7 @@ public class SnapshotDiffRest {
   )
   @APIResponse(
     responseCode = "400",
-    description = "aAppId and bAppId are the same (self-diff is not useful).",
+    description = "aAppId and bAppId are the same (self-diff is not useful), or ?maxItems is outside [1, 20000].",
     content = @Content(mediaType = "application/problem+json", schema = @Schema(implementation = ProblemJson.class))
   )
   @APIResponse(responseCode = "401", description = "Authentication required.")
@@ -105,7 +132,9 @@ public class SnapshotDiffRest {
   public Response diff(
     @PathParam("aAppId") String aAppId,
     @PathParam("bAppId") String bAppId,
-    @Context SecurityContext sc
+    @Context SecurityContext sc,
+    @Parameter(description = "Cap on the total number of items returned across added + removed + changed lists. Each list is capped at ceil(maxItems/3). Default 5000, max 20000.")
+    @QueryParam("maxItems") @DefaultValue("5000") @Min(1) @Max(HARD_MAX_ITEMS) int maxItems
   ) {
     // Auth gate — must be authenticated
     if (sc.getUserPrincipal() == null) {
@@ -166,6 +195,27 @@ public class SnapshotDiffRest {
     removed.sort(String::compareTo);
     changed.sort((x, y) -> x.entityAppId().compareTo(y.entityAppId()));
 
+    // Record full totals before capping
+    int totalAdded = added.size();
+    int totalRemoved = removed.size();
+    int totalChanged = changed.size();
+
+    // Apply per-list cap: each list gets ceil(maxItems / 3) entries
+    int perListCap = (maxItems + 2) / 3;
+    boolean truncated = false;
+    if (added.size() > perListCap) {
+      added = added.subList(0, perListCap);
+      truncated = true;
+    }
+    if (removed.size() > perListCap) {
+      removed = removed.subList(0, perListCap);
+      truncated = true;
+    }
+    if (changed.size() > perListCap) {
+      changed = changed.subList(0, perListCap);
+      truncated = true;
+    }
+
     SnapshotDiffIO diff = new SnapshotDiffIO(
       snapshotA.getAppId(),
       snapshotB.getAppId(),
@@ -174,7 +224,11 @@ public class SnapshotDiffRest {
       added,
       removed,
       changed,
-      unchangedCount
+      unchangedCount,
+      totalAdded,
+      totalRemoved,
+      totalChanged,
+      truncated
     );
 
     return Response.ok(diff).build();

--- a/backend/src/test/java/de/dlr/shepard/v2/snapshot/resources/SnapshotDiffRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/snapshot/resources/SnapshotDiffRestTest.java
@@ -10,6 +10,7 @@ import de.dlr.shepard.context.snapshot.services.SnapshotService;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import java.security.Principal;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +24,9 @@ import org.mockito.MockitoAnnotations;
  * <p>No CDI container or network required; fields are injected directly.
  * Covers: 401 unauthenticated, 400 self-diff, 404 A not found, 404 B not found,
  * 200 correct added list, 200 correct removed list, 200 correct changed list,
- * 200 correct unchangedCount, 200 lists are sorted by entityAppId.
+ * 200 correct unchangedCount, 200 lists are sorted by entityAppId,
+ * 200 truncation when maxItems exceeded (APISIMP-SNAPSHOT-DIFF-UNCAPPED),
+ * 200 truncated=false when diff fits within maxItems.
  */
 class SnapshotDiffRestTest {
 
@@ -38,6 +41,7 @@ class SnapshotDiffRestTest {
   static final long SNAP_B_CAPTURED_AT = 1_700_001_000_000L;
 
   static final String CALLER = "alice";
+  static final int DEFAULT_MAX = SnapshotDiffRest.DEFAULT_MAX_ITEMS;
 
   // ── mocks ────────────────────────────────────────────────────────────────
 
@@ -90,7 +94,7 @@ class SnapshotDiffRestTest {
   @Test
   void diff_returns401_whenUnauthenticated() {
     when(sc.getUserPrincipal()).thenReturn(null);
-    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc);
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, DEFAULT_MAX);
     assertThat(r.getStatus()).isEqualTo(401);
   }
 
@@ -98,7 +102,7 @@ class SnapshotDiffRestTest {
 
   @Test
   void diff_returns400_whenAandBAreSameAppId() {
-    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_A_APP_ID, sc);
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_A_APP_ID, sc, DEFAULT_MAX);
     assertThat(r.getStatus()).isEqualTo(400);
   }
 
@@ -107,14 +111,14 @@ class SnapshotDiffRestTest {
   @Test
   void diff_returns404_whenSnapshotANotFound() {
     when(snapshotService.findByAppId(SNAP_A_APP_ID)).thenReturn(null);
-    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc);
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, DEFAULT_MAX);
     assertThat(r.getStatus()).isEqualTo(404);
   }
 
   @Test
   void diff_returns404_whenSnapshotBNotFound() {
     when(snapshotService.findByAppId(SNAP_B_APP_ID)).thenReturn(null);
-    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc);
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, DEFAULT_MAX);
     assertThat(r.getStatus()).isEqualTo(404);
   }
 
@@ -128,7 +132,7 @@ class SnapshotDiffRestTest {
       Map.of("entity-c", 1L, "entity-a", 1L)
     );
 
-    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc);
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, DEFAULT_MAX);
     assertThat(r.getStatus()).isEqualTo(200);
 
     SnapshotDiffIO body = (SnapshotDiffIO) r.getEntity();
@@ -136,6 +140,10 @@ class SnapshotDiffRestTest {
     assertThat(body.removed()).isEmpty();
     assertThat(body.changed()).isEmpty();
     assertThat(body.unchangedCount()).isZero();
+    assertThat(body.totalAdded()).isEqualTo(2);
+    assertThat(body.totalRemoved()).isZero();
+    assertThat(body.totalChanged()).isZero();
+    assertThat(body.truncated()).isFalse();
   }
 
   // ── 200 correct removed list ──────────────────────────────────────────────
@@ -148,7 +156,7 @@ class SnapshotDiffRestTest {
     );
     when(snapshotService.getEntryRevisionMap(SNAP_B_OGM_ID)).thenReturn(Map.of());
 
-    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc);
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, DEFAULT_MAX);
     assertThat(r.getStatus()).isEqualTo(200);
 
     SnapshotDiffIO body = (SnapshotDiffIO) r.getEntity();
@@ -156,6 +164,10 @@ class SnapshotDiffRestTest {
     assertThat(body.added()).isEmpty();
     assertThat(body.changed()).isEmpty();
     assertThat(body.unchangedCount()).isZero();
+    assertThat(body.totalRemoved()).isEqualTo(2);
+    assertThat(body.totalAdded()).isZero();
+    assertThat(body.totalChanged()).isZero();
+    assertThat(body.truncated()).isFalse();
   }
 
   // ── 200 correct changed list ──────────────────────────────────────────────
@@ -170,7 +182,7 @@ class SnapshotDiffRestTest {
       Map.of("entity-x", 3L)
     );
 
-    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc);
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, DEFAULT_MAX);
     assertThat(r.getStatus()).isEqualTo(200);
 
     SnapshotDiffIO body = (SnapshotDiffIO) r.getEntity();
@@ -182,6 +194,8 @@ class SnapshotDiffRestTest {
     assertThat(body.added()).isEmpty();
     assertThat(body.removed()).isEmpty();
     assertThat(body.unchangedCount()).isZero();
+    assertThat(body.totalChanged()).isEqualTo(1);
+    assertThat(body.truncated()).isFalse();
   }
 
   // ── 200 correct unchangedCount ────────────────────────────────────────────
@@ -196,7 +210,7 @@ class SnapshotDiffRestTest {
       Map.of("entity-same", 5L)
     );
 
-    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc);
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, DEFAULT_MAX);
     assertThat(r.getStatus()).isEqualTo(200);
 
     SnapshotDiffIO body = (SnapshotDiffIO) r.getEntity();
@@ -204,6 +218,7 @@ class SnapshotDiffRestTest {
     assertThat(body.added()).isEmpty();
     assertThat(body.removed()).isEmpty();
     assertThat(body.changed()).isEmpty();
+    assertThat(body.truncated()).isFalse();
   }
 
   // ── 200 lists sorted by entityAppId ──────────────────────────────────────
@@ -219,7 +234,7 @@ class SnapshotDiffRestTest {
       Map.of("entity-c", 7L, "entity-a", 1L, "entity-b", 2L)
     );
 
-    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc);
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, DEFAULT_MAX);
     assertThat(r.getStatus()).isEqualTo(200);
 
     SnapshotDiffIO body = (SnapshotDiffIO) r.getEntity();
@@ -234,13 +249,14 @@ class SnapshotDiffRestTest {
     assertThat(body.changed().get(0).revisionB()).isEqualTo(2L);
     // unchanged: entity-c
     assertThat(body.unchangedCount()).isEqualTo(1);
+    assertThat(body.truncated()).isFalse();
   }
 
   // ── 200 metadata fields carried through ──────────────────────────────────
 
   @Test
   void diff_200_metadataFieldsAreCorrect() {
-    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc);
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, DEFAULT_MAX);
     assertThat(r.getStatus()).isEqualTo(200);
 
     SnapshotDiffIO body = (SnapshotDiffIO) r.getEntity();
@@ -248,5 +264,122 @@ class SnapshotDiffRestTest {
     assertThat(body.snapshotBAppId()).isEqualTo(SNAP_B_APP_ID);
     assertThat(body.snapshotACapturedAtMs()).isEqualTo(SNAP_A_CAPTURED_AT);
     assertThat(body.snapshotBCapturedAtMs()).isEqualTo(SNAP_B_CAPTURED_AT);
+  }
+
+  // ── APISIMP-SNAPSHOT-DIFF-UNCAPPED: truncation cap ───────────────────────
+
+  @Test
+  void diff_capsLists_whenMaxItemsExceeded() {
+    // Build a diff with 12 added + 12 removed + 12 changed entities.
+    // maxItems=9 → perListCap = ceil(9/3) = 3, so each list is capped at 3.
+    // Total returned: 3+3+3 = 9; truncated = true.
+    Map<String, Long> mapA = new HashMap<>();
+    Map<String, Long> mapB = new HashMap<>();
+
+    // 12 removed (in A only)
+    for (int i = 0; i < 12; i++) {
+      mapA.put("removed-" + String.format("%02d", i), 1L);
+    }
+    // 12 added (in B only)
+    for (int i = 0; i < 12; i++) {
+      mapB.put("added-" + String.format("%02d", i), 1L);
+    }
+    // 12 changed (in both with different revisions)
+    for (int i = 0; i < 12; i++) {
+      String key = "changed-" + String.format("%02d", i);
+      mapA.put(key, 1L);
+      mapB.put(key, 2L);
+    }
+
+    when(snapshotService.getEntryRevisionMap(SNAP_A_OGM_ID)).thenReturn(mapA);
+    when(snapshotService.getEntryRevisionMap(SNAP_B_OGM_ID)).thenReturn(mapB);
+
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, 9);
+    assertThat(r.getStatus()).isEqualTo(200);
+
+    SnapshotDiffIO body = (SnapshotDiffIO) r.getEntity();
+    assertThat(body.truncated()).isTrue();
+
+    // Each list capped at ceil(9/3) = 3
+    assertThat(body.added()).hasSize(3);
+    assertThat(body.removed()).hasSize(3);
+    assertThat(body.changed()).hasSize(3);
+
+    // Totals reflect the full uncapped diff
+    assertThat(body.totalAdded()).isEqualTo(12);
+    assertThat(body.totalRemoved()).isEqualTo(12);
+    assertThat(body.totalChanged()).isEqualTo(12);
+
+    // Returned items are the first N alphabetically (sorted before cap)
+    assertThat(body.added().get(0)).isEqualTo("added-00");
+    assertThat(body.removed().get(0)).isEqualTo("removed-00");
+    assertThat(body.changed().get(0).entityAppId()).isEqualTo("changed-00");
+  }
+
+  @Test
+  void diff_notTruncated_whenDiffFitsWithinMaxItems() {
+    // 2 added + 2 removed + 2 changed; maxItems=12 → perListCap=4; no truncation.
+    when(snapshotService.getEntryRevisionMap(SNAP_A_OGM_ID)).thenReturn(
+      Map.of("removed-a", 1L, "removed-b", 1L, "changed-x", 1L, "changed-y", 1L)
+    );
+    when(snapshotService.getEntryRevisionMap(SNAP_B_OGM_ID)).thenReturn(
+      Map.of("added-a", 1L, "added-b", 1L, "changed-x", 2L, "changed-y", 2L)
+    );
+
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, 12);
+    assertThat(r.getStatus()).isEqualTo(200);
+
+    SnapshotDiffIO body = (SnapshotDiffIO) r.getEntity();
+    assertThat(body.truncated()).isFalse();
+    assertThat(body.added()).hasSize(2);
+    assertThat(body.removed()).hasSize(2);
+    assertThat(body.changed()).hasSize(2);
+    assertThat(body.totalAdded()).isEqualTo(2);
+    assertThat(body.totalRemoved()).isEqualTo(2);
+    assertThat(body.totalChanged()).isEqualTo(2);
+  }
+
+  @Test
+  void diff_capsOnlySingleListWhenOnlyThatListExceedsCap() {
+    // Only the added list is large (5 entries); maxItems=3 → perListCap=1.
+    // Only added is capped; removed and changed are empty so not truncated themselves.
+    Map<String, Long> mapB = new HashMap<>();
+    for (int i = 0; i < 5; i++) {
+      mapB.put("added-" + i, 1L);
+    }
+    when(snapshotService.getEntryRevisionMap(SNAP_A_OGM_ID)).thenReturn(Map.of());
+    when(snapshotService.getEntryRevisionMap(SNAP_B_OGM_ID)).thenReturn(mapB);
+
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, 3);
+    assertThat(r.getStatus()).isEqualTo(200);
+
+    SnapshotDiffIO body = (SnapshotDiffIO) r.getEntity();
+    assertThat(body.truncated()).isTrue();
+    assertThat(body.added()).hasSize(1); // perListCap = ceil(3/3) = 1
+    assertThat(body.removed()).isEmpty();
+    assertThat(body.changed()).isEmpty();
+    assertThat(body.totalAdded()).isEqualTo(5);
+    assertThat(body.totalRemoved()).isZero();
+    assertThat(body.totalChanged()).isZero();
+  }
+
+  @Test
+  void diff_defaultMaxItems_doesNotTruncateSmallDiff() {
+    // Default maxItems = 5000; a 3-entry diff (1+1+1) must not truncate.
+    when(snapshotService.getEntryRevisionMap(SNAP_A_OGM_ID)).thenReturn(
+      Map.of("e-removed", 1L, "e-changed", 1L)
+    );
+    when(snapshotService.getEntryRevisionMap(SNAP_B_OGM_ID)).thenReturn(
+      Map.of("e-added", 1L, "e-changed", 2L)
+    );
+
+    Response r = diffRest.diff(SNAP_A_APP_ID, SNAP_B_APP_ID, sc, SnapshotDiffRest.DEFAULT_MAX_ITEMS);
+    assertThat(r.getStatus()).isEqualTo(200);
+
+    SnapshotDiffIO body = (SnapshotDiffIO) r.getEntity();
+    assertThat(body.truncated()).isFalse();
+    assertThat(body.totalAdded()).isEqualTo(body.added().size());
+    assertThat(body.totalRemoved()).isEqualTo(body.removed().size());
+    assertThat(body.totalChanged()).isEqualTo(body.changed().size());
   }
 }


### PR DESCRIPTION
## Summary

- `GET /v2/snapshots/{aAppId}/diff/{bAppId}` previously returned unbounded `added`/`removed`/`changed` lists. For a 50k-entity collection with all entities changed between snapshots, the `changed` list alone serialised ~2.6 MB per call.
- Add `@QueryParam("maxItems") @DefaultValue("5000") @Min(1) @Max(20000) int maxItems` to `SnapshotDiffRest.diff()`. Each of the three lists is capped at `ceil(maxItems/3)` entries (lists are sorted before capping, so returned items are always the first N alphabetically).
- Add `totalAdded`, `totalRemoved`, `totalChanged`, `truncated` fields to `SnapshotDiffIO` so callers always know the full diff scope. The total fields are accurate even when `truncated=true`.
- Update `SnapshotMcpTools` to pass the four new fields (MCP returns the full uncapped diff with `truncated=false`).
- 4 new regression tests covering: all-lists-capped, no-truncation-fits, single-list-capped, default-5000-does-not-truncate-small-diff.

## Test plan

- [ ] `mvn test -Dtest=SnapshotDiffRestTest` → 14/14 green (verified locally)
- [ ] CI full backend verify green
- [ ] `?maxItems=100` with a 200-entry diff → `truncated: true`, each list ≤ 34 entries, `totalAdded`/`totalRemoved`/`totalChanged` reflect full counts
- [ ] `?maxItems=20001` → 400 (JSR-380 `@Max(20000)`)
- [ ] Default call (no `?maxItems`) with a 3-entry diff → `truncated: false`

Fixes: `APISIMP-SNAPSHOT-DIFF-UNCAPPED` (fire-373 sweep, `aidocs/agent-findings/apisimp-sweep-fire373-2026-07-02.md §F1`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TCM5WRXVZWMGMDd4K1oA6w)_