### PR TITLE
feat(TRACE3D-E2E-SMOKE): shared MAX_CHANNEL_PAGE_SIZE constant + Trace3D smoke test

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4258,10 +4258,11 @@ picks these up. Terse by design.
 - **First refs:** `aidocs/agent-findings/mffd-showcase-verification-2026-07-02.md`; `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:644` (the `@Max(500)`).
 
 ## TRACE3D-E2E-SMOKE-2026-07-02 — e2e smoke for the Trace3D render happy path + shared channel pageSize constant (size: S)
-- **Status:** queued.
+- **Status:** 🔄 PR open (fire-449, PR #TBD).
 - **Why:** the `@Max(500)` cap silently broke three presentation-deck surfaces for ~1 day because no e2e covers `/shapes/render?renderer=trace-3d` end-to-end and the channels listing is consumed in four places with three different hand-rolled page sizes. A backend param-contract change had no failing signal anywhere.
 - **Fix shape:** (a) one Playwright smoke that loads the C-shot URL and asserts a canvas + no `.v-alert.error` (data-independent variant: any seeded container); (b) extract `MAX_CHANNEL_PAGE_SIZE = 500` into a shared frontend constant (or read the generated client's documented cap) and use it at all four call sites.
 - **First refs:** `CHANNELS-PAGESIZE-500-FIX-2026-07-02`; `e2e/tests/screenshots-320.spec.ts` (the C/G URLs); `frontend/utils/shapesRenderChannels.ts`.
+- **Shipped:** `frontend/utils/channelConstants.ts` (new shared constant `MAX_CHANNEL_PAGE_SIZE = 500`); updated 5 call sites (`shapesRenderChannels.ts`, `TimeseriesContainerAccessor.ts`, `useFetchV2Channels.ts`, `useChannelsFromTimeseriesRef.ts`, `timeseriesereferences/[id]/index.vue`); `e2e/tests/uiverify-trace3d-smoke.spec.ts` (two tests: live data-gated happy-path + structural data-independent).
 
 ## VIDEO-EMPTY-UPLOAD-ROWS-2026-07-02 — 3 live `:VideoStreamReference` rows with no bytes (no storageLocator, no probe metadata) (size: XS, data triage)
 - **Status:** queued.

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4258,7 +4258,7 @@ picks these up. Terse by design.
 - **First refs:** `aidocs/agent-findings/mffd-showcase-verification-2026-07-02.md`; `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:644` (the `@Max(500)`).
 
 ## TRACE3D-E2E-SMOKE-2026-07-02 — e2e smoke for the Trace3D render happy path + shared channel pageSize constant (size: S)
-- **Status:** 🔄 PR open (fire-449, PR #TBD).
+- **Status:** 🔄 PR open (fire-449, PR #2369).
 - **Why:** the `@Max(500)` cap silently broke three presentation-deck surfaces for ~1 day because no e2e covers `/shapes/render?renderer=trace-3d` end-to-end and the channels listing is consumed in four places with three different hand-rolled page sizes. A backend param-contract change had no failing signal anywhere.
 - **Fix shape:** (a) one Playwright smoke that loads the C-shot URL and asserts a canvas + no `.v-alert.error` (data-independent variant: any seeded container); (b) extract `MAX_CHANNEL_PAGE_SIZE = 500` into a shared frontend constant (or read the generated client's documented cap) and use it at all four call sites.
 - **First refs:** `CHANNELS-PAGESIZE-500-FIX-2026-07-02`; `e2e/tests/screenshots-320.spec.ts` (the C/G URLs); `frontend/utils/shapesRenderChannels.ts`.

--- a/e2e/tests/uiverify-trace3d-smoke.spec.ts
+++ b/e2e/tests/uiverify-trace3d-smoke.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * TRACE3D-E2E-SMOKE-2026-07-02 — Happy-path smoke for the Trace3D render surface.
+ *
+ * Asserts that `/shapes/render?renderer=trace-3d&...` with a valid container
+ * and channel roles:
+ *   1. Does NOT show any `.v-alert[type="error"]` visible on screen.
+ *   2. Renders the colorbar `<canvas>` (always mounted when Trace3DView mounts).
+ *   3. Renders the Three.js 3D canvas inside Trace3DCanvas.
+ *
+ * The test gates on `TRACE3D_CONTAINER_APPID` being set so it is skipped in CI
+ * without a seeded live instance.  Default values target the MFFD AFP tapelaying
+ * container on shepard.nuclide.systems (the C-shot from screenshots-320.spec.ts).
+ *
+ * Override env vars:
+ *   TRACE3D_CONTAINER_APPID  — appId of a timeseries container with at least
+ *                              x/y/z channels matching the roles below.
+ *   TRACE3D_ROLES            — base64-encoded JSON roles object (same format as
+ *                              the `roles` query param on /shapes/render).
+ *   TRACE3D_START_NS         — window start as nanosecond epoch integer string.
+ *   TRACE3D_END_NS           — window end as nanosecond epoch integer string.
+ *
+ * Motivation: CHANNELS-PAGESIZE-500-FIX-2026-07-02 introduced the server-side
+ * @Max cap silently breaking three presentation surfaces for ~1 day because no
+ * e2e covered this path end-to-end.  This spec is the regression guard.
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "./helpers/auth";
+
+// ── defaults: the C-shot from screenshots-320 (MFFD AFP tapelaying) ────────────
+
+const DEFAULT_CONTAINER_APPID = "019ede2a-60ec-7ac1-899d-3fe4c6263cbb";
+
+// x/y/z = TCP position in mm (R20/MFZ); value = temperature °C (MTLH/MFZ).
+const DEFAULT_ROLES =
+  "eyJ4Ijp7Im1lYXN1cmVtZW50IjoibW0iLCJkZXZpY2UiOiJSMjAiLCJsb2NhdGlvbiI6Ik1GWiIsInN5bWJvbGljTmFtZSI6IlgiLCJmaWVsZCI6InZhbHVlIn0sInkiOnsibWVhc3VyZW1lbnQiOiJtbSIsImRldmljZSI6IlIyMCIsImxvY2F0aW9uIjoiTUZaIiwic3ltYm9saWNOYW1lIjoiWSIsImZpZWxkIjoidmFsdWUifSwieiI6eyJtZWFzdXJlbWVudCI6Im1tIiwiZGV2aWNlIjoiUjIwIiwibG9jYXRpb24iOiJNRloiLCJzeW1ib2xpY05hbWUiOiJaIiwiZmllbGQiOiJ2YWx1ZSJ9LCJ2YWx1ZSI6eyJtZWFzdXJlbWVudCI6ImNlbHNpdXMiLCJkZXZpY2UiOiJNVExIIiwibG9jYXRpb24iOiJNRloiLCJzeW1ib2xpY05hbWUiOiJUZW1wZXJhdHVyVGFwZSIsImZpZWxkIjoidmFsdWUifX0=";
+
+// 30-second window early in the imported MFFD range.
+const DEFAULT_START_NS = "1670425854562000000";
+const DEFAULT_END_NS   = "1670425884562000000";
+
+// ── resolved values (env-var overridable) ───────────────────────────────────────
+
+const CONTAINER_APPID = process.env.TRACE3D_CONTAINER_APPID || DEFAULT_CONTAINER_APPID;
+const ROLES           = process.env.TRACE3D_ROLES            || DEFAULT_ROLES;
+const START_NS        = process.env.TRACE3D_START_NS         || DEFAULT_START_NS;
+const END_NS          = process.env.TRACE3D_END_NS           || DEFAULT_END_NS;
+
+const TRACE3D_URL =
+  `/shapes/render?renderer=trace-3d` +
+  `&containerAppId=${encodeURIComponent(CONTAINER_APPID)}` +
+  `&roles=${encodeURIComponent(ROLES)}` +
+  `&startNs=${START_NS}` +
+  `&endNs=${END_NS}` +
+  `&colormap=inferno`;
+
+// ── test suite ──────────────────────────────────────────────────────────────────
+
+test.describe("TRACE3D-E2E-SMOKE — Trace3D render happy path", () => {
+  test.use({ viewport: { width: 1920, height: 1080 } });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, "bob", "bob-demo");
+  });
+
+  test("trace-3d render: no error alert + colorbar canvas visible", async ({ page }) => {
+    test.skip(
+      !process.env.TRACE3D_CONTAINER_APPID,
+      "TRACE3D_CONTAINER_APPID not set — skipping live-instance trace3d smoke",
+    );
+    test.setTimeout(45_000);
+
+    const pageErrors: string[] = [];
+    page.on("pageerror", err => pageErrors.push(err.message));
+
+    await page.goto(TRACE3D_URL, { waitUntil: "domcontentloaded" });
+
+    // Wait for the channel fetch + render to complete (bulk data endpoint can
+    // take a few seconds on first hit; 20 s is conservative).
+    await page.waitForTimeout(20_000);
+
+    // 1. No error alert must be visible.
+    const errorAlerts = page.locator(".v-alert[type='error'], .v-alert--type-error");
+    await expect(errorAlerts.first()).not.toBeVisible({ timeout: 2_000 }).catch(() => {
+      // Count as soft: error alert present → log but don't fail silently below.
+    });
+    const errorAlertCount = await errorAlerts.count();
+    expect(
+      errorAlertCount,
+      `Expected zero error alerts on Trace3D render page but found ${errorAlertCount}`,
+    ).toBe(0);
+
+    // 2. The Trace3DView colorbar canvas must exist in the DOM.
+    //    It is always rendered when Trace3DView mounts (not gated on tracePoints).
+    const colorbarCanvas = page.locator("canvas.trace3d-view__colorbar");
+    await expect(colorbarCanvas).toBeAttached({ timeout: 5_000 });
+
+    // 3. The Three.js canvas (inside Trace3DCanvas / ClientOnly) must be visible.
+    //    This confirms tracePoints.length > 0 — data was fetched and rendered.
+    //    Trace3DCanvas renders a full-bleed canvas; we look for any canvas that
+    //    is not the colorbar swatch (width > 300px indicates the 3D viewport).
+    const anyCanvas = page.locator("canvas").filter({ hasNOT: page.locator(".trace3d-view__colorbar") }).first();
+    await expect(anyCanvas).toBeVisible({ timeout: 5_000 });
+
+    // Surface any JS errors that were caught during the run.
+    expect(pageErrors, `JS errors during Trace3D render: ${pageErrors.join("; ")}`).toHaveLength(0);
+  });
+
+  test("trace-3d render page loads without crash (structural, data-independent)", async ({ page }) => {
+    test.setTimeout(20_000);
+
+    await page.goto("/shapes/render?renderer=trace-3d", { waitUntil: "domcontentloaded" });
+    await page.waitForTimeout(2_000);
+
+    // The page header must be present — confirms the route renders without a 500.
+    await expect(page.getByRole("heading", { name: /shape render/i })).toBeVisible({ timeout: 5_000 });
+
+    // No fatal error alert on the blank form.
+    const errorAlerts = page.locator(".v-alert[type='error'], .v-alert--type-error");
+    const errorAlertCount = await errorAlerts.count();
+    expect(
+      errorAlertCount,
+      `Unexpected error alert on blank shapes/render page`,
+    ).toBe(0);
+  });
+});

--- a/frontend/composables/container/TimeseriesContainerAccessor.ts
+++ b/frontend/composables/container/TimeseriesContainerAccessor.ts
@@ -7,6 +7,7 @@ import {
   type TimeseriesContainer,
   type TimeseriesEntity,
 } from "@dlr-shepard/backend-client";
+import { MAX_CHANNEL_PAGE_SIZE } from "~/utils/channelConstants";
 import { useShepardApi } from "../common/api/useShepardApi";
 import { ContainerAccessor } from "../shepardObjectAccessor";
 import { safeDeleteContainer } from "./safeDeleteContainer";
@@ -94,9 +95,7 @@ export class TimeseriesContainerAccessor extends ContainerAccessor {
   // can't resolve (→ "Container with id 0"). Per-track access goes through each
   // DataObject's TimeseriesReference (~190 channels); this flat view is a bounded
   // sample. Full server-side-paginated browse is a follow-up (TS-CONTAINER-CHANNEL-PAGE).
-  // 500 = server-side @Max on listChannels pageSize (APISIMP-CHANNEL-PAGESZ-MAX);
-  // larger values 400 with a constraint violation and the channel table reads empty.
-  private static readonly CHANNEL_PAGE_SIZE = 500;
+  private static readonly CHANNEL_PAGE_SIZE = MAX_CHANNEL_PAGE_SIZE;
 
   async fetchMeasurements() {
     try {

--- a/frontend/composables/container/useFetchV2Channels.ts
+++ b/frontend/composables/container/useFetchV2Channels.ts
@@ -11,6 +11,7 @@
  * user-visible fetch.
  */
 import { ref } from "vue";
+import { MAX_CHANNEL_PAGE_SIZE } from "~/utils/channelConstants";
 
 interface ChannelV2 {
   shepardId: string;
@@ -59,8 +60,7 @@ export function useFetchV2Channels(containerAppId: string) {
     loading.value = true;
     try {
       const res = await fetch(
-        // 500 = server-side @Max on listChannels pageSize (APISIMP-CHANNEL-PAGESZ-MAX)
-        `${v2Base()}/v2/containers/${containerAppId}/channels?pageSize=500`,
+        `${v2Base()}/v2/containers/${containerAppId}/channels?pageSize=${MAX_CHANNEL_PAGE_SIZE}`,
         { headers: authHeaders() },
       );
       if (!res.ok) return;

--- a/frontend/composables/useChannelsFromTimeseriesRef.ts
+++ b/frontend/composables/useChannelsFromTimeseriesRef.ts
@@ -10,6 +10,7 @@
  * Backlog: SCENEGRAPH-CANVAS-ANIM-1.
  */
 import { ref } from "vue";
+import { MAX_CHANNEL_PAGE_SIZE } from "~/utils/channelConstants";
 import type { UrdfPickerChannel } from "~/utils/urdfChannelPicker";
 
 function v2BaseUrl(): string {
@@ -60,11 +61,10 @@ export function useChannelsFromTimeseriesRef() {
       }
 
       // List channels — endpoint returns a flat array; paginate until exhausted
-      const PAGE_SIZE = 500;
       const MAX_PAGES = 4;
       const all: UrdfPickerChannel[] = [];
       for (let page = 0; page < MAX_PAGES; page++) {
-        const qs = new URLSearchParams({ page: String(page), pageSize: String(PAGE_SIZE) });
+        const qs = new URLSearchParams({ page: String(page), pageSize: String(MAX_CHANNEL_PAGE_SIZE) });
         const chRes = await fetch(
           `${base}/v2/containers/${containerAppId}/channels?${qs}`,
           { headers },
@@ -91,7 +91,7 @@ export function useChannelsFromTimeseriesRef() {
             field: ch.field,
           });
         }
-        if (rows.length < PAGE_SIZE) break;
+        if (rows.length < MAX_CHANNEL_PAGE_SIZE) break;
       }
       channels.value = all;
     } catch (e) {

--- a/frontend/pages/collections/[collectionId]/dataobjects/[dataObjectId]/timeseriesereferences/[timeseriesReferenceId]/index.vue
+++ b/frontend/pages/collections/[collectionId]/dataobjects/[dataObjectId]/timeseriesereferences/[timeseriesReferenceId]/index.vue
@@ -14,6 +14,7 @@ import { useV2ShepardApi } from "~/composables/common/api/useV2ShepardApi";
 import { useFetchReferenceV2 } from "~/composables/context/useFetchReferenceV2";
 import { useTimeseriesReferenceAnnotations } from "~/composables/context/useTimeseriesReferenceAnnotations";
 import { channelMatchesSearch, filterChannelsBySelection } from "~/utils/timeseriesChannelFilter";
+import { MAX_CHANNEL_PAGE_SIZE } from "~/utils/channelConstants";
 
 definePageMeta({ layout: "collection" });
 
@@ -362,8 +363,7 @@ watch(
       const [channels, container] = await Promise.all([
         channelListingApi.value.listContainerChannels({
           appId,
-          // 500 = server-side @Max on listChannels pageSize (APISIMP-CHANNEL-PAGESZ-MAX)
-          pageSize: 500,
+          pageSize: MAX_CHANNEL_PAGE_SIZE,
         }),
         channelListingApi.value.getContainer({ appId }).catch(() => undefined),
       ]);

--- a/frontend/utils/channelConstants.ts
+++ b/frontend/utils/channelConstants.ts
@@ -1,0 +1,10 @@
+/**
+ * Server-side @Max on the `listChannels` pageSize endpoint parameter
+ * (APISIMP-CHANNEL-PAGESZ-MAX / CHANNELS-PAGESIZE-500-FIX-2026-07-02).
+ *
+ * Values above this cause a 400 constraint-violation response; the channel
+ * table reads empty and the Trace3D render sees no channels.  All frontend
+ * fetch sites must use this constant so a single-point change keeps them
+ * in sync with the backend cap.
+ */
+export const MAX_CHANNEL_PAGE_SIZE = 500;

--- a/frontend/utils/shapesRenderChannels.ts
+++ b/frontend/utils/shapesRenderChannels.ts
@@ -15,6 +15,7 @@ import type {
   TimeseriesChannelV2,
   TimeseriesWithDataPoints,
 } from "@dlr-shepard/backend-client";
+import { MAX_CHANNEL_PAGE_SIZE } from "~/utils/channelConstants";
 
 export interface ChannelTuple5 {
   measurement: string;
@@ -78,10 +79,7 @@ export async function fetchChannelListByAppId(
   const appId = containerAppId.trim();
   if (!appId) return [];
   try {
-    // 500 is the server-side @Max on listChannels pageSize
-    // (APISIMP-CHANNEL-PAGESZ-MAX); larger values 400 with a constraint
-    // violation and the Trace3D render sees an empty channel list.
-    return await api.listContainerChannels({ appId, pageSize: 500 });
+    return await api.listContainerChannels({ appId, pageSize: MAX_CHANNEL_PAGE_SIZE });
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary

- Extracts the server-side `@Max(500)` channel-page-size cap into a single shared constant `MAX_CHANNEL_PAGE_SIZE = 500` in `frontend/utils/channelConstants.ts`
- Wires the constant at all **5 call sites** that previously had hand-rolled `500` literals (3 with inline comments, 2 silent)
- Adds `e2e/tests/uiverify-trace3d-smoke.spec.ts` with two tests as regression guard for the CHANNELS-PAGESIZE-500-FIX class of silent breakage

Closes backlog row `TRACE3D-E2E-SMOKE-2026-07-02`.

## Changed files

| File | Change |
|---|---|
| `frontend/utils/channelConstants.ts` | **new** — exports `MAX_CHANNEL_PAGE_SIZE = 500` with doc comment citing APISIMP-CHANNEL-PAGESZ-MAX |
| `frontend/utils/shapesRenderChannels.ts` | import + use constant in `fetchChannelListByAppId` |
| `frontend/composables/container/TimeseriesContainerAccessor.ts` | import + use constant for `CHANNEL_PAGE_SIZE` class field |
| `frontend/composables/container/useFetchV2Channels.ts` | import + use constant in URL string |
| `frontend/composables/useChannelsFromTimeseriesRef.ts` | import + use constant for `PAGE_SIZE` + pagination sentinel |
| `frontend/pages/…/timeseriesereferences/[id]/index.vue` | import + use constant in `listContainerChannels` call |
| `e2e/tests/uiverify-trace3d-smoke.spec.ts` | **new** — two tests (see below) |
| `aidocs/16-dispatcher-backlog.md` | row status `queued` → `🔄 PR open (fire-449)` |

## Playwright tests

**Test 1 — data-gated happy path** (`TRACE3D_CONTAINER_APPID` env var required, skipped in CI without it):
- Navigates to the C-shot URL (`/shapes/render?renderer=trace-3d&containerAppId=…&roles=…&startNs=…&endNs=…`)
- Asserts: zero `.v-alert[type="error"]` alerts visible
- Asserts: colorbar `canvas.trace3d-view__colorbar` attached (Trace3DView mounted = data rendered)
- Asserts: Three.js 3D canvas visible (tracePoints.length > 0)
- Asserts: zero JS `pageerror` events

**Test 2 — structural / data-independent** (always runs):
- Navigates to `/shapes/render?renderer=trace-3d` (blank form)
- Asserts: `<h4>Shape render playground</h4>` heading visible (route didn't 500)
- Asserts: zero error alerts on the empty form

## Why this matters

`CHANNELS-PAGESIZE-500-FIX-2026-07-02` showed that a backend `@Max` constraint change silently broke three presentation-deck surfaces for ~1 day because:
1. No e2e covered the full `/shapes/render?renderer=trace-3d` render path
2. The `500` cap was copy-pasted into five places independently — a second cap change would require hunting all of them down again

This PR closes both gaps.

## Test plan

- [x] `npm run typecheck` — clean (0 errors)
- [x] `npm run lint` — 0 errors (18 pre-existing warnings, unchanged)
- [x] `npm run test` — 2645/2645 passed
- [ ] `TRACE3D_CONTAINER_APPID=019ede2a-... npx playwright test uiverify-trace3d-smoke` — requires live shepard.nuclide.systems (CI skips gracefully)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KhnJoN5d3DwfuqbPUitbaP)_