### PR TITLE
fix(APISIMP): batch 4 XS OpenAPI/wire violations (fire-444)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/bundle/resources/FileBundleReferenceRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/bundle/resources/FileBundleReferenceRest.java
@@ -447,10 +447,16 @@ public class FileBundleReferenceRest {
   public Response listGroupFiles(
     @PathParam("bundleAppId") String bundleAppId,
     @PathParam("groupAppId") String groupAppId,
-    @Parameter(description = "0-based page index. Default 0. Values past the last page return an empty items[] with the correct totalElements/totalPages.")
-    @QueryParam("page") Integer page,
-    @Parameter(description = "Page size. Default 200; clamped server-side to [1, 1000]. Out-of-range hints are clamped, never rejected.")
-    @QueryParam("pageSize") Integer pageSize,
+    @Parameter(
+      description = "0-based page index. Default 0. Values past the last page return an empty items[] with the correct totalElements/totalPages.",
+      schema = @Schema(minimum = "0", defaultValue = "0")
+    )
+    @QueryParam("page") @DefaultValue("0") Integer page,
+    @Parameter(
+      description = "Page size, capped at 1000 (default 200). Out-of-range values are clamped server-side, never rejected.",
+      schema = @Schema(minimum = "1", maximum = "1000", defaultValue = "200")
+    )
+    @QueryParam("pageSize") @DefaultValue("200") Integer pageSize,
     @Context SecurityContext securityContext
   ) {
     FileBundleReference bundle = fileBundleReferenceDAO.findByAppId(bundleAppId);

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -999,7 +999,8 @@ public class ContainersV2Rest {
       "Non-timeseries kinds answer 415.\n\nAuth: Read on the container."
   )
   @APIResponse(responseCode = "200",
-    description = "Paged list of channel annotations with X-Total-Count header (may be empty).")
+    description = "Paged list of channel annotations with X-Total-Count header (may be empty).",
+    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)))
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Read on the container.")
   @APIResponse(responseCode = "404", description = "No container with that appId.")
@@ -1007,9 +1008,11 @@ public class ContainersV2Rest {
   public Response listChannelAnnotations(
       @PathParam("appId") String appId,
       @PathParam("channelShepardId") String channelShepardId,
-      @Parameter(description = "Zero-based page index (default 0).")
+      @Parameter(description = "Zero-based page index (default 0).",
+        schema = @Schema(minimum = "0", defaultValue = "0"))
         @QueryParam("page") @DefaultValue("0") @Min(0) int page,
-      @Parameter(description = "Items per page, capped at 500 (default 200).")
+      @Parameter(description = "Items per page, capped at 500 (default 200).",
+        schema = @Schema(minimum = "1", maximum = "500", defaultValue = "200"))
         @QueryParam("pageSize") @DefaultValue("200") @Min(1) @Max(500) int pageSize,
       @Context SecurityContext sc
   ) {
@@ -1113,16 +1116,19 @@ public class ContainersV2Rest {
       "Non-timeseries kinds answer 415.\n\nAuth: Read on the container."
   )
   @APIResponse(responseCode = "200",
-    description = "Paged list of temporal annotations with X-Total-Count header (may be empty).")
+    description = "Paged list of temporal annotations with X-Total-Count header (may be empty).",
+    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)))
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Read on the container.")
   @APIResponse(responseCode = "404", description = "No container with that appId.")
   @APIResponse(responseCode = "415", description = "This container kind has no temporal-annotation concept.")
   public Response listTemporalAnnotations(
       @PathParam("appId") String appId,
-      @Parameter(description = "Zero-based page index (default 0).")
+      @Parameter(description = "Zero-based page index (default 0).",
+        schema = @Schema(minimum = "0", defaultValue = "0"))
         @QueryParam("page") @DefaultValue("0") @Min(0) int page,
-      @Parameter(description = "Items per page, capped at 500 (default 200).")
+      @Parameter(description = "Items per page, capped at 500 (default 200).",
+        schema = @Schema(minimum = "1", maximum = "500", defaultValue = "200"))
         @QueryParam("pageSize") @DefaultValue("200") @Min(1) @Max(500) int pageSize,
       @Context SecurityContext sc
   ) {

--- a/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotPinnedReadRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotPinnedReadRest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -121,7 +122,11 @@ public class SnapshotPinnedReadRest {
   public Response getDataObjects(
     @PathParam("collectionAppId") String collectionAppId,
     @PathParam("snapshotAppId") String snapshotAppId,
+    @Parameter(description = "Zero-based page index (default 0).",
+      schema = @Schema(minimum = "0", defaultValue = "0"))
     @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
+    @Parameter(description = "Items per page, capped at 2000 (default 500).",
+      schema = @Schema(minimum = "1", maximum = "2000", defaultValue = "500"))
     @QueryParam("pageSize") @DefaultValue("500") @Min(1) @Max(2000) int pageSize,
     @Context SecurityContext sc
   ) {

--- a/plugins/wiki-writer/src/main/java/de/dlr/shepard/plugins/wikiwriter/io/WikiWriteResponseIO.java
+++ b/plugins/wiki-writer/src/main/java/de/dlr/shepard/plugins/wikiwriter/io/WikiWriteResponseIO.java
@@ -1,5 +1,6 @@
 package de.dlr.shepard.plugins.wikiwriter.io;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -22,6 +23,7 @@ public class WikiWriteResponseIO {
    *             This field will be removed in the L2e deprecation window.
    */
   @Deprecated
+  @JsonIgnore
   private long labJournalEntryId;
 
   /**


### PR DESCRIPTION
## Summary

Fixes 4 XS violations found in the fire-444 API-simplification sweep (`aidocs/agent-findings/apisimp-sweep-fire444-2026-07-06.md`):

- **APISIMP-WIKI-NUMERIC-ID-WIRE** — `WikiWriteResponseIO.labJournalEntryId` (Neo4j OGM numeric id) was serialized in every `POST /v2/.../wiki-write` response despite `labJournalEntryAppId` (UUID v7) being present. Adds `@JsonIgnore` to suppress the numeric id leak.
- **APISIMP-BUNDLE-FILES-NO-DEFAULTVALUE** — `listGroupFiles` page/pageSize lacked `@DefaultValue`, so the OpenAPI spec showed no defaults. Adds `@DefaultValue("0")`/`@DefaultValue("200")` + `@Schema(...)` in `@Parameter`. `Integer` type preserved (intentional server-side clamping contract).
- **APISIMP-PAGESIZE-CAP-UNDOCUMENTED** — `listGroupFiles` (cap 1000), `SnapshotPinnedReadRest.getDataObjects` (cap 2000), `listChannelAnnotations`/`listTemporalAnnotations` (cap 500) enforced non-standard pageSize maxima without documenting them in `@Schema(maximum = "…")`. Adds schema declarations to all four endpoints. Also adds `@Parameter` import + annotations to `SnapshotPinnedReadRest`.
- **APISIMP-CHANNEL-ANNOTATION-MISSING-SCHEMA** — `listChannelAnnotations` and `listTemporalAnnotations` 200 `@APIResponse` lacked `content = @Content(schema = @Schema(implementation = PagedResponseIO.class))`. Matches the pattern used by every other list endpoint on `ContainersV2Rest`.

All changes are annotation-only / wire-removal (no logic changes except removing the one numeric id from the response).

**Queued for next fire:** APISIMP-SEARCH-SPLIT-PAGINATION (Size S) — dual `page`/`doPage` pagination vocabulary on `GET /v2/search`.

## Acceptance criteria

- `GET /v2/.../wiki-write` response body no longer contains `labJournalEntryId`
- OpenAPI spec shows `defaultValue`/`maximum` for `listGroupFiles`, `getDataObjects`, `listChannelAnnotations`, `listTemporalAnnotations`
- OpenAPI spec shows `PagedResponseIO` schema for `listChannelAnnotations`/`listTemporalAnnotations` 200 responses
- `mvn verify -pl backend` green

---
_Generated by [Claude Code](https://claude.ai/code/session_0143BAUJPMezVoRWDmf75qCj)_