### PR TITLE
APISIMP-REFANNOT-IN-MEMORY-PAGING-1: push reference annotation paging to DB

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/references/handlers/TimeseriesReferenceKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/handlers/TimeseriesReferenceKindHandler.java
@@ -214,6 +214,18 @@ public class TimeseriesReferenceKindHandler implements ReferenceKindHandler {
   }
 
   @Override
+  public long countAnnotations(String refAppId) {
+    return tsAnnotationDAO.countByTimeseriesReferenceAppId(refAppId);
+  }
+
+  @Override
+  public List<Map<String, Object>> listAnnotations(String refAppId, int skip, int limit) {
+    return tsAnnotationDAO.findByTimeseriesReferenceAppId(refAppId, skip, limit).stream()
+      .map(TimeseriesReferenceKindHandler::annotationToMap)
+      .toList();
+  }
+
+  @Override
   public Map<String, Object> createAnnotation(String refAppId, Map<String, Object> body) {
     if (body == null || !body.containsKey("startNs") || body.get("startNs") == null) {
       throw new BadRequestException("startNs is required for timeseries annotations");

--- a/backend/src/main/java/de/dlr/shepard/v2/references/handlers/TimeseriesReferenceKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/handlers/TimeseriesReferenceKindHandler.java
@@ -219,7 +219,7 @@ public class TimeseriesReferenceKindHandler implements ReferenceKindHandler {
   }
 
   @Override
-  public List<Map<String, Object>> listAnnotations(String refAppId, int skip, int limit) {
+  public List<Map<String, Object>> listAnnotations(String refAppId, long skip, int limit) {
     return tsAnnotationDAO.findByTimeseriesReferenceAppId(refAppId, skip, limit).stream()
       .map(TimeseriesReferenceKindHandler::annotationToMap)
       .toList();

--- a/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java
@@ -159,7 +159,7 @@ public class ReferenceAnnotationRest {
   ) {
     return gateAndDispatch(appId, AccessType.Read, sc, r -> {
       long total = r.handler().countAnnotations(appId);
-      int skip = page * pageSize;
+      long skip = (long) page * pageSize;
       List<Map<String, Object>> slice = r.handler().listAnnotations(appId, skip, pageSize);
       return Response.ok(new PagedResponseIO<>(slice, total, page, pageSize))
           .header("X-Total-Count", total)

--- a/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java
@@ -158,10 +158,9 @@ public class ReferenceAnnotationRest {
     @Context SecurityContext sc
   ) {
     return gateAndDispatch(appId, AccessType.Read, sc, r -> {
-      List<Map<String, Object>> rows = r.handler().listAnnotations(appId);
-      int total = rows.size();
-      int from = (int) Math.min((long) page * pageSize, (long) total);
-      List<Map<String, Object>> slice = rows.subList(from, (int) Math.min((long) from + pageSize, (long) total));
+      long total = r.handler().countAnnotations(appId);
+      int skip = page * pageSize;
+      List<Map<String, Object>> slice = r.handler().listAnnotations(appId, skip, pageSize);
       return Response.ok(new PagedResponseIO<>(slice, total, page, pageSize))
           .header("X-Total-Count", total)
           .build();

--- a/backend/src/main/java/de/dlr/shepard/v2/references/spi/ReferenceKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/spi/ReferenceKindHandler.java
@@ -266,9 +266,9 @@ public interface ReferenceKindHandler {
    * Default: in-memory subList of {@link #listAnnotations(String)} for handlers that have
    * not yet overridden with a DB-side implementation.
    */
-  default List<Map<String, Object>> listAnnotations(String refAppId, int skip, int limit) {
+  default List<Map<String, Object>> listAnnotations(String refAppId, long skip, int limit) {
     List<Map<String, Object>> all = listAnnotations(refAppId);
-    int from = (int) Math.min((long) skip, (long) all.size());
+    int from = (int) Math.min(skip, (long) all.size());
     int to = (int) Math.min((long) from + limit, (long) all.size());
     return all.subList(from, to);
   }

--- a/backend/src/main/java/de/dlr/shepard/v2/references/spi/ReferenceKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/spi/ReferenceKindHandler.java
@@ -252,6 +252,28 @@ public interface ReferenceKindHandler {
   }
 
   /**
+   * Count annotations on the reference identified by {@code refAppId}.
+   * Handlers that override {@link #listAnnotations(String, int, int)} should also override
+   * this to push the count to the DB rather than loading all rows.
+   * Default: falls back to {@link #listAnnotations(String)}.size() (in-memory).
+   */
+  default long countAnnotations(String refAppId) {
+    return listAnnotations(refAppId).size();
+  }
+
+  /**
+   * List annotations on the reference, paginated. Handlers push SKIP+LIMIT to the store.
+   * Default: in-memory subList of {@link #listAnnotations(String)} for handlers that have
+   * not yet overridden with a DB-side implementation.
+   */
+  default List<Map<String, Object>> listAnnotations(String refAppId, int skip, int limit) {
+    List<Map<String, Object>> all = listAnnotations(refAppId);
+    int from = (int) Math.min((long) skip, (long) all.size());
+    int to = (int) Math.min((long) from + limit, (long) all.size());
+    return all.subList(from, to);
+  }
+
+  /**
    * Create an annotation on the reference {@code refAppId} from {@code body}.
    * The handler validates required fields (e.g. {@code startNs} for timeseries,
    * {@code startSeconds} for video) and throws {@link jakarta.ws.rs.BadRequestException}

--- a/backend/src/main/java/de/dlr/shepard/v2/timeseries/daos/TimeseriesAnnotationDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/timeseries/daos/TimeseriesAnnotationDAO.java
@@ -4,6 +4,7 @@ import de.dlr.shepard.common.neo4j.daos.GenericDAO;
 import de.dlr.shepard.common.util.CypherQueryHelper;
 import de.dlr.shepard.v2.timeseries.model.TimeseriesAnnotation;
 import jakarta.enterprise.context.RequestScoped;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.StreamSupport;
@@ -20,6 +21,32 @@ public class TimeseriesAnnotationDAO extends GenericDAO<TimeseriesAnnotation> {
     return StreamSupport
       .stream(findByQuery(query, Map.of("refAppId", refAppId)).spliterator(), false)
       .toList();
+  }
+
+  public List<TimeseriesAnnotation> findByTimeseriesReferenceAppId(String refAppId, int skip, int limit) {
+    String query =
+      "MATCH (r:TimeseriesReference {appId: $refAppId})-[:has_timeseries_annotation]->" +
+      CypherQueryHelper.getObjectPart("a", "TimeseriesAnnotation", false) +
+      " RETURN a ORDER BY a.appId SKIP $skip LIMIT $limit";
+    Map<String, Object> params = new HashMap<>();
+    params.put("refAppId", refAppId);
+    params.put("skip", (long) skip);
+    params.put("limit", (long) limit);
+    return StreamSupport
+      .stream(findByQuery(query, params).spliterator(), false)
+      .toList();
+  }
+
+  public long countByTimeseriesReferenceAppId(String refAppId) {
+    String query =
+      "MATCH (r:TimeseriesReference {appId: $refAppId})-[:has_timeseries_annotation]->" +
+      CypherQueryHelper.getObjectPart("a", "TimeseriesAnnotation", false) +
+      " RETURN count(a) AS total";
+    for (var row : session.query(query, Map.of("refAppId", refAppId)).queryResults()) {
+      Object val = row.get("total");
+      if (val instanceof Number n) return n.longValue();
+    }
+    return 0L;
   }
 
   public TimeseriesAnnotation findByAppId(String appId) {

--- a/backend/src/main/java/de/dlr/shepard/v2/timeseries/daos/TimeseriesAnnotationDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/timeseries/daos/TimeseriesAnnotationDAO.java
@@ -23,14 +23,14 @@ public class TimeseriesAnnotationDAO extends GenericDAO<TimeseriesAnnotation> {
       .toList();
   }
 
-  public List<TimeseriesAnnotation> findByTimeseriesReferenceAppId(String refAppId, int skip, int limit) {
+  public List<TimeseriesAnnotation> findByTimeseriesReferenceAppId(String refAppId, long skip, int limit) {
     String query =
       "MATCH (r:TimeseriesReference {appId: $refAppId})-[:has_timeseries_annotation]->" +
       CypherQueryHelper.getObjectPart("a", "TimeseriesAnnotation", false) +
       " RETURN a ORDER BY a.appId SKIP $skip LIMIT $limit";
     Map<String, Object> params = new HashMap<>();
     params.put("refAppId", refAppId);
-    params.put("skip", (long) skip);
+    params.put("skip", skip);
     params.put("limit", (long) limit);
     return StreamSupport
       .stream(findByQuery(query, params).spliterator(), false)

--- a/backend/src/test/java/de/dlr/shepard/v2/references/handlers/TimeseriesAnnotationKindHandlerTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/references/handlers/TimeseriesAnnotationKindHandlerTest.java
@@ -71,13 +71,13 @@ class TimeseriesAnnotationKindHandlerTest {
   @Test
   void listAnnotationsPaged_delegatesToDao() {
     var a = annotation(ANN_ID, 1_000L, null, "spike");
-    when(dao.findByTimeseriesReferenceAppId(REF_ID, 6, 3)).thenReturn(List.of(a));
+    when(dao.findByTimeseriesReferenceAppId(REF_ID, 6L, 3)).thenReturn(List.of(a));
 
-    List<Map<String, Object>> result = handler.listAnnotations(REF_ID, 6, 3);
+    List<Map<String, Object>> result = handler.listAnnotations(REF_ID, 6L, 3);
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0)).containsEntry("startNs", 1_000L);
-    verify(dao).findByTimeseriesReferenceAppId(REF_ID, 6, 3);
+    verify(dao).findByTimeseriesReferenceAppId(REF_ID, 6L, 3);
   }
 
   // ── create ──────────────────────────────────────────────────────────────

--- a/backend/src/test/java/de/dlr/shepard/v2/references/handlers/TimeseriesAnnotationKindHandlerTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/references/handlers/TimeseriesAnnotationKindHandlerTest.java
@@ -61,6 +61,25 @@ class TimeseriesAnnotationKindHandlerTest {
       .containsKey("endNs");
   }
 
+  @Test
+  void countAnnotations_delegatesToDao() {
+    when(dao.countByTimeseriesReferenceAppId(REF_ID)).thenReturn(7L);
+    assertThat(handler.countAnnotations(REF_ID)).isEqualTo(7L);
+    verify(dao).countByTimeseriesReferenceAppId(REF_ID);
+  }
+
+  @Test
+  void listAnnotationsPaged_delegatesToDao() {
+    var a = annotation(ANN_ID, 1_000L, null, "spike");
+    when(dao.findByTimeseriesReferenceAppId(REF_ID, 6, 3)).thenReturn(List.of(a));
+
+    List<Map<String, Object>> result = handler.listAnnotations(REF_ID, 6, 3);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0)).containsEntry("startNs", 1_000L);
+    verify(dao).findByTimeseriesReferenceAppId(REF_ID, 6, 3);
+  }
+
   // ── create ──────────────────────────────────────────────────────────────
 
   @Test

--- a/backend/src/test/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRestTest.java
@@ -3,6 +3,7 @@ package de.dlr.shepard.v2.references.resources;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -106,7 +107,7 @@ class ReferenceAnnotationRestTest {
   void list_returns200WithAnnotations() {
     Map<String, Object> ann = Map.of("appId", ANN_ID, "label", "spike");
     when(handler.countAnnotations(REF_ID)).thenReturn(1L);
-    when(handler.listAnnotations(eq(REF_ID), anyInt(), anyInt())).thenReturn(List.of(ann));
+    when(handler.listAnnotations(eq(REF_ID), anyLong(), anyInt())).thenReturn(List.of(ann));
 
     var r = resource.list(REF_ID, 0, 200, sc);
     assertThat(r.getStatus()).isEqualTo(200);
@@ -122,7 +123,7 @@ class ReferenceAnnotationRestTest {
   @Test
   void list_returns200WithEmptyList() {
     when(handler.countAnnotations(REF_ID)).thenReturn(0L);
-    when(handler.listAnnotations(eq(REF_ID), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+    when(handler.listAnnotations(eq(REF_ID), anyLong(), anyInt())).thenReturn(Collections.emptyList());
     var r = resource.list(REF_ID, 0, 200, sc);
     assertThat(r.getStatus()).isEqualTo(200);
     @SuppressWarnings("unchecked")
@@ -134,18 +135,18 @@ class ReferenceAnnotationRestTest {
   @Test
   void list_passesCorrectSkipAndLimitToHandler() {
     when(handler.countAnnotations(REF_ID)).thenReturn(10L);
-    when(handler.listAnnotations(eq(REF_ID), anyInt(), anyInt())).thenReturn(List.of());
+    when(handler.listAnnotations(eq(REF_ID), anyLong(), anyInt())).thenReturn(List.of());
 
     resource.list(REF_ID, 2, 3, sc);
     // page=2, pageSize=3 → skip=6, limit=3
-    verify(handler).listAnnotations(REF_ID, 6, 3);
+    verify(handler).listAnnotations(REF_ID, 6L, 3);
     verify(handler).countAnnotations(REF_ID);
   }
 
   @Test
   void list_xTotalCountHeaderMatchesTotalField() {
     when(handler.countAnnotations(REF_ID)).thenReturn(7L);
-    when(handler.listAnnotations(eq(REF_ID), anyInt(), anyInt())).thenReturn(List.of());
+    when(handler.listAnnotations(eq(REF_ID), anyLong(), anyInt())).thenReturn(List.of());
 
     var r = resource.list(REF_ID, 0, 200, sc);
     @SuppressWarnings("unchecked")

--- a/backend/src/test/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRestTest.java
@@ -2,6 +2,7 @@ package de.dlr.shepard.v2.references.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -104,65 +105,53 @@ class ReferenceAnnotationRestTest {
   @Test
   void list_returns200WithAnnotations() {
     Map<String, Object> ann = Map.of("appId", ANN_ID, "label", "spike");
-    when(handler.listAnnotations(REF_ID)).thenReturn(List.of(ann));
+    when(handler.countAnnotations(REF_ID)).thenReturn(1L);
+    when(handler.listAnnotations(eq(REF_ID), anyInt(), anyInt())).thenReturn(List.of(ann));
 
     var r = resource.list(REF_ID, 0, 200, sc);
     assertThat(r.getStatus()).isEqualTo(200);
     @SuppressWarnings("unchecked")
     var page = (PagedResponseIO<Map<String, Object>>) r.getEntity();
     assertThat(page.items()).hasSize(1);
-    assertThat(page.total()).isEqualTo(1);
+    assertThat(page.total()).isEqualTo(1L);
     assertThat(page.page()).isEqualTo(0);
     assertThat(page.items().get(0).get("label")).isEqualTo("spike");
-    assertThat(r.getHeaders().getFirst("X-Total-Count")).isEqualTo(1);
+    assertThat(r.getHeaders().getFirst("X-Total-Count")).isEqualTo(1L);
   }
 
   @Test
   void list_returns200WithEmptyList() {
-    when(handler.listAnnotations(REF_ID)).thenReturn(Collections.emptyList());
+    when(handler.countAnnotations(REF_ID)).thenReturn(0L);
+    when(handler.listAnnotations(eq(REF_ID), anyInt(), anyInt())).thenReturn(Collections.emptyList());
     var r = resource.list(REF_ID, 0, 200, sc);
     assertThat(r.getStatus()).isEqualTo(200);
     @SuppressWarnings("unchecked")
     var page = (PagedResponseIO<Map<String, Object>>) r.getEntity();
     assertThat(page.items()).isEmpty();
-    assertThat(page.total()).isEqualTo(0);
+    assertThat(page.total()).isEqualTo(0L);
   }
 
   @Test
-  void list_paginationSlicesCorrectly() {
-    List<Map<String, Object>> allAnns = List.of(
-      Map.of("appId", "a1", "label", "first"),
-      Map.of("appId", "a2", "label", "second"),
-      Map.of("appId", "a3", "label", "third")
-    );
-    when(handler.listAnnotations(REF_ID)).thenReturn(allAnns);
+  void list_passesCorrectSkipAndLimitToHandler() {
+    when(handler.countAnnotations(REF_ID)).thenReturn(10L);
+    when(handler.listAnnotations(eq(REF_ID), anyInt(), anyInt())).thenReturn(List.of());
 
-    // page=0, pageSize=2 → first two items, total=3
-    var r0 = resource.list(REF_ID, 0, 2, sc);
-    assertThat(r0.getStatus()).isEqualTo(200);
-    assertThat(r0.getHeaders().getFirst("X-Total-Count")).isEqualTo(3);
-    @SuppressWarnings("unchecked")
-    var p0 = (PagedResponseIO<Map<String, Object>>) r0.getEntity();
-    assertThat(p0.total()).isEqualTo(3);
-    assertThat(p0.items()).hasSize(2);
-    assertThat(p0.items().get(0).get("label")).isEqualTo("first");
+    resource.list(REF_ID, 2, 3, sc);
+    // page=2, pageSize=3 → skip=6, limit=3
+    verify(handler).listAnnotations(REF_ID, 6, 3);
+    verify(handler).countAnnotations(REF_ID);
+  }
 
-    // page=1, pageSize=2 → third item only
-    var r1 = resource.list(REF_ID, 1, 2, sc);
-    assertThat(r1.getStatus()).isEqualTo(200);
-    @SuppressWarnings("unchecked")
-    var p1 = (PagedResponseIO<Map<String, Object>>) r1.getEntity();
-    assertThat(p1.total()).isEqualTo(3);
-    assertThat(p1.items()).hasSize(1);
-    assertThat(p1.items().get(0).get("label")).isEqualTo("third");
+  @Test
+  void list_xTotalCountHeaderMatchesTotalField() {
+    when(handler.countAnnotations(REF_ID)).thenReturn(7L);
+    when(handler.listAnnotations(eq(REF_ID), anyInt(), anyInt())).thenReturn(List.of());
 
-    // page=5, limit=2 → beyond end → empty items, total still 3
-    var r2 = resource.list(REF_ID, 5, 2, sc);
-    assertThat(r2.getStatus()).isEqualTo(200);
+    var r = resource.list(REF_ID, 0, 200, sc);
     @SuppressWarnings("unchecked")
-    var p2 = (PagedResponseIO<Map<String, Object>>) r2.getEntity();
-    assertThat(p2.total()).isEqualTo(3);
-    assertThat(p2.items()).isEmpty();
+    var page = (PagedResponseIO<Map<String, Object>>) r.getEntity();
+    assertThat(r.getHeaders().getFirst("X-Total-Count")).isEqualTo(7L);
+    assertThat(page.total()).isEqualTo(7L);
   }
 
   // ── create ──────────────────────────────────────────────────────────────

--- a/plugins/video/src/main/java/de/dlr/shepard/v2/video/daos/VideoAnnotationDAO.java
+++ b/plugins/video/src/main/java/de/dlr/shepard/v2/video/daos/VideoAnnotationDAO.java
@@ -4,6 +4,7 @@ import de.dlr.shepard.common.neo4j.daos.GenericDAO;
 import de.dlr.shepard.common.util.CypherQueryHelper;
 import de.dlr.shepard.v2.video.model.VideoAnnotation;
 import jakarta.enterprise.context.RequestScoped;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.StreamSupport;
@@ -20,6 +21,32 @@ public class VideoAnnotationDAO extends GenericDAO<VideoAnnotation> {
     return StreamSupport
       .stream(findByQuery(query, Map.of("refAppId", refAppId)).spliterator(), false)
       .toList();
+  }
+
+  public List<VideoAnnotation> findByVideoReferenceAppId(String refAppId, int skip, int limit) {
+    String query =
+      "MATCH (r:VideoStreamReference {appId: $refAppId})-[:has_video_annotation]->" +
+      CypherQueryHelper.getObjectPart("a", "VideoAnnotation", false) +
+      " RETURN a ORDER BY a.appId SKIP $skip LIMIT $limit";
+    Map<String, Object> params = new HashMap<>();
+    params.put("refAppId", refAppId);
+    params.put("skip", (long) skip);
+    params.put("limit", (long) limit);
+    return StreamSupport
+      .stream(findByQuery(query, params).spliterator(), false)
+      .toList();
+  }
+
+  public long countByVideoReferenceAppId(String refAppId) {
+    String query =
+      "MATCH (r:VideoStreamReference {appId: $refAppId})-[:has_video_annotation]->" +
+      CypherQueryHelper.getObjectPart("a", "VideoAnnotation", false) +
+      " RETURN count(a) AS total";
+    for (var row : session.query(query, Map.of("refAppId", refAppId)).queryResults()) {
+      Object val = row.get("total");
+      if (val instanceof Number n) return n.longValue();
+    }
+    return 0L;
   }
 
   public VideoAnnotation findByAppId(String appId) {

--- a/plugins/video/src/main/java/de/dlr/shepard/v2/video/daos/VideoAnnotationDAO.java
+++ b/plugins/video/src/main/java/de/dlr/shepard/v2/video/daos/VideoAnnotationDAO.java
@@ -23,14 +23,14 @@ public class VideoAnnotationDAO extends GenericDAO<VideoAnnotation> {
       .toList();
   }
 
-  public List<VideoAnnotation> findByVideoReferenceAppId(String refAppId, int skip, int limit) {
+  public List<VideoAnnotation> findByVideoReferenceAppId(String refAppId, long skip, int limit) {
     String query =
       "MATCH (r:VideoStreamReference {appId: $refAppId})-[:has_video_annotation]->" +
       CypherQueryHelper.getObjectPart("a", "VideoAnnotation", false) +
       " RETURN a ORDER BY a.appId SKIP $skip LIMIT $limit";
     Map<String, Object> params = new HashMap<>();
     params.put("refAppId", refAppId);
-    params.put("skip", (long) skip);
+    params.put("skip", skip);
     params.put("limit", (long) limit);
     return StreamSupport
       .stream(findByQuery(query, params).spliterator(), false)

--- a/plugins/video/src/main/java/de/dlr/shepard/v2/video/handlers/VideoStreamReferenceKindHandler.java
+++ b/plugins/video/src/main/java/de/dlr/shepard/v2/video/handlers/VideoStreamReferenceKindHandler.java
@@ -157,6 +157,18 @@ public class VideoStreamReferenceKindHandler implements ReferenceKindHandler {
   }
 
   @Override
+  public long countAnnotations(String refAppId) {
+    return videoAnnotationDAO.countByVideoReferenceAppId(refAppId);
+  }
+
+  @Override
+  public List<Map<String, Object>> listAnnotations(String refAppId, int skip, int limit) {
+    return videoAnnotationDAO.findByVideoReferenceAppId(refAppId, skip, limit).stream()
+      .map(VideoStreamReferenceKindHandler::annotationToMap)
+      .toList();
+  }
+
+  @Override
   public Map<String, Object> createAnnotation(String refAppId, Map<String, Object> body) {
     if (body == null || !body.containsKey("startSeconds") || body.get("startSeconds") == null) {
       throw new BadRequestException("startSeconds is required for video annotations");

--- a/plugins/video/src/main/java/de/dlr/shepard/v2/video/handlers/VideoStreamReferenceKindHandler.java
+++ b/plugins/video/src/main/java/de/dlr/shepard/v2/video/handlers/VideoStreamReferenceKindHandler.java
@@ -162,7 +162,7 @@ public class VideoStreamReferenceKindHandler implements ReferenceKindHandler {
   }
 
   @Override
-  public List<Map<String, Object>> listAnnotations(String refAppId, int skip, int limit) {
+  public List<Map<String, Object>> listAnnotations(String refAppId, long skip, int limit) {
     return videoAnnotationDAO.findByVideoReferenceAppId(refAppId, skip, limit).stream()
       .map(VideoStreamReferenceKindHandler::annotationToMap)
       .toList();

--- a/plugins/video/src/test/java/de/dlr/shepard/v2/video/handlers/VideoAnnotationKindHandlerTest.java
+++ b/plugins/video/src/test/java/de/dlr/shepard/v2/video/handlers/VideoAnnotationKindHandlerTest.java
@@ -72,13 +72,13 @@ class VideoAnnotationKindHandlerTest {
   @Test
   void listAnnotationsPaged_delegatesToDao() {
     var a = annotation(ANN_ID, 0.0, 5.0, "ignition");
-    when(dao.findByVideoReferenceAppId(REF_ID, 6, 3)).thenReturn(List.of(a));
+    when(dao.findByVideoReferenceAppId(REF_ID, 6L, 3)).thenReturn(List.of(a));
 
-    List<Map<String, Object>> result = handler.listAnnotations(REF_ID, 6, 3);
+    List<Map<String, Object>> result = handler.listAnnotations(REF_ID, 6L, 3);
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0)).containsEntry("startSeconds", 0.0);
-    verify(dao).findByVideoReferenceAppId(REF_ID, 6, 3);
+    verify(dao).findByVideoReferenceAppId(REF_ID, 6L, 3);
   }
 
   // ── create ──────────────────────────────────────────────────────────────

--- a/plugins/video/src/test/java/de/dlr/shepard/v2/video/handlers/VideoAnnotationKindHandlerTest.java
+++ b/plugins/video/src/test/java/de/dlr/shepard/v2/video/handlers/VideoAnnotationKindHandlerTest.java
@@ -62,6 +62,25 @@ class VideoAnnotationKindHandlerTest {
       .containsEntry("label", "ignition");
   }
 
+  @Test
+  void countAnnotations_delegatesToDao() {
+    when(dao.countByVideoReferenceAppId(REF_ID)).thenReturn(5L);
+    assertThat(handler.countAnnotations(REF_ID)).isEqualTo(5L);
+    verify(dao).countByVideoReferenceAppId(REF_ID);
+  }
+
+  @Test
+  void listAnnotationsPaged_delegatesToDao() {
+    var a = annotation(ANN_ID, 0.0, 5.0, "ignition");
+    when(dao.findByVideoReferenceAppId(REF_ID, 6, 3)).thenReturn(List.of(a));
+
+    List<Map<String, Object>> result = handler.listAnnotations(REF_ID, 6, 3);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0)).containsEntry("startSeconds", 0.0);
+    verify(dao).findByVideoReferenceAppId(REF_ID, 6, 3);
+  }
+
   // ── create ──────────────────────────────────────────────────────────────
 
   @Test


### PR DESCRIPTION
## Summary

Replaces the in-memory subList paging on `GET /v2/references/{appId}/annotations` with DB-side SKIP/LIMIT queries, eliminating full annotation table loads for large timeseries/video references.

**Root cause:** `ReferenceAnnotationRest.list()` called `handler.listAnnotations(appId)` (unbounded) then sliced in Java — O(N) DB read for every page request.

**Fix:**
- `TimeseriesAnnotationDAO` — new `findByTimeseriesReferenceAppId(refAppId, skip, limit)` and `countByTimeseriesReferenceAppId(refAppId)` using Cypher `SKIP $skip LIMIT $limit`
- `VideoAnnotationDAO` (video plugin) — same DB-side paged + count methods
- `ReferenceKindHandler` SPI — two new default methods: `countAnnotations(String)` (falls back to `listAnnotations().size()`) and `listAnnotations(String, int, int)` (in-memory subList fallback for handlers not yet overriding)
- `TimeseriesReferenceKindHandler` + `VideoStreamReferenceKindHandler` — override both to delegate to DAO (true DB-side paging)
- `ReferenceAnnotationRest.list()` — calls `handler.countAnnotations()` + `handler.listAnnotations(skip, limit)` instead of loading all rows then slicing

**Tests:**
- `ReferenceAnnotationRestTest` — updated to mock new SPI signatures; new tests for skip/limit passthrough and X-Total-Count/total field consistency
- `TimeseriesAnnotationKindHandlerTest` — new `countAnnotations_delegatesToDao` and `listAnnotationsPaged_delegatesToDao`
- `VideoAnnotationKindHandlerTest` — same two new tests

Fixes APISIMP-PAGINATION-ANNOTATIONS finding from `aidocs/platform/191-v2-surface-convergence.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWUjmW3rxPAiZHSYo9FXQb)_