### PR TITLE
fix(APISIMP-SEMANTIC-CONTENT-TYPE): emit application/problem+json on RFC 7807 error responses

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
@@ -1076,7 +1076,7 @@ public class DataObjectV2Rest {
     );
     return Response.status(Response.Status.NOT_ACCEPTABLE)
       .entity(body)
-      .type(MediaType.APPLICATION_JSON)
+      .type("application/problem+json")
       .build();
   }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
@@ -635,7 +635,7 @@ public class ProvenanceRest {
     );
     return Response.status(Response.Status.NOT_ACCEPTABLE)
       .entity(body)
-      .type(MediaType.APPLICATION_JSON)
+      .type("application/problem+json")
       .build();
   }
 

--- a/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticPredicateStatsRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticPredicateStatsRest.java
@@ -137,7 +137,7 @@ public class SemanticPredicateStatsRest {
       null
     );
     return Response.status(Status.BAD_REQUEST)
-      .type(MediaType.APPLICATION_JSON)
+      .type("application/problem+json")
       .entity(body)
       .build();
   }

--- a/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticSparqlRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticSparqlRest.java
@@ -477,7 +477,7 @@ public class SemanticSparqlRest {
    */
   static Response problem(Status status, String type, String title, String detail) {
     ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type(MediaType.APPLICATION_JSON).entity(body).build();
+    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   private static String readConfig(String key, String fallback) {

--- a/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticTermSearchRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticTermSearchRest.java
@@ -337,6 +337,6 @@ public class SemanticTermSearchRest {
 
   static Response problem(Status status, String type, String title, String detail) {
     ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type(MediaType.APPLICATION_JSON).entity(body).build();
+    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java
@@ -219,7 +219,7 @@ public class VocabularyBrowseRest {
       null
     );
     return Response.status(Status.NOT_FOUND)
-      .type(MediaType.APPLICATION_JSON)
+      .type("application/problem+json")
       .entity(body)
       .build();
   }

--- a/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestJsonLdTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestJsonLdTest.java
@@ -219,7 +219,7 @@ class ProvenanceRestJsonLdTest {
     );
 
     assertEquals(406, r.getStatus());
-    assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+    assertEquals("application/problem+json", r.getMediaType().toString());
     ProblemJson body = (ProblemJson) r.getEntity();
     assertNotNull(body);
     assertEquals(406, body.status());


### PR DESCRIPTION
## Summary

- **Root cause:** Six local `problem()` helpers in v2 semantic, provenance, and dataobject resources built RFC 7807 error bodies but set `Content-Type: application/json` instead of `application/problem+json`. Clients that Content-Type-sniff to distinguish error envelopes from success bodies would misclassify these.
- **Fix:** Change `.type(MediaType.APPLICATION_JSON)` → `.type("application/problem+json")` in each of the six sites. Zero wire-shape change; zero new imports; annotation-only.
- **Files fixed:** `SemanticSparqlRest`, `SemanticTermSearchRest`, `VocabularyBrowseRest`, `SemanticPredicateStatsRest`, `ProvenanceRest` (`enforceJsonLdProfile`), `DataObjectV2Rest` (`enforceJsonLdProfile`).

Closes backlog row **APISIMP-SEMANTIC-CONTENT-TYPE** (filed fire-399 sweep, `aidocs/agent-findings/apisimp-sweep-2026-07-04.md §F3`).

## Checklist

- [x] Backend-only change; no frontend touch
- [x] Zero v1 `/shepard/api/` surface change
- [x] aidocs/16 row updated to 🔄 in-flight
- [x] doc-stage index regenerated

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ddda9y7sEZx2artgaQ9Kyj)_