### PR TITLE
APISIMP-AAS-GET-SHELL-UNCAPPED: cap getShell() inline submodels at 500

### DIFF
--- a/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java
+++ b/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java
@@ -52,6 +52,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Tag(name = "AAS")
 public class AasShellsRest {
 
+  static final int SHELL_MAX_SUBMODELS = 500;
+
   @Inject
   AasConfigService aasConfigService;
 
@@ -128,7 +130,11 @@ public class AasShellsRest {
           "(`urn:shepard:collection:{appId}`) per IDTA-01002-3-2 §4.3, or " +
           "(b) the bare shepard Collection appId. " +
           "Returns 404 when the Shell does not exist or the caller lacks read access " +
-          "(404-on-no-read discipline — not 403). See `aidocs/integrations/52-aas-backend-integration.md §7`.")
+          "(404-on-no-read discipline — not 403). " +
+          "Inline submodel references are capped at " + SHELL_MAX_SUBMODELS + "; " +
+          "when the Collection has more top-level DataObjects the response carries " +
+          "`X-Shepard-Truncated: true` and `X-Shepard-Truncated-At: " + SHELL_MAX_SUBMODELS + "`. " +
+          "See `aidocs/integrations/52-aas-backend-integration.md §7`.")
   @APIResponse(
       responseCode = "200",
       description = "Shell for the requested Collection.",
@@ -149,7 +155,14 @@ public class AasShellsRest {
       return problem(Response.Status.NOT_FOUND, "AAS Shell not found");
     }
     List<DataObject> dataObjects = dataObjectDAO.findTopLevelByCollectionAppId(appId);
-    return Response.ok(mappingService.toShell(collection, dataObjects)).build();
+    boolean truncated = dataObjects.size() > SHELL_MAX_SUBMODELS;
+    List<DataObject> capped = truncated ? dataObjects.subList(0, SHELL_MAX_SUBMODELS) : dataObjects;
+    Response.ResponseBuilder rb = Response.ok(mappingService.toShell(collection, capped));
+    if (truncated) {
+      rb.header("X-Shepard-Truncated", "true")
+        .header("X-Shepard-Truncated-At", SHELL_MAX_SUBMODELS);
+    }
+    return rb.build();
   }
 
   @GET

--- a/plugins/aas/src/test/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRestTest.java
+++ b/plugins/aas/src/test/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRestTest.java
@@ -394,6 +394,51 @@ class AasShellsRestTest {
     assertEquals(2, body.pageSize());
   }
 
+  // --- APISIMP-AAS-GET-SHELL-UNCAPPED: SHELL_MAX_SUBMODELS cap ---
+
+  @Test
+  void getShellCapsTruncatesAt500WhenCollectionHas501DataObjects() {
+    Collection c = makeCollection("big-col", "Big");
+    // Build 501 mock DataObjects
+    List<DataObject> bigList = new java.util.ArrayList<>();
+    for (int i = 0; i < AasShellsRest.SHELL_MAX_SUBMODELS + 1; i++) {
+      bigList.add(org.mockito.Mockito.mock(DataObject.class));
+    }
+    AasShellIO shell = makeShell("big-col");
+    when(collectionDAO.findByAppId(eq("big-col"), any())).thenReturn(c);
+    when(dataObjectDAO.findTopLevelByCollectionAppId(eq("big-col"))).thenReturn(bigList);
+    // Expect toShell to be called with exactly SHELL_MAX_SUBMODELS elements
+    when(mappingService.toShell(eq(c), eq(bigList.subList(0, AasShellsRest.SHELL_MAX_SUBMODELS))))
+        .thenReturn(shell);
+
+    var r = resource.getShell("big-col");
+
+    assertEquals(200, r.getStatus());
+    assertEquals("true", r.getHeaderString("X-Shepard-Truncated"));
+    assertEquals(String.valueOf(AasShellsRest.SHELL_MAX_SUBMODELS),
+        r.getHeaderString("X-Shepard-Truncated-At"));
+  }
+
+  @Test
+  void getShellNoTruncationHeaderWhenAt500DataObjects() {
+    Collection c = makeCollection("ok-col", "Ok");
+    List<DataObject> list = new java.util.ArrayList<>();
+    for (int i = 0; i < AasShellsRest.SHELL_MAX_SUBMODELS; i++) {
+      list.add(org.mockito.Mockito.mock(DataObject.class));
+    }
+    AasShellIO shell = makeShell("ok-col");
+    when(collectionDAO.findByAppId(eq("ok-col"), any())).thenReturn(c);
+    when(dataObjectDAO.findTopLevelByCollectionAppId(eq("ok-col"))).thenReturn(list);
+    when(mappingService.toShell(eq(c), eq(list))).thenReturn(shell);
+
+    var r = resource.getShell("ok-col");
+
+    assertEquals(200, r.getStatus());
+    assertTrue(r.getHeaderString("X-Shepard-Truncated") == null
+        || !r.getHeaderString("X-Shepard-Truncated").equals("true"),
+        "No truncation header when exactly at cap");
+  }
+
   // --- aasDisabledResponse (APISIMP-AAS-SHELLS-DISABLED-ENVELOPE) ---
 
   @Test


### PR DESCRIPTION
## Summary

`GET /v2/aas/shells/{aasId}` previously called `findTopLevelByCollectionAppId(appId)`
with no cap, embedding the entire DataObject list as inline submodel references in the
Shell body. A Collection with 10 000 top-level DataObjects produced a 10 000-reference
response body with no guard — effectively a DoS vector.

The sibling `listSubmodels()` endpoint was fixed by `APISIMP-AAS-SUBMODELS-UNBOUNDED`
(fire-281, PR #2147) but `getShell()` was not updated in that same PR.

**Changes:**

| File | Change |
|------|--------|
| `AasShellsRest.java` | Add `SHELL_MAX_SUBMODELS = 500` constant; cap `dataObjects.subList(0, SHELL_MAX_SUBMODELS)` when list exceeds cap; add `X-Shepard-Truncated: true` + `X-Shepard-Truncated-At: 500` response headers when truncation fires |
| `AasShellsRestTest.java` | 2 new tests: 501-DO collection → truncated + headers; 500-DO → 200 with no truncation header |

**Backlog row:** `APISIMP-AAS-GET-SHELL-UNCAPPED` (added to `aidocs/16` in sweep commit `f6b870860`).

## What changed

Before this fix, `getShell()` had:
```java
List<DataObject> dataObjects = dataObjectDAO.findTopLevelByCollectionAppId(appId);
return Response.ok(mappingService.toShell(collection, dataObjects)).build();
```

After:
```java
List<DataObject> dataObjects = dataObjectDAO.findTopLevelByCollectionAppId(appId);
boolean truncated = dataObjects.size() > SHELL_MAX_SUBMODELS;
List<DataObject> capped = truncated ? dataObjects.subList(0, SHELL_MAX_SUBMODELS) : dataObjects;
Response.ResponseBuilder rb = Response.ok(mappingService.toShell(collection, capped));
if (truncated) {
  rb.header("X-Shepard-Truncated", "true")
    .header("X-Shepard-Truncated-At", SHELL_MAX_SUBMODELS);
}
return rb.build();
```

## Test plan

- [x] `AasShellsRestTest` — 2 new tests + 20 existing; all green locally
- [x] No v1 `/shepard/api/` paths touched
- [x] No numeric Neo4j ids on the wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEgRKtJMTnDE4GQk47CD5s

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEgRKtJMTnDE4GQk47CD5s)_