### PR TITLE
feat(apisimp): APISIMP-PAGINATION-ANNOTATION-GAP-P2 — add @PositiveOrZero/@Min(1) to page/pageSize params

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java
@@ -25,6 +25,8 @@ import io.quarkus.security.Authenticated;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -173,9 +175,9 @@ public class SemanticAnnotationV2Rest {
       + "vocabulary are returned.")
     @QueryParam("vocabId") String vocabId,
     @Parameter(description = "Zero-based page index (default 0).")
-    @QueryParam("page") @DefaultValue("0") int page,
+    @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
     @Parameter(description = "Page size — number of annotations per page (default 50, range 1–200).")
-    @QueryParam("pageSize") @DefaultValue("50") @Max(200) int pageSize,
+    @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize,
     @Context SecurityContext sc
   ) {
     String caller = callerName(sc);
@@ -231,9 +233,9 @@ public class SemanticAnnotationV2Rest {
       + "Optional — omit to search across all vocabularies.")
     @QueryParam("vocabId") String vocabId,
     @Parameter(description = "Zero-based page index (default 0).")
-    @QueryParam("page") @DefaultValue("0") int page,
+    @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
     @Parameter(description = "Page size — number of annotations per page (default 50, range 1–200).")
-    @QueryParam("pageSize") @DefaultValue("50") @Max(200) int pageSize,
+    @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize,
     @Context SecurityContext sc
   ) {
     String caller = callerName(sc);

--- a/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferencesV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferencesV2Rest.java
@@ -12,6 +12,9 @@ import de.dlr.shepard.v2.references.services.ReferencesV2Service;
 import de.dlr.shepard.v2.references.util.JsonNodeMaps;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -466,9 +469,9 @@ public class ReferencesV2Rest {
     @Parameter(name = "fileKind", description = "Optional sub-type filter; only meaningful when kind=file. Narrows results to FileReferences whose fileKind matches (e.g. \"urdf\", \"hdf5\"). Ignored for all other kinds.")
     @QueryParam("fileKind") String fileKind,
     @Parameter(name = "page", description = "Zero-based page index. Defaults to 0. Returns 400 when negative.")
-    @QueryParam("page") @jakarta.ws.rs.DefaultValue("0") int page,
+    @QueryParam("page") @jakarta.ws.rs.DefaultValue("0") @PositiveOrZero int page,
     @Parameter(name = "pageSize", description = "Maximum items per page. Range [1, 200]. Defaults to 50.")
-    @QueryParam("pageSize") @jakarta.ws.rs.DefaultValue("50") int pageSize,
+    @QueryParam("pageSize") @jakarta.ws.rs.DefaultValue("50") @Min(1) @Max(200) int pageSize,
     @Context SecurityContext sc
   ) {
     String caller = callerOrNull(sc);


### PR DESCRIPTION
## Summary

`SemanticAnnotationV2Rest` (list + search methods) and `ReferencesV2Rest` (list method) accepted `page`/`pageSize` via manual `if`-guards only — no JSR-380 bean-validation annotations. This leaves the OpenAPI spec without machine-readable constraint hints and bypasses the JAX-RS validation interceptor layer used by every other paginated v2 endpoint.

**Changed files:**
- `backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java`
  — added `@PositiveOrZero` to `page` on both `list()` and `search()` methods; added `@Min(1)` to `pageSize` on both (which already had `@Max(200)`); added `jakarta.validation.constraints.{Min,PositiveOrZero}` imports.
- `backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferencesV2Rest.java`
  — added `@PositiveOrZero` to `page`; added `@Min(1) @Max(200)` to `pageSize`; added `jakarta.validation.constraints.{Max,Min,PositiveOrZero}` imports.

The manual `if`-guards are kept as defence-in-depth (they also serve as the unit-test contract, since Mockito unit tests call the Java method directly and bypass JAX-RS interceptors).

**Wire change:** none — the 400 responses were already produced by the if-guards. The annotations add a second enforcement layer and surface the constraints in the generated OpenAPI spec.

**Tests:** 99 unit tests pass (65 in `SemanticAnnotationV2RestTest`, 34 in `ReferencesV2RestTest`).

Backlog row: `APISIMP-PAGINATION-ANNOTATION-GAP-P2` (fire-382).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGfpiGqAJJfnD6C5D7Busc)_