### PR TITLE
fix(APISIMP-COLLECTION-WATCHERS-IN-MEMORY-PAGING): push SKIP/LIMIT to CollectionWatcherDAO

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/daos/CollectionWatcherDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/daos/CollectionWatcherDAO.java
@@ -31,6 +31,33 @@ public class CollectionWatcherDAO extends GenericDAO<CollectionWatcher> {
     return result;
   }
 
+  /** Bounded page of watcher records — SKIP/LIMIT pushed to Neo4j. */
+  public List<CollectionWatcher> findByCollectionAppId(String collectionAppId, int skip, int limit) {
+    String query =
+      "MATCH (w:CollectionWatcher) " +
+      "WHERE w.collectionAppId = $collectionAppId " +
+      "RETURN w ORDER BY w.since ASC " +
+      "SKIP $skip LIMIT $limit";
+    List<CollectionWatcher> result = new ArrayList<>();
+    for (var w : findByQuery(query, Map.of("collectionAppId", collectionAppId, "skip", skip, "limit", limit))) {
+      result.add(w);
+    }
+    return result;
+  }
+
+  /** Total watcher count for a collection — used for pagination envelope. */
+  public long countByCollectionAppId(String collectionAppId) {
+    String query =
+      "MATCH (w:CollectionWatcher) " +
+      "WHERE w.collectionAppId = $collectionAppId " +
+      "RETURN count(w) AS cnt";
+    var result = session.query(query, Map.of("collectionAppId", collectionAppId));
+    var row = result.iterator();
+    if (!row.hasNext()) return 0L;
+    Object cnt = row.next().get("cnt");
+    return cnt instanceof Number n ? n.longValue() : 0L;
+  }
+
   /** Find the watcher record for a specific (username, collectionAppId) pair. */
   public CollectionWatcher findByUsernameAndCollection(String username, String collectionAppId) {
     String query =

--- a/backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/resources/CollectionWatchersRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/resources/CollectionWatchersRest.java
@@ -25,7 +25,6 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.util.List;
 import java.util.Optional;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
@@ -88,11 +87,10 @@ public class CollectionWatchersRest {
   ) {
     String caller = caller(securityContext);
     if (caller == null) return unauthorized();
-    List<CollectionWatcherIO> all = service.list(collectionAppId, caller);
-    long total = all.size();
-    int from = (int) Math.min((long) page * pageSize, total);
-    int to = (int) Math.min((long) from + pageSize, total);
-    return Response.ok(new PagedResponseIO<>(all.subList(from, to), total, page, pageSize))
+    long total = service.count(collectionAppId, caller);
+    int skip = (int) Math.min((long) page * pageSize, total);
+    List<CollectionWatcherIO> items = service.list(collectionAppId, caller, skip, pageSize);
+    return Response.ok(new PagedResponseIO<>(items, total, page, pageSize))
         .header("X-Total-Count", total)  // kept during deprecation window (APISIMP-PAGINATION-ENVELOPE)
         .build();
   }

--- a/backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/services/CollectionWatcherService.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/services/CollectionWatcherService.java
@@ -55,7 +55,7 @@ public class CollectionWatcherService {
   // ─── Public API ───────────────────────────────────────────────────────────
 
   /**
-   * List all watchers for a collection.
+   * List all watchers for a collection (unbounded — retained for internal/notification use).
    *
    * @param collectionAppId the collection's appId
    * @param caller          authenticated username
@@ -63,6 +63,33 @@ public class CollectionWatcherService {
   public List<CollectionWatcherIO> list(String collectionAppId, String caller) {
     assertCollectionReadable(collectionAppId, caller);
     return dao.findByCollectionAppId(collectionAppId)
+      .stream()
+      .map(CollectionWatcherIO::from)
+      .toList();
+  }
+
+  /**
+   * Count watchers for a collection (for pagination envelope).
+   *
+   * @param collectionAppId the collection's appId
+   * @param caller          authenticated username
+   */
+  public long count(String collectionAppId, String caller) {
+    assertCollectionReadable(collectionAppId, caller);
+    return dao.countByCollectionAppId(collectionAppId);
+  }
+
+  /**
+   * Bounded page of watchers — SKIP/LIMIT pushed to Neo4j.
+   *
+   * @param collectionAppId the collection's appId
+   * @param caller          authenticated username
+   * @param skip            number of rows to skip
+   * @param limit           max rows to return
+   */
+  public List<CollectionWatcherIO> list(String collectionAppId, String caller, int skip, int limit) {
+    assertCollectionReadable(collectionAppId, caller);
+    return dao.findByCollectionAppId(collectionAppId, skip, limit)
       .stream()
       .map(CollectionWatcherIO::from)
       .toList();

--- a/backend/src/test/java/de/dlr/shepard/v2/collectionwatchers/resources/CollectionWatchersRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/collectionwatchers/resources/CollectionWatchersRestTest.java
@@ -2,6 +2,7 @@ package de.dlr.shepard.v2.collectionwatchers.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -10,13 +11,13 @@ import static org.mockito.Mockito.when;
 
 import de.dlr.shepard.v2.common.io.PagedResponseIO;
 import de.dlr.shepard.v2.collectionwatchers.io.CollectionWatcherIO;
-import de.dlr.shepard.v2.collectionwatchers.resources.CollectionWatchersRest;
 import de.dlr.shepard.v2.collectionwatchers.services.CollectionWatcherService;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,13 +57,15 @@ class CollectionWatchersRestTest {
     when(securityContext.getUserPrincipal()).thenReturn(null);
     Response r = resource.list(COLL_APP_ID, 0, 50, securityContext);
     assertEquals(401, r.getStatus());
-    verify(service, never()).list(anyString(), anyString());
+    verify(service, never()).count(anyString(), anyString());
+    verify(service, never()).list(anyString(), anyString(), anyInt(), anyInt());
   }
 
   @Test
   void listReturns200WithWatchers() {
     CollectionWatcherIO io = makeIO("app-1", ALICE, COLL_APP_ID);
-    when(service.list(COLL_APP_ID, ALICE)).thenReturn(List.of(io));
+    when(service.count(COLL_APP_ID, ALICE)).thenReturn(1L);
+    when(service.list(COLL_APP_ID, ALICE, 0, 50)).thenReturn(List.of(io));
 
     Response r = resource.list(COLL_APP_ID, 0, 50, securityContext);
 
@@ -70,25 +73,16 @@ class CollectionWatchersRestTest {
     @SuppressWarnings("unchecked")
     PagedResponseIO<CollectionWatcherIO> body = (PagedResponseIO<CollectionWatcherIO>) r.getEntity();
     assertEquals(1, body.items().size());
-    assertEquals(1L, r.getHeaderString("X-Total-Count") != null
-      ? Long.parseLong(r.getHeaderString("X-Total-Count")) : -1L);
+    assertEquals(1L, Long.parseLong(r.getHeaderString("X-Total-Count")));
   }
 
   @Test
-  void listPropagates403FromService() {
-    when(service.list(eq(COLL_APP_ID), eq(ALICE))).thenThrow(new ForbiddenException());
-    org.junit.jupiter.api.Assertions.assertThrows(ForbiddenException.class,
-      () -> resource.list(COLL_APP_ID, 0, 50, securityContext));
-  }
-
-  @Test
-  void listPaginatesResultsWhenPageSizeProvided() {
-    List<CollectionWatcherIO> all = List.of(
+  void listUsesCountAndBoundedServiceCall() {
+    when(service.count(COLL_APP_ID, ALICE)).thenReturn(3L);
+    when(service.list(COLL_APP_ID, ALICE, 0, 2)).thenReturn(List.of(
       makeIO("app-1", "user1", COLL_APP_ID),
-      makeIO("app-2", "user2", COLL_APP_ID),
-      makeIO("app-3", "user3", COLL_APP_ID)
-    );
-    when(service.list(COLL_APP_ID, ALICE)).thenReturn(all);
+      makeIO("app-2", "user2", COLL_APP_ID)
+    ));
 
     Response r = resource.list(COLL_APP_ID, 0, 2, securityContext);
 
@@ -97,15 +91,34 @@ class CollectionWatchersRestTest {
     PagedResponseIO<CollectionWatcherIO> body = (PagedResponseIO<CollectionWatcherIO>) r.getEntity();
     assertEquals(2, body.items().size());
     assertEquals(3L, Long.parseLong(r.getHeaderString("X-Total-Count")));
+    // Verify the bounded call was made with correct skip+limit (not the unbounded 1-arg variant).
+    verify(service).list(COLL_APP_ID, ALICE, 0, 2);
   }
 
   @Test
-  void listMaxPageSizeReturnsFirstTwoHundred() {
-    List<CollectionWatcherIO> all = new java.util.ArrayList<>();
-    for (int i = 0; i < 250; i++) {
-      all.add(makeIO("app-" + i, "user" + i, COLL_APP_ID));
-    }
-    when(service.list(COLL_APP_ID, ALICE)).thenReturn(all);
+  void listSecondPagePassesCorrectSkip() {
+    // page=1, pageSize=2 → skip=2
+    when(service.count(COLL_APP_ID, ALICE)).thenReturn(3L);
+    when(service.list(COLL_APP_ID, ALICE, 2, 2)).thenReturn(List.of(
+      makeIO("app-3", "user3", COLL_APP_ID)
+    ));
+
+    Response r = resource.list(COLL_APP_ID, 1, 2, securityContext);
+
+    assertEquals(200, r.getStatus());
+    @SuppressWarnings("unchecked")
+    PagedResponseIO<CollectionWatcherIO> body = (PagedResponseIO<CollectionWatcherIO>) r.getEntity();
+    assertEquals(1, body.items().size());
+    assertEquals("app-3", body.items().get(0).watcherAppId());
+    verify(service).list(COLL_APP_ID, ALICE, 2, 2);
+  }
+
+  @Test
+  void listMaxPageSizePassesCorrectBounds() {
+    List<CollectionWatcherIO> items = new ArrayList<>();
+    for (int i = 0; i < 200; i++) items.add(makeIO("app-" + i, "user" + i, COLL_APP_ID));
+    when(service.count(COLL_APP_ID, ALICE)).thenReturn(250L);
+    when(service.list(COLL_APP_ID, ALICE, 0, 200)).thenReturn(items);
 
     Response r = resource.list(COLL_APP_ID, 0, 200, securityContext);
 
@@ -117,32 +130,21 @@ class CollectionWatchersRestTest {
   }
 
   @Test
+  void listPropagates403FromService() {
+    when(service.count(eq(COLL_APP_ID), eq(ALICE))).thenThrow(new ForbiddenException());
+    org.junit.jupiter.api.Assertions.assertThrows(ForbiddenException.class,
+      () -> resource.list(COLL_APP_ID, 0, 50, securityContext));
+  }
+
+  @Test
   void listPageParamsCarryValidationAnnotations() throws NoSuchMethodException {
-    java.lang.reflect.Method m = de.dlr.shepard.v2.collectionwatchers.resources.CollectionWatchersRest.class.getDeclaredMethod(
+    java.lang.reflect.Method m = CollectionWatchersRest.class.getDeclaredMethod(
         "list", String.class, int.class, int.class, jakarta.ws.rs.core.SecurityContext.class);
     java.lang.reflect.Parameter page = m.getParameters()[1];
     java.lang.reflect.Parameter size = m.getParameters()[2];
     assertNotNull(page.getAnnotation(jakarta.validation.constraints.PositiveOrZero.class), "page: @PositiveOrZero");
     assertNotNull(size.getAnnotation(jakarta.validation.constraints.Min.class), "pageSize: @Min");
     assertNotNull(size.getAnnotation(jakarta.validation.constraints.Max.class), "pageSize: @Max");
-  }
-
-  @Test
-  void listReturnsSecondPageCorrectly() {
-    List<CollectionWatcherIO> all = List.of(
-      makeIO("app-1", "user1", COLL_APP_ID),
-      makeIO("app-2", "user2", COLL_APP_ID),
-      makeIO("app-3", "user3", COLL_APP_ID)
-    );
-    when(service.list(COLL_APP_ID, ALICE)).thenReturn(all);
-
-    Response r = resource.list(COLL_APP_ID, 1, 2, securityContext);
-
-    assertEquals(200, r.getStatus());
-    @SuppressWarnings("unchecked")
-    PagedResponseIO<CollectionWatcherIO> body = (PagedResponseIO<CollectionWatcherIO>) r.getEntity();
-    assertEquals(1, body.items().size());
-    assertEquals("app-3", body.items().get(0).watcherAppId());
   }
 
   // ─── GET /watches/me ──────────────────────────────────────────────────────

--- a/backend/src/test/java/de/dlr/shepard/v2/collectionwatchers/services/CollectionWatcherServiceTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/collectionwatchers/services/CollectionWatcherServiceTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -173,7 +173,7 @@ class CollectionWatcherServiceTest {
     assertFalse(result.isPresent());
   }
 
-  // ─── list() ──────────────────────────────────────────────────────────────
+  // ─── list() (unbounded) ───────────────────────────────────────────────────
 
   @Test
   void listReturnsMappedWatchers() {
@@ -197,6 +197,50 @@ class CollectionWatcherServiceTest {
 
     assertThrows(ForbiddenException.class, () -> service.list(COLLECTION_APP_ID, ALICE));
     verify(dao, never()).findByCollectionAppId(anyString());
+  }
+
+  // ─── count() ─────────────────────────────────────────────────────────────
+
+  @Test
+  void countReturnsDaoResult() {
+    when(dao.countByCollectionAppId(COLLECTION_APP_ID)).thenReturn(7L);
+
+    long result = service.count(COLLECTION_APP_ID, ALICE);
+
+    assertEquals(7L, result);
+    verify(dao).countByCollectionAppId(COLLECTION_APP_ID);
+  }
+
+  @Test
+  void countThrowsForbiddenWhenNoReadPermission() {
+    when(permissionsService.isAccessTypeAllowedForUser(eq(COLLECTION_OGM_ID), eq(AccessType.Read), eq(ALICE), anyLong()))
+      .thenReturn(false);
+
+    assertThrows(ForbiddenException.class, () -> service.count(COLLECTION_APP_ID, ALICE));
+    verify(dao, never()).countByCollectionAppId(anyString());
+  }
+
+  // ─── list() (bounded) ─────────────────────────────────────────────────────
+
+  @Test
+  void boundedListCallsDaoWithSkipAndLimit() {
+    List<CollectionWatcher> watchers = List.of(makeWatcher(BOB, COLLECTION_APP_ID, "app-b"));
+    when(dao.findByCollectionAppId(COLLECTION_APP_ID, 10, 5)).thenReturn(watchers);
+
+    List<CollectionWatcherIO> result = service.list(COLLECTION_APP_ID, ALICE, 10, 5);
+
+    assertEquals(1, result.size());
+    assertEquals("app-b", result.get(0).watcherAppId());
+    verify(dao).findByCollectionAppId(COLLECTION_APP_ID, 10, 5);
+  }
+
+  @Test
+  void boundedListThrowsForbiddenWhenNoReadPermission() {
+    when(permissionsService.isAccessTypeAllowedForUser(eq(COLLECTION_OGM_ID), eq(AccessType.Read), eq(ALICE), anyLong()))
+      .thenReturn(false);
+
+    assertThrows(ForbiddenException.class, () -> service.list(COLLECTION_APP_ID, ALICE, 0, 50));
+    verify(dao, never()).findByCollectionAppId(anyString(), anyInt(), anyInt());
   }
 
   // ─── notifyWatchersOfNewDataObject() ─────────────────────────────────────


### PR DESCRIPTION
## Summary

`GET /v2/collections/{collectionAppId}/watches` (CW1) declared `?page=`/`?pageSize=` query params but called `service.list(collectionAppId, caller)` → `dao.findByCollectionAppId(collectionAppId)` — a full `MATCH (w:CollectionWatcher) WHERE w.collectionAppId = $collectionAppId RETURN w ORDER BY w.since ASC` with no `SKIP`/`LIMIT` — then sliced in Java with `subList`. A collection with 10,000 subscribers materialised all 10,000 `CollectionWatcher` nodes before returning page-0's 50 items.

**Changes:**

- `CollectionWatcherDAO`: add `findByCollectionAppId(String, int skip, int limit)` (existing Cypher + `SKIP $skip LIMIT $limit`) and `countByCollectionAppId(String)` (`COUNT(w)` query)
- `CollectionWatcherService`: add `count(String collectionAppId, String caller)` and bounded `list(String, String, int, int)` overloads; unbounded `list(String, String)` retained for internal notification-dispatch use
- `CollectionWatchersRest.list()`: replace Java `subList` with `service.count()` then bounded `service.list()`; remove unused `SchemaType` import
- `CollectionWatchersRestTest`: rewrite list tests to mock `count()` + bounded `list()` — verifies correct `skip` is computed for page 0 and page N; validates `X-Total-Count` header against count not items size
- `CollectionWatcherServiceTest`: add `countReturnsDaoResult`, `countThrowsForbiddenWhenNoReadPermission`, `boundedListCallsDaoWithSkipAndLimit`, `boundedListThrowsForbiddenWhenNoReadPermission`

**Tests:** 32 passing (15 REST + 17 service). No wire-shape change.

**Backlog:** `APISIMP-COLLECTION-WATCHERS-IN-MEMORY-PAGING` — fire-416 sweep finding F1. Filed in `aidocs/16-dispatcher-backlog.md` (commit `3559831`).


---
_Generated by [Claude Code](https://claude.ai/code/session_015K7YHB31jhPeJiwggVEQhG)_