### PR TITLE
fix(APISIMP-AAS-SHELL-DO-LOAD-CAP): cap getShell() DataObject load at DB layer

### DIFF
--- a/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java
+++ b/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java
@@ -154,9 +154,12 @@ public class AasShellsRest {
     if (collection == null) {
       return problem(Response.Status.NOT_FOUND, "AAS Shell not found");
     }
-    List<DataObject> dataObjects = dataObjectDAO.findTopLevelByCollectionAppId(appId);
-    boolean truncated = dataObjects.size() > SHELL_MAX_SUBMODELS;
-    List<DataObject> capped = truncated ? dataObjects.subList(0, SHELL_MAX_SUBMODELS) : dataObjects;
+    // Load at most SHELL_MAX_SUBMODELS+1 rows from the DB so the JVM heap
+    // is bounded regardless of Collection size (APISIMP-AAS-SHELL-DO-LOAD-CAP).
+    List<DataObject> probe = dataObjectDAO.findTopLevelByCollectionAppId(
+        appId, 0, SHELL_MAX_SUBMODELS + 1);
+    boolean truncated = probe.size() > SHELL_MAX_SUBMODELS;
+    List<DataObject> capped = truncated ? probe.subList(0, SHELL_MAX_SUBMODELS) : probe;
     Response.ResponseBuilder rb = Response.ok(mappingService.toShell(collection, capped));
     if (truncated) {
       rb.header("X-Shepard-Truncated", "true")


### PR DESCRIPTION
## Summary

`AasShellsRest.getShell()` (`GET /v2/aas/shells/{aasId}`) was calling
`dataObjectDAO.findTopLevelByCollectionAppId(appId)` — the unbounded variant —
loading every top-level DataObject for the Collection into the JVM heap, then
capping at `SHELL_MAX_SUBMODELS = 500` via in-memory `subList(0, 500)`.

A Collection with 50 000 DataObjects caused 50 000 Neo4j OGM hydrations on every
single `getShell()` call regardless of how many submodels the caller actually needed.

## Fix

Replace the unbounded DAO call with the existing paginated variant, passing
`page=0, pageSize=SHELL_MAX_SUBMODELS+1` so Neo4j returns at most 501 rows:

```java
// BEFORE (in-memory anti-pattern):
List<DataObject> dataObjects = dataObjectDAO.findTopLevelByCollectionAppId(appId);
boolean truncated = dataObjects.size() > SHELL_MAX_SUBMODELS;
List<DataObject> capped = truncated ? dataObjects.subList(0, SHELL_MAX_SUBMODELS) : dataObjects;

// AFTER (DB-side cap):
List<DataObject> probe = dataObjectDAO.findTopLevelByCollectionAppId(
    appId, 0, SHELL_MAX_SUBMODELS + 1);
boolean truncated = probe.size() > SHELL_MAX_SUBMODELS;
List<DataObject> capped = truncated ? probe.subList(0, SHELL_MAX_SUBMODELS) : probe;
```

No new DAO method is needed — `findTopLevelByCollectionAppId(String, int, int)` already
exists and is used by `listSubmodels()`. The `X-Shepard-Truncated` /
`X-Shepard-Truncated-At` header semantics are unchanged.

## Acceptance criteria

- `getShell()` never hydrates more than `SHELL_MAX_SUBMODELS + 1` (`501`) DataObject
  nodes regardless of Collection size.
- `X-Shepard-Truncated: true` / `X-Shepard-Truncated-At: 500` headers fire exactly
  when the Collection has > 500 top-level DataObjects.
- `mvn verify -pl backend` passes (no new tests required — logic change is
  trivial and covered by existing AAS integration tests).

## Backlog row

`APISIMP-AAS-SHELL-DO-LOAD-CAP` in `aidocs/16-dispatcher-backlog.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLV91F9dfm9QoSbad2TT8T)_