### PR TITLE
feat(apisimp): APISIMP-REF-ANNOTATION-LIST-UNCAPPED — X-Total-Count header on annotation list

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java
@@ -147,7 +147,7 @@ public class ReferenceAnnotationRest {
       "Returns 404 when no reference with that appId exists, or when the reference kind " +
       "does not support annotations. Auth: Read permission on the parent DataObject."
   )
-  @APIResponse(responseCode = "200", description = "Paged array of annotation maps (may be empty).")
+  @APIResponse(responseCode = "200", description = "Paged envelope: items + total + page + pageSize. Header X-Total-Count = total count before paging (kept during deprecation window, APISIMP-PAGINATION-ENVELOPE).")
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Read permission on the parent DataObject.")
   @APIResponse(responseCode = "404", description = "No reference with that appId, or kind does not support annotations.")
@@ -162,7 +162,9 @@ public class ReferenceAnnotationRest {
       int total = rows.size();
       int from = (int) Math.min((long) page * limit, (long) total);
       List<Map<String, Object>> slice = rows.subList(from, (int) Math.min((long) from + limit, (long) total));
-      return Response.ok(new PagedResponseIO<>(slice, total, page, limit)).build();
+      return Response.ok(new PagedResponseIO<>(slice, total, page, limit))
+          .header("X-Total-Count", total)
+          .build();
     });
   }
 

--- a/backend/src/test/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRestTest.java
@@ -114,6 +114,7 @@ class ReferenceAnnotationRestTest {
     assertThat(page.total()).isEqualTo(1);
     assertThat(page.page()).isEqualTo(0);
     assertThat(page.items().get(0).get("label")).isEqualTo("spike");
+    assertThat(r.getHeaders().getFirst("X-Total-Count")).isEqualTo(1);
   }
 
   @Test
@@ -139,6 +140,7 @@ class ReferenceAnnotationRestTest {
     // page=0, limit=2 → first two items, total=3
     var r0 = resource.list(REF_ID, 0, 2, sc);
     assertThat(r0.getStatus()).isEqualTo(200);
+    assertThat(r0.getHeaders().getFirst("X-Total-Count")).isEqualTo(3);
     @SuppressWarnings("unchecked")
     var p0 = (PagedResponseIO<Map<String, Object>>) r0.getEntity();
     assertThat(p0.total()).isEqualTo(3);


### PR DESCRIPTION
## Summary

- Adds `X-Total-Count` response header to `GET /v2/references/{appId}/annotations` (the only missing piece — `page`/`limit` params and slice logic were already wired on the HEAD branch).
- Updates `@APIResponse(responseCode = "200")` description to the standard paged-envelope wording consistent with `/v2/notifications`, `/v2/projects`, `/v2/collections/{id}/lab-journal-entries`, etc.
- Adds two header assertions to `ReferenceAnnotationRestTest` (17 tests total, all green).

## Backlog row closed

`APISIMP-REF-ANNOTATION-LIST-UNCAPPED` (filed fire-379, `aidocs/16-dispatcher-backlog.md`)

## Acceptance criteria

- [x] `GET /v2/references/{appId}/annotations?page=0&limit=50` returns `{items, total, page, pageSize}` envelope with ≤ limit rows
- [x] `X-Total-Count` header present (this commit)
- [x] `mvn -P unit-test -DskipITs verify` green (17/17 `ReferenceAnnotationRestTest`)

## Files changed

| File | Change |
|------|--------|
| `backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java` | Add `.header("X-Total-Count", total)` to `list()` response; update `@APIResponse` description |
| `backend/src/test/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRestTest.java` | Add `X-Total-Count` header assertions to two existing tests |

## Context

Dispatched by fire-379 APISIMP sweep. The sweep also filed `APISIMP-CONTAINER-CHANNEL-ANNOTATIONS-UNCAPPED` and `APISIMP-CONTAINER-TEMPORAL-ANNOTATIONS-UNCAPPED` as follow-on XS rows for the next fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyGYZQoUPRo1crmAXRzi2X

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyGYZQoUPRo1crmAXRzi2X)_