### PR TITLE
fix(APISIMP-INDEPENDENCE-PROOF-INPUT-CAP): cap setA/setB at 500 elements each

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/quality/io/IndependenceProofRequestIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/quality/io/IndependenceProofRequestIO.java
@@ -1,5 +1,7 @@
 package de.dlr.shepard.v2.quality.io;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,20 +19,27 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
  *
  * <p>Either set may contain DataObjects from different Collections; the caller
  * is responsible for ensuring the appIds are valid and accessible.
+ *
+ * <p>Both sets are capped at 500 elements. Larger sets drive unbounded
+ * 10-hop Neo4j ancestor-walks and should be batched by the caller.
  */
 @Data
 @NoArgsConstructor
 @Schema(description = "Two sets of DataObject appIds to check for independence.")
 public class IndependenceProofRequestIO {
 
+  @NotNull
+  @Size(min = 1, max = 500, message = "setA must contain 1–500 elements")
   @Schema(
-    description = "AppIds of DataObjects in set A (e.g. training set). Must contain at least 1 element.",
+    description = "AppIds of DataObjects in set A (e.g. training set). 1–500 elements.",
     example = "[\"01907a2b-0000-7000-8000-000000000001\"]"
   )
   private List<String> setA;
 
+  @NotNull
+  @Size(min = 1, max = 500, message = "setB must contain 1–500 elements")
   @Schema(
-    description = "AppIds of DataObjects in set B (e.g. test set). Must contain at least 1 element.",
+    description = "AppIds of DataObjects in set B (e.g. test set). 1–500 elements.",
     example = "[\"01907a2b-0000-7000-8000-000000000002\"]"
   )
   private List<String> setB;

--- a/backend/src/main/java/de/dlr/shepard/v2/quality/resources/IndependenceProofRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/quality/resources/IndependenceProofRest.java
@@ -7,6 +7,7 @@ import de.dlr.shepard.v2.quality.services.IndependenceProofService;
 import io.quarkus.security.Authenticated;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -88,9 +89,9 @@ public class IndependenceProofRest {
     description = "Check completed. Inspect `independent` and the two lists for details.",
     content = @Content(schema = @Schema(implementation = IndependenceProofResultIO.class))
   )
-  @APIResponse(responseCode = "400", description = "Request body missing or setA/setB is null/empty.")
+  @APIResponse(responseCode = "400", description = "Request body missing, setA/setB is null/empty, or either set exceeds 500 elements.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
-  public Response check(IndependenceProofRequestIO body) {
+  public Response check(@Valid IndependenceProofRequestIO body) {
     if (body == null) {
       return problem(PROBLEM_TYPE_BAD_REQUEST, "Missing request body",
         Response.Status.BAD_REQUEST, "Request body is required.");

--- a/backend/src/test/java/de/dlr/shepard/v2/quality/io/IndependenceProofRequestIOTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/quality/io/IndependenceProofRequestIOTest.java
@@ -1,0 +1,114 @@
+package de.dlr.shepard.v2.quality.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * APISIMP-INDEPENDENCE-PROOF-INPUT-CAP — validates that the {@code @Size(min=1, max=500)}
+ * and {@code @NotNull} constraints on {@code IndependenceProofRequestIO.setA/setB} are
+ * correctly declared and enforced by the JSR-380 validator.
+ */
+class IndependenceProofRequestIOTest {
+
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  // ── happy path ────────────────────────────────────────────────────────────
+
+  @Test
+  void valid_withOneElementEach() {
+    IndependenceProofRequestIO req = new IndependenceProofRequestIO();
+    req.setSetA(List.of("appid-a1"));
+    req.setSetB(List.of("appid-b1"));
+    assertThat(validator.validate(req)).isEmpty();
+  }
+
+  @Test
+  void valid_withExactly500Elements() {
+    IndependenceProofRequestIO req = new IndependenceProofRequestIO();
+    req.setSetA(ids("a", 500));
+    req.setSetB(ids("b", 500));
+    assertThat(validator.validate(req)).isEmpty();
+  }
+
+  // ── setA violations ───────────────────────────────────────────────────────
+
+  @Test
+  void invalid_whenSetAIsNull() {
+    IndependenceProofRequestIO req = new IndependenceProofRequestIO();
+    req.setSetA(null);
+    req.setSetB(List.of("appid-b1"));
+    assertThat(violatedPaths(validator.validate(req))).contains("setA");
+  }
+
+  @Test
+  void invalid_whenSetAIsEmpty() {
+    IndependenceProofRequestIO req = new IndependenceProofRequestIO();
+    req.setSetA(List.of());
+    req.setSetB(List.of("appid-b1"));
+    assertThat(violatedPaths(validator.validate(req))).contains("setA");
+  }
+
+  @Test
+  void invalid_whenSetAExceeds500() {
+    IndependenceProofRequestIO req = new IndependenceProofRequestIO();
+    req.setSetA(ids("a", 501));
+    req.setSetB(List.of("appid-b1"));
+    assertThat(violatedPaths(validator.validate(req))).contains("setA");
+  }
+
+  // ── setB violations ───────────────────────────────────────────────────────
+
+  @Test
+  void invalid_whenSetBIsNull() {
+    IndependenceProofRequestIO req = new IndependenceProofRequestIO();
+    req.setSetA(List.of("appid-a1"));
+    req.setSetB(null);
+    assertThat(violatedPaths(validator.validate(req))).contains("setB");
+  }
+
+  @Test
+  void invalid_whenSetBIsEmpty() {
+    IndependenceProofRequestIO req = new IndependenceProofRequestIO();
+    req.setSetA(List.of("appid-a1"));
+    req.setSetB(List.of());
+    assertThat(violatedPaths(validator.validate(req))).contains("setB");
+  }
+
+  @Test
+  void invalid_whenSetBExceeds500() {
+    IndependenceProofRequestIO req = new IndependenceProofRequestIO();
+    req.setSetA(List.of("appid-a1"));
+    req.setSetB(ids("b", 501));
+    assertThat(violatedPaths(validator.validate(req))).contains("setB");
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private static List<String> ids(String prefix, int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> "appid-" + prefix + i)
+        .collect(Collectors.toList());
+  }
+
+  private static Set<String> violatedPaths(Set<ConstraintViolation<IndependenceProofRequestIO>> violations) {
+    return violations.stream()
+        .map(v -> v.getPropertyPath().toString())
+        .collect(Collectors.toSet());
+  }
+}


### PR DESCRIPTION
## Summary

`POST /v2/quality/independence-proof` accepted unbounded `setA` / `setB` lists in `IndependenceProofRequestIO`. The service runs **3 expensive Neo4j operations** over the full input verbatim:

1. `SHARED_ANCESTORS` Cypher — 10-hop `has_successor` ancestor-walk from every appId in **both** sets simultaneously
2. `fetchAttributeMaps(setA)` — full `MATCH (do:DataObject) WHERE do.appId IN $appIds` over setA
3. `fetchAttributeMaps(setB)` — same for setB

A caller providing 5 000 appIds per set drives tens of thousands of Neo4j traversal threads in a single synchronous request.

## Changes

**`IndependenceProofRequestIO`** — add JSR-380 constraints to both list fields:
```java
@NotNull
@Size(min = 1, max = 500, message = "setA must contain 1–500 elements")
private List<String> setA;

@NotNull
@Size(min = 1, max = 500, message = "setB must contain 1–500 elements")
private List<String> setB;
```

**`IndependenceProofRest`** — add `@Valid` to the `@POST` body parameter so Quarkus/RESTEasy returns RFC 7807 400 automatically on constraint violation. Updated `@APIResponse(responseCode = "400")` description to mention the cap.

**`IndependenceProofRequestIOTest`** — 8 new unit tests covering: null setA, empty setA, 501-element setA, null setB, empty setB, 501-element setB, exactly-500 elements (valid), single-element each (valid).

## Acceptance criteria

- ✅ Body with 501 elements in either set → 400 RFC 7807
- ✅ Body with 500 elements in each set → 200
- ✅ `mvn test -DnoPlugins -DbootstrapTestjar -Dtest="IndependenceProofRequestIOTest,IndependenceProofServiceTest"` → 14 tests, 0 failures

Backlog row: `APISIMP-INDEPENDENCE-PROOF-INPUT-CAP` (`aidocs/16`)
Sweep report: `aidocs/agent-findings/apisimp-sweep-fire376-2026-07-03.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkRoNgGgpeYBDz46CCusFR)_