### PR TITLE
fix(apisimp): use ProblemJson + application/problem+json on 410 tombstone methods (APISIMP-TOMBSTONE-BARE-STRING)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/admin/resources/AdminFeaturesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/resources/AdminFeaturesRest.java
@@ -1,5 +1,6 @@
 package de.dlr.shepard.v2.admin.resources;
 
+import de.dlr.shepard.common.exceptions.ProblemJson;
 import de.dlr.shepard.common.util.Constants;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.RequestScoped;
@@ -35,10 +36,19 @@ public class AdminFeaturesRest {
     "Use GET /v2/admin/config/feature-toggles to list toggles and " +
     "PATCH /v2/admin/config/feature-toggles with {\"toggle-name\": true/false} to mutate them.";
 
+  private static final String SUCCESSOR = "/v2/admin/config/feature-toggles";
+
   private static Response gone() {
     return Response.status(Response.Status.GONE)
-      .header("Link", "</v2/admin/config/feature-toggles>; rel=\"successor-version\"")
-      .entity(GONE_DETAIL)
+      .type("application/problem+json")
+      .header("Location", SUCCESSOR)
+      .header("Link", "<" + SUCCESSOR + ">; rel=\"successor-version\"")
+      .entity(new ProblemJson(
+        "urn:shepard:error:gone",
+        "Gone",
+        Response.Status.GONE.getStatusCode(),
+        GONE_DETAIL,
+        null))
       .build();
   }
 

--- a/backend/src/main/java/de/dlr/shepard/v2/filecontainer/resources/FileContainerStatsRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/filecontainer/resources/FileContainerStatsRest.java
@@ -1,5 +1,6 @@
 package de.dlr.shepard.v2.filecontainer.resources;
 
+import de.dlr.shepard.common.exceptions.ProblemJson;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -7,6 +8,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -24,9 +26,6 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Tag(name = "File containers — stats (tombstoned, use /v2/containers/{appId}/stats)")
 public class FileContainerStatsRest {
 
-  private static final String GONE_MSG =
-    "This path has been removed. Use GET /v2/containers/{appId}/stats instead.";
-
   @GET
   @Path("/{containerAppId}/stats")
   @Operation(
@@ -36,6 +35,18 @@ public class FileContainerStatsRest {
   )
   @APIResponse(responseCode = "410", description = "Endpoint removed. Use GET /v2/containers/{appId}/stats.")
   public Response getStats(@PathParam("containerAppId") String containerAppId) {
-    return Response.status(Response.Status.GONE).entity(GONE_MSG).build();
+    String newLocation = UriBuilder.fromPath("/v2/containers/{appId}/stats")
+      .build(containerAppId)
+      .toString();
+    return Response.status(Response.Status.GONE)
+      .type("application/problem+json")
+      .header("Location", newLocation)
+      .entity(new ProblemJson(
+        "urn:shepard:error:gone",
+        "Gone",
+        Response.Status.GONE.getStatusCode(),
+        "This path has been removed. Use GET " + newLocation + " instead.",
+        null))
+      .build();
   }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/structureddatacontainer/resources/StructuredDataContainerStatsRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/structureddatacontainer/resources/StructuredDataContainerStatsRest.java
@@ -1,5 +1,6 @@
 package de.dlr.shepard.v2.structureddatacontainer.resources;
 
+import de.dlr.shepard.common.exceptions.ProblemJson;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -7,6 +8,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -24,9 +26,6 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Tag(name = "Structured data containers — stats (tombstoned, use /v2/containers/{appId}/stats)")
 public class StructuredDataContainerStatsRest {
 
-  private static final String GONE_MSG =
-    "This path has been removed. Use GET /v2/containers/{appId}/stats instead.";
-
   @GET
   @Path("/{containerAppId}/stats")
   @Operation(
@@ -36,6 +35,18 @@ public class StructuredDataContainerStatsRest {
   )
   @APIResponse(responseCode = "410", description = "Endpoint removed. Use GET /v2/containers/{appId}/stats.")
   public Response getStats(@PathParam("containerAppId") String containerAppId) {
-    return Response.status(Response.Status.GONE).entity(GONE_MSG).build();
+    String newLocation = UriBuilder.fromPath("/v2/containers/{appId}/stats")
+      .build(containerAppId)
+      .toString();
+    return Response.status(Response.Status.GONE)
+      .type("application/problem+json")
+      .header("Location", newLocation)
+      .entity(new ProblemJson(
+        "urn:shepard:error:gone",
+        "Gone",
+        Response.Status.GONE.getStatusCode(),
+        "This path has been removed. Use GET " + newLocation + " instead.",
+        null))
+      .build();
   }
 }

--- a/backend/src/test/java/de/dlr/shepard/v2/admin/resources/AdminFeaturesRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/admin/resources/AdminFeaturesRestTest.java
@@ -2,7 +2,9 @@ package de.dlr.shepard.v2.admin.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import de.dlr.shepard.common.exceptions.ProblemJson;
 import jakarta.annotation.security.RolesAllowed;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,22 +36,26 @@ class AdminFeaturesRestTest {
   }
 
   @Test
-  void listResponseBodyMentionsSuccessorPath() {
+  void listResponseBodyIsProblemJson() {
     var r = resource.list();
-    String body = (String) r.getEntity();
+    ProblemJson body = (ProblemJson) r.getEntity();
     assertNotNull(body);
-    org.junit.jupiter.api.Assertions.assertTrue(
-      body.contains("/v2/admin/config/feature-toggles"),
-      "410 body must reference the successor path"
+    assertTrue(
+      body.detail().contains("/v2/admin/config/feature-toggles"),
+      "410 body detail must reference the successor path"
     );
+    assertEquals("urn:shepard:error:gone", body.type());
   }
 
   @Test
-  void listResponseCarriesLinkHeader() {
+  void listResponseCarriesLocationAndLinkHeaders() {
     var r = resource.list();
+    String location = (String) r.getHeaders().getFirst("Location");
+    assertNotNull(location, "410 response must carry a Location header");
+    assertEquals("/v2/admin/config/feature-toggles", location);
     String link = (String) r.getHeaders().getFirst("Link");
     assertNotNull(link, "410 response must carry a Link header");
-    org.junit.jupiter.api.Assertions.assertTrue(
+    assertTrue(
       link.contains("/v2/admin/config/feature-toggles"),
       "Link header must point to the successor resource"
     );
@@ -62,13 +68,13 @@ class AdminFeaturesRestTest {
   }
 
   @Test
-  void patchResponseBodyMentionsSuccessorPath() {
+  void patchResponseBodyIsProblemJson() {
     var r = resource.patch("any-toggle");
-    String body = (String) r.getEntity();
+    ProblemJson body = (ProblemJson) r.getEntity();
     assertNotNull(body);
-    org.junit.jupiter.api.Assertions.assertTrue(
-      body.contains("/v2/admin/config/feature-toggles"),
-      "410 body must reference the successor path"
+    assertTrue(
+      body.detail().contains("/v2/admin/config/feature-toggles"),
+      "410 body detail must reference the successor path"
     );
   }
 }

--- a/backend/src/test/java/de/dlr/shepard/v2/filecontainer/resources/FileContainerStatsRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/filecontainer/resources/FileContainerStatsRestTest.java
@@ -1,7 +1,9 @@
 package de.dlr.shepard.v2.filecontainer.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import de.dlr.shepard.common.exceptions.ProblemJson;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,5 +34,17 @@ class FileContainerStatsRestTest {
   void returnsGoneForArbitraryAppId() {
     Response r = rest.getStats("00000000-0000-7000-8000-000000000000");
     assertEquals(410, r.getStatus());
+  }
+
+  @Test
+  void responseBodyIsProblemJsonWithLocationHeader() {
+    String appId = "01928eaa-1111-7000-9000-aaaaaaaaaaaa";
+    Response r = rest.getStats(appId);
+    ProblemJson body = (ProblemJson) r.getEntity();
+    assertNotNull(body);
+    assertEquals("urn:shepard:error:gone", body.type());
+    String location = (String) r.getHeaders().getFirst("Location");
+    assertNotNull(location);
+    assertEquals("/v2/containers/" + appId + "/stats", location);
   }
 }

--- a/backend/src/test/java/de/dlr/shepard/v2/structureddatacontainer/resources/StructuredDataContainerStatsRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/structureddatacontainer/resources/StructuredDataContainerStatsRestTest.java
@@ -1,7 +1,9 @@
 package de.dlr.shepard.v2.structureddatacontainer.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import de.dlr.shepard.common.exceptions.ProblemJson;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,5 +34,17 @@ class StructuredDataContainerStatsRestTest {
   void returnsGoneForArbitraryAppId() {
     Response r = rest.getStats("00000000-0000-7000-8000-000000000001");
     assertEquals(410, r.getStatus());
+  }
+
+  @Test
+  void responseBodyIsProblemJsonWithLocationHeader() {
+    String appId = "01928eaa-2222-7000-9000-bbbbbbbbbbbb";
+    Response r = rest.getStats(appId);
+    ProblemJson body = (ProblemJson) r.getEntity();
+    assertNotNull(body);
+    assertEquals("urn:shepard:error:gone", body.type());
+    String location = (String) r.getHeaders().getFirst("Location");
+    assertNotNull(location);
+    assertEquals("/v2/containers/" + appId + "/stats", location);
   }
 }

--- a/plugins/minter-datacite/src/main/java/de/dlr/shepard/plugins/minter/datacite/resources/DataciteAdminRest.java
+++ b/plugins/minter-datacite/src/main/java/de/dlr/shepard/plugins/minter/datacite/resources/DataciteAdminRest.java
@@ -1,5 +1,6 @@
 package de.dlr.shepard.plugins.minter.datacite.resources;
 
+import de.dlr.shepard.common.exceptions.ProblemJson;
 import de.dlr.shepard.common.util.Constants;
 import de.dlr.shepard.plugins.minter.datacite.daos.DataciteHttpClient;
 import de.dlr.shepard.plugins.minter.datacite.daos.DataciteHttpClient.DataciteHttpResponse;
@@ -48,6 +49,7 @@ public class DataciteAdminRest {
   private static final String GONE_MSG =
     "This endpoint has been removed. Use PATCH /v2/admin/config/minter-datacite " +
     "with a 'password' field to set the credential, or 'password': null to clear it.";
+  private static final String GONE_LOCATION = "/v2/admin/config/minter-datacite";
 
   @Inject
   DataciteMinterConfigService service;
@@ -66,7 +68,16 @@ public class DataciteAdminRest {
   )
   @APIResponse(responseCode = "410", description = "Endpoint removed. Use PATCH /v2/admin/config/minter-datacite.")
   public Response setCredential(DataciteCredentialIO body, @Context SecurityContext security) {
-    return Response.status(Response.Status.GONE).entity(GONE_MSG).build();
+    return Response.status(Response.Status.GONE)
+      .type("application/problem+json")
+      .header("Location", GONE_LOCATION)
+      .entity(new ProblemJson(
+        "urn:shepard:error:gone",
+        "Gone",
+        Response.Status.GONE.getStatusCode(),
+        GONE_MSG,
+        null))
+      .build();
   }
 
   // ─── DELETE /credential (tombstoned) ────────────────────────────
@@ -80,7 +91,16 @@ public class DataciteAdminRest {
   )
   @APIResponse(responseCode = "410", description = "Endpoint removed. Use PATCH /v2/admin/config/minter-datacite.")
   public Response clearCredential(@Context SecurityContext security) {
-    return Response.status(Response.Status.GONE).entity(GONE_MSG).build();
+    return Response.status(Response.Status.GONE)
+      .type("application/problem+json")
+      .header("Location", GONE_LOCATION)
+      .entity(new ProblemJson(
+        "urn:shepard:error:gone",
+        "Gone",
+        Response.Status.GONE.getStatusCode(),
+        GONE_MSG,
+        null))
+      .build();
   }
 
   // ─── POST /test-connection ──────────────────────────────────────

--- a/plugins/minter-epic/src/main/java/de/dlr/shepard/plugins/minter/epic/resources/EpicAdminRest.java
+++ b/plugins/minter-epic/src/main/java/de/dlr/shepard/plugins/minter/epic/resources/EpicAdminRest.java
@@ -1,5 +1,6 @@
 package de.dlr.shepard.plugins.minter.epic.resources;
 
+import de.dlr.shepard.common.exceptions.ProblemJson;
 import de.dlr.shepard.common.util.Constants;
 import de.dlr.shepard.plugins.minter.epic.daos.EpicHttpClient;
 import de.dlr.shepard.plugins.minter.epic.daos.EpicHttpClient.EpicHttpResponse;
@@ -48,6 +49,7 @@ public class EpicAdminRest {
   private static final String GONE_MSG =
     "This endpoint has been removed. Use PATCH /v2/admin/config/minter-epic " +
     "with a 'credential' field to set the credential, or 'credential': null to clear it.";
+  private static final String GONE_LOCATION = "/v2/admin/config/minter-epic";
 
   @Inject
   EpicMinterConfigService service;
@@ -66,7 +68,16 @@ public class EpicAdminRest {
   )
   @APIResponse(responseCode = "410", description = "Endpoint removed. Use PATCH /v2/admin/config/minter-epic.")
   public Response setCredential(EpicCredentialIO body, @Context SecurityContext security) {
-    return Response.status(Response.Status.GONE).entity(GONE_MSG).build();
+    return Response.status(Response.Status.GONE)
+      .type("application/problem+json")
+      .header("Location", GONE_LOCATION)
+      .entity(new ProblemJson(
+        "urn:shepard:error:gone",
+        "Gone",
+        Response.Status.GONE.getStatusCode(),
+        GONE_MSG,
+        null))
+      .build();
   }
 
   // ─── DELETE /credential (tombstoned) ────────────────────────────
@@ -80,7 +91,16 @@ public class EpicAdminRest {
   )
   @APIResponse(responseCode = "410", description = "Endpoint removed. Use PATCH /v2/admin/config/minter-epic.")
   public Response clearCredential(@Context SecurityContext security) {
-    return Response.status(Response.Status.GONE).entity(GONE_MSG).build();
+    return Response.status(Response.Status.GONE)
+      .type("application/problem+json")
+      .header("Location", GONE_LOCATION)
+      .entity(new ProblemJson(
+        "urn:shepard:error:gone",
+        "Gone",
+        Response.Status.GONE.getStatusCode(),
+        GONE_MSG,
+        null))
+      .build();
   }
 
   // ─── POST /test-connection ──────────────────────────────────────


### PR DESCRIPTION
## Summary

**Row:** `APISIMP-TOMBSTONE-BARE-STRING` (XS) — identified by sweep agent on fire-462  
**Pattern fix:** Five 410 Gone tombstone methods returned `.entity(plainString).build()` with `Content-Type: application/json` instead of the canonical ProblemJson + `application/problem+json` + `Location` header pattern established by `WikiWriterTombstoneRest` and `GitReferenceRest`.

### Files changed

| File | Change |
|---|---|
| `FileContainerStatsRest.java` | Add `Location: /v2/containers/{appId}/stats` + ProblemJson entity |
| `StructuredDataContainerStatsRest.java` | Same as above |
| `AdminFeaturesRest.java` | Add `Location: /v2/admin/config/feature-toggles` + ProblemJson (keep existing `Link` header) |
| `DataciteAdminRest.java` | Add `Location: /v2/admin/config/minter-datacite` + ProblemJson (POST + DELETE `/credential`) |
| `EpicAdminRest.java` | Add `Location: /v2/admin/config/minter-epic` + ProblemJson (POST + DELETE `/credential`) |

### Tests updated

- `AdminFeaturesRestTest`: cast entity to `ProblemJson`, assert `type()` + `detail()`, assert both `Location` and `Link` headers
- `FileContainerStatsRestTest`: new `responseBodyIsProblemJsonWithLocationHeader()` test
- `StructuredDataContainerStatsRestTest`: same new test

All 31 affected tests green locally.

## Test plan

- [ ] `backend/mvnw -f backend/pom.xml test -pl .` green (JUnit)
- [ ] `plugins/minter-datacite` and `plugins/minter-epic` tests green
- [ ] All 410 responses carry `Content-Type: application/problem+json` + `Location` header + ProblemJson body


---
_Generated by [Claude Code](https://claude.ai/code/session_01YMyKeDmWBbxxyNCqc5xdt9)_