### PR TITLE
APISIMP-USERGROUP-PATCH-UNCAPPED: cap usernames/permissions arrays at 500 in UserGroupV2Rest

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserGroupV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserGroupV2Rest.java
@@ -67,6 +67,9 @@ public class UserGroupV2Rest {
   @Inject
   UserGroupService service;
 
+  private static final String PT_BAD_REQUEST = "/problems/user-groups.bad-request";
+  private static final int MAX_MEMBERS = 500;
+
   private static Response problem(String type, String title, Response.Status status, String detail) {
     ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
     return Response.status(status).type("application/problem+json").entity(body).build();
@@ -160,12 +163,16 @@ public class UserGroupV2Rest {
   @Parameter(name = "appId", description = "UUID v7 application identifier.")
   public Response patchUserGroup(@PathParam("appId") String appId, JsonNode body) {
     if (body == null || body.isNull()) {
-      return problem("/problems/user-groups.bad-request", "Bad Request", Response.Status.BAD_REQUEST,
+      return problem(PT_BAD_REQUEST, "Bad Request", Response.Status.BAD_REQUEST,
           "patch body must not be null");
     }
     String newName = body.has("name") ? body.get("name").textValue() : null;
     List<String> newUsernames = null;
     if (body.has("usernames") && body.get("usernames").isArray()) {
+      if (body.get("usernames").size() > MAX_MEMBERS) {
+        return problem(PT_BAD_REQUEST, "Too many members", Response.Status.BAD_REQUEST,
+            "usernames list may not exceed " + MAX_MEMBERS + " elements; got " + body.get("usernames").size());
+      }
       newUsernames = StreamSupport.stream(body.get("usernames").spliterator(), false)
         .map(JsonNode::textValue)
         .toList();
@@ -255,7 +262,7 @@ public class UserGroupV2Rest {
     @RequestBody(required = true, content = @Content(mediaType = "application/merge-patch+json")) JsonNode body
   ) {
     if (body == null || !body.isObject()) {
-      return problem("/problems/user-groups.bad-request", "Bad Request", Response.Status.BAD_REQUEST,
+      return problem(PT_BAD_REQUEST, "Bad Request", Response.Status.BAD_REQUEST,
           "PATCH body must be a JSON object");
     }
     var group = service.getUserGroupByAppId(appId);
@@ -268,18 +275,38 @@ public class UserGroupV2Rest {
       current.setOwner(ownerStr);
     }
     if (patch.containsKey("reader") && patch.get("reader") instanceof java.util.List<?> readerList) {
+      if (readerList.size() > MAX_MEMBERS) {
+        return problem(PT_BAD_REQUEST, "Too many readers", Response.Status.BAD_REQUEST,
+            "reader list may not exceed " + MAX_MEMBERS + " elements");
+      }
       current.setReader(readerList.stream().map(Object::toString).toArray(String[]::new));
     }
     if (patch.containsKey("writer") && patch.get("writer") instanceof java.util.List<?> writerList) {
+      if (writerList.size() > MAX_MEMBERS) {
+        return problem(PT_BAD_REQUEST, "Too many writers", Response.Status.BAD_REQUEST,
+            "writer list may not exceed " + MAX_MEMBERS + " elements");
+      }
       current.setWriter(writerList.stream().map(Object::toString).toArray(String[]::new));
     }
     if (patch.containsKey("manager") && patch.get("manager") instanceof java.util.List<?> managerList) {
+      if (managerList.size() > MAX_MEMBERS) {
+        return problem(PT_BAD_REQUEST, "Too many managers", Response.Status.BAD_REQUEST,
+            "manager list may not exceed " + MAX_MEMBERS + " elements");
+      }
       current.setManager(managerList.stream().map(Object::toString).toArray(String[]::new));
     }
     if (patch.containsKey("readerGroupIds") && patch.get("readerGroupIds") instanceof java.util.List<?> rgl) {
+      if (rgl.size() > MAX_MEMBERS) {
+        return problem(PT_BAD_REQUEST, "Too many reader groups", Response.Status.BAD_REQUEST,
+            "readerGroupIds list may not exceed " + MAX_MEMBERS + " elements");
+      }
       current.setReaderGroupIds(rgl.stream().mapToLong(v -> Long.parseLong(v.toString())).toArray());
     }
     if (patch.containsKey("writerGroupIds") && patch.get("writerGroupIds") instanceof java.util.List<?> wgl) {
+      if (wgl.size() > MAX_MEMBERS) {
+        return problem(PT_BAD_REQUEST, "Too many writer groups", Response.Status.BAD_REQUEST,
+            "writerGroupIds list may not exceed " + MAX_MEMBERS + " elements");
+      }
       current.setWriterGroupIds(wgl.stream().mapToLong(v -> Long.parseLong(v.toString())).toArray());
     }
     var updated = service.updateUserGroupPermissions(current, group.getId());

--- a/backend/src/test/java/de/dlr/shepard/v2/users/resources/UserGroupV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/users/resources/UserGroupV2RestTest.java
@@ -213,6 +213,26 @@ class UserGroupV2RestTest {
     assertEquals(400, r.getStatus());
   }
 
+  @Test
+  void patchUserGroup_usernamesAt501_returns400() {
+    ObjectNode patch = MAPPER.createObjectNode();
+    var arr = patch.putArray("usernames");
+    for (int i = 0; i <= 500; i++) arr.add("user-" + i); // 501 elements
+    Response r = resource.patchUserGroup(APP_ID, patch);
+    assertEquals(400, r.getStatus());
+  }
+
+  @Test
+  void patchUserGroup_usernamesAt500_returns200() {
+    when(service.patchUserGroupByAppId(eq(APP_ID), isNull(), any()))
+      .thenReturn(stubGroup(APP_ID, GROUP_NAME));
+    ObjectNode patch = MAPPER.createObjectNode();
+    var arr = patch.putArray("usernames");
+    for (int i = 0; i < 500; i++) arr.add("user-" + i); // exactly 500 — allowed
+    Response r = resource.patchUserGroup(APP_ID, patch);
+    assertEquals(200, r.getStatus());
+  }
+
   // ── DELETE /v2/user-groups/{appId} ───────────────────────────────────
 
   @Test
@@ -318,6 +338,44 @@ class UserGroupV2RestTest {
     } catch (InvalidPathException e) {
       assertNotNull(e);
     }
+  }
+
+  // ── APISIMP-USERGROUP-PATCH-UNCAPPED — size guard tests ─────────────────
+
+  @Test
+  void patchPermissions_oversizedReader_returns400() {
+    var group = stubGroup(APP_ID, GROUP_NAME, 42L);
+    when(service.getUserGroupByAppId(APP_ID)).thenReturn(group);
+    when(service.getUserGroupPermissions(42L)).thenReturn(stubPermissions());
+    ObjectNode patch = MAPPER.createObjectNode();
+    var arr = patch.putArray("reader");
+    for (int i = 0; i <= 500; i++) arr.add("user-" + i); // 501 elements
+    Response r = resource.patchUserGroupPermissions(APP_ID, patch);
+    assertEquals(400, r.getStatus());
+  }
+
+  @Test
+  void patchPermissions_oversizedWriter_returns400() {
+    var group = stubGroup(APP_ID, GROUP_NAME, 42L);
+    when(service.getUserGroupByAppId(APP_ID)).thenReturn(group);
+    when(service.getUserGroupPermissions(42L)).thenReturn(stubPermissions());
+    ObjectNode patch = MAPPER.createObjectNode();
+    var arr = patch.putArray("writer");
+    for (int i = 0; i <= 500; i++) arr.add("user-" + i); // 501 elements
+    Response r = resource.patchUserGroupPermissions(APP_ID, patch);
+    assertEquals(400, r.getStatus());
+  }
+
+  @Test
+  void patchPermissions_oversizedManager_returns400() {
+    var group = stubGroup(APP_ID, GROUP_NAME, 42L);
+    when(service.getUserGroupByAppId(APP_ID)).thenReturn(group);
+    when(service.getUserGroupPermissions(42L)).thenReturn(stubPermissions());
+    ObjectNode patch = MAPPER.createObjectNode();
+    var arr = patch.putArray("manager");
+    for (int i = 0; i <= 500; i++) arr.add("user-" + i); // 501 elements
+    Response r = resource.patchUserGroupPermissions(APP_ID, patch);
+    assertEquals(400, r.getStatus());
   }
 
   // ── APISIMP-USERGROUP-ORDERBY — reflection regression tests ─────────────


### PR DESCRIPTION
## Summary

Both `PATCH /v2/user-groups/{appId}` and `PATCH /v2/user-groups/{appId}/permissions`
previously accepted unbounded array inputs with no server-side cap — an attacker or
misconfigured client could submit a list with tens of thousands of entries, causing
oversized Neo4j writes and downstream memory pressure.

**Changes:**
- Add `MAX_MEMBERS = 500` constant and `PT_BAD_REQUEST` problem-type constant in `UserGroupV2Rest`
- `patchUserGroup`: returns `400 application/problem+json` when `usernames` array exceeds 500
- `patchUserGroupPermissions`: same guard on `reader`, `writer`, `manager`, `readerGroupIds`, `writerGroupIds`
- 5 new unit tests (28 total in `UserGroupV2RestTest`); all green locally

**Backlog row:** `APISIMP-USERGROUP-PATCH-UNCAPPED` (added to `aidocs/16`). Also marks two already-shipped rows as done: `APISIMP-INDEPENDENCE-PROOF-INPUT-CAP` (commit `dd332dec3`) and `APISIMP-CROSS-TIMELINE-UNCAPPED-COLLECTIONS` (PR #2252).

## What changed

| File | Change |
|------|--------|
| `UserGroupV2Rest.java` | Add `MAX_MEMBERS=500` cap + `problem()` helper; guard `usernames`, `reader`, `writer`, `manager`, `readerGroupIds`, `writerGroupIds` |
| `UserGroupV2RestTest.java` | 5 new tests: 501-element reject + 500-element accept for `usernames`; 501-element reject for `reader`/`writer`/`manager` |
| `aidocs/16-dispatcher-backlog.md` | Mark `APISIMP-INDEPENDENCE-PROOF-INPUT-CAP` + `APISIMP-CROSS-TIMELINE-UNCAPPED-COLLECTIONS` shipped; add `APISIMP-USERGROUP-PATCH-UNCAPPED` row |

## Test plan

- [x] `UserGroupV2RestTest` — 28 tests, 0 failures (runs fully offline, no DB needed)
- [x] `IndependenceProofRequestIOTest` — 8 tests, 0 failures (pre-existing)
- [x] No v1 `/shepard/api/` paths touched
- [x] No numeric Neo4j ids on the wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hgGk2KDiMVnYbsRdAj669

---
_Generated by [Claude Code](https://claude.ai/code/session_017hgGk2KDiMVnYbsRdAj669)_