### PR TITLE
fix(FRONTEND): correct useFetchAllDataObjects arg order in CollectionCrossTrackViewPane

### DIFF
--- a/frontend/components/context/CollectionCrossTrackViewPane.vue
+++ b/frontend/components/context/CollectionCrossTrackViewPane.vue
@@ -71,10 +71,9 @@ const initialError = ref<string | null>(null);
 
 const { series, loading, error, fetchCrossDo } = useCrossDoBulkData();
 
-const collectionAppIdRef = computed(() => props.collectionAppId);
 const { dataObjects: allDataObjects, loading: doLoading } = useFetchAllDataObjects(
+  props.collectionAppId,
   props.collectionId,
-  collectionAppIdRef,
 );
 // doLoading tracks the DO list fetch; the template combines it with `loading`
 // (cross-track fetch) via `fetching || loading`.


### PR DESCRIPTION
## Summary

- `CollectionCrossTrackViewPane.vue` was passing `props.collectionId` (`number`) as the first argument and `collectionAppIdRef` (`Ref<string>`) as the second to `useFetchAllDataObjects`, which is the reverse of the migrated signature `(collectionAppId: string, numericId?: number)` introduced by LINEAGE-V2.
- Fixes the TypeScript build error on `main` that blocked all Dependabot merges.

## Root cause

The LINEAGE-V2 migration (PR #2268) swapped the parameter order but left `CollectionCrossTrackViewPane.vue` with the old call shape. `vue-tsc` reports it as `Argument of type 'number' is not assignable to parameter of type 'string'` at line 76.

## Fix

Pass `props.collectionAppId` (string) as arg 1 and `props.collectionId` (number) as the optional arg 2; remove the now-unnecessary `collectionAppIdRef` computed ref.

## Test plan

- [x] `npx vue-tsc --noEmit -p .nuxt/tsconfig.json` — 0 errors
- [ ] Frontend image build green in CI


---
_Generated by [Claude Code](https://claude.ai/code/session_01QuEyVUeRAKy49bRCq6eKWY)_