### PR TITLE
fix(apisimp): add @Parameter descriptions to page/pageSize params (XS batch fire-445)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -153,8 +154,8 @@ public class ReferenceAnnotationRest {
   @APIResponse(responseCode = "404", description = "No reference with that appId, or kind does not support annotations.")
   public Response list(
     @PathParam("appId") String appId,
-    @QueryParam("page") @DefaultValue("0") @Min(0) int page,
-    @QueryParam("pageSize") @DefaultValue("200") @Min(1) @Max(1000) int pageSize,
+    @Parameter(description = "Zero-based page index (default 0).") @QueryParam("page") @DefaultValue("0") @Min(0) int page,
+    @Parameter(description = "Items per page (1–1000). Default 200.") @QueryParam("pageSize") @DefaultValue("200") @Min(1) @Max(1000) int pageSize,
     @Context SecurityContext sc
   ) {
     return gateAndDispatch(appId, AccessType.Read, sc, r -> {

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/CollectionTemplatesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/CollectionTemplatesRest.java
@@ -33,6 +33,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -97,8 +98,8 @@ public class CollectionTemplatesRest {
   @APIResponse(responseCode = "404", description = "No Collection with that appId.")
   public Response listAllowed(
     @PathParam("appId") String collectionAppId,
-    @DefaultValue("0") @Min(0) @QueryParam("page") int page,
-    @DefaultValue("50") @Min(1) @Max(200) @QueryParam("pageSize") int pageSize,
+    @Parameter(description = "Zero-based page index (default 0).") @DefaultValue("0") @Min(0) @QueryParam("page") int page,
+    @Parameter(description = "Items per page (1–200). Default 50.") @DefaultValue("50") @Min(1) @Max(200) @QueryParam("pageSize") int pageSize,
     @Context SecurityContext securityContext
   ) {
     Optional<Long> ogmId = resolveAndGate(collectionAppId, AccessType.Read, securityContext);
@@ -122,8 +123,8 @@ public class CollectionTemplatesRest {
   @APIResponse(responseCode = "404", description = "No Collection with that appId.")
   public Response listUsed(
     @PathParam("appId") String collectionAppId,
-    @DefaultValue("0") @Min(0) @QueryParam("page") int page,
-    @DefaultValue("50") @Min(1) @Max(200) @QueryParam("pageSize") int pageSize,
+    @Parameter(description = "Zero-based page index (default 0).") @DefaultValue("0") @Min(0) @QueryParam("page") int page,
+    @Parameter(description = "Items per page (1–200). Default 50.") @DefaultValue("50") @Min(1) @Max(200) @QueryParam("pageSize") int pageSize,
     @Context SecurityContext securityContext
   ) {
     Optional<Long> ogmId = resolveAndGate(collectionAppId, AccessType.Read, securityContext);


### PR DESCRIPTION
## Summary

Batch XS fix for two APISIMP findings from the fire-445 sweep (`aidocs/agent-findings/apisimp-sweep-fire445-2026-07-06.md`).

**APISIMP-COLL-TEMPLATES-ANNOT-MISSING-PARAM** — `CollectionTemplatesRest` (`GET /v2/collections/{appId}/templates/allowed` and `/used`): `page` and `pageSize` `@QueryParam` fields lacked `@Parameter(description=...)` annotations, making them opaque in the generated OpenAPI spec. Sibling endpoints in `ShepardTemplateRest` already carry proper `@Parameter` annotations.

**APISIMP-REFANNOT-PAGE-MISSING-PARAM** — `ReferenceAnnotationRest` (`GET /v2/references/{appId}/annotations`): same gap — `@DefaultValue`/`@Min`/`@Max` were present but no `@Parameter` description for the OpenAPI generator. Same pattern as the already-fixed `CHANNEL-ANNOTATION-MISSING-SCHEMA`.

## Changes

- `CollectionTemplatesRest.java`: add `import org.eclipse.microprofile.openapi.annotations.parameters.Parameter` + `@Parameter(description=...)` before `@QueryParam("page")` and `@QueryParam("pageSize")` in `listAllowed()` and `listUsed()`.
- `ReferenceAnnotationRest.java`: same import + `@Parameter` additions in `list()`.

No behaviour change — OpenAPI spec output only (4 annotation additions total).

## Test plan

- [ ] `mvn compile -DnoPlugins -DskipTests -Dquarkus.build.skip=true` passes in `backend/` (verified locally before push)
- [ ] CI checks green
- [ ] Inspect generated OpenAPI spec: `page` and `pageSize` now carry descriptions and schema constraints for the three affected endpoints

---
_Generated by [Claude Code](https://claude.ai/code/session_0187GdgNCsfxuez5krPMS5q5)_