### PR TITLE
fix(apisimp): Bean Validation constraints on BundleGroupsV2Rest.listGroupFiles pagination (APISIMP-BUNDLE-GROUP-FILES-INTEGER-PARAMS)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java
@@ -19,6 +19,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -333,7 +334,7 @@ public class BundleGroupsV2Rest {
     description =
       "Canonical path (APISIMP-BUNDLE-REF-KIND-UNIFY). " +
       "Returns the files attached to the `:FileGroup` identified by `groupAppId`, paginated. " +
-      "`pageSize` default 200; max 1000; out-of-range values are clamped, never rejected. " +
+      "`pageSize` default 200; max 1000. " +
       "Auth: Read permission on the parent DataObject."
   )
   @APIResponse(
@@ -348,15 +349,15 @@ public class BundleGroupsV2Rest {
     @PathParam("bundleAppId") String bundleAppId,
     @PathParam("groupAppId") String groupAppId,
     @Parameter(
-      description = "0-based page index. Default 0.",
+      description = "Zero-based page index (default 0).",
       schema = @Schema(minimum = "0", defaultValue = "0")
     )
-    @QueryParam("page") @DefaultValue("0") Integer page,
+    @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
     @Parameter(
-      description = "Page size; clamped at 1000. Default 200.",
+      description = "Page size, 1–1000 (default 200).",
       schema = @Schema(minimum = "1", maximum = "1000", defaultValue = "200")
     )
-    @QueryParam("pageSize") @DefaultValue("200") Integer pageSize,
+    @QueryParam("pageSize") @DefaultValue("200") @Min(1) @Max(1000) int pageSize,
     @Context SecurityContext securityContext
   ) {
     FileBundleReference bundle = fileBundleReferenceDAO.findByAppId(bundleAppId);
@@ -368,15 +369,12 @@ public class BundleGroupsV2Rest {
     if (parent == null) return problem(PROBLEM_TYPE_NOT_FOUND, "Group not found", Response.Status.NOT_FOUND, "No FileGroup with appId '" + groupAppId + "'.");
     if (!bundleAppId.equals(parent)) return problem(PROBLEM_TYPE_NOT_FOUND, "Group not in bundle", Response.Status.NOT_FOUND, "FileGroup '" + groupAppId + "' does not belong to bundle '" + bundleAppId + "'.");
 
-    int pageIdx = (page == null || page < 0) ? 0 : page;
-    int effectiveSize = (pageSize == null) ? DEFAULT_FILES_PAGE_SIZE : Math.min(MAX_FILES_PAGE_SIZE, Math.max(1, pageSize));
-
     long total = fileGroupService.countFiles(groupAppId);
-    int totalPages = effectiveSize == 0 ? 0 : (int) ((total + effectiveSize - 1) / effectiveSize);
-    int skip = pageIdx * effectiveSize;
-    List<ShepardFile> items = skip < total ? fileGroupService.listFiles(groupAppId, skip, effectiveSize) : List.of();
+    int totalPages = (int) ((total + pageSize - 1) / pageSize);
+    int skip = page * pageSize;
+    List<ShepardFile> items = skip < total ? fileGroupService.listFiles(groupAppId, skip, pageSize) : List.of();
 
-    return Response.ok(new PagedFilesIO(items, pageIdx, effectiveSize, total, totalPages)).build();
+    return Response.ok(new PagedFilesIO(items, page, pageSize, total, totalPages)).build();
   }
 
   // ─── upload file into a group ─────────────────────────────────────────────

--- a/backend/src/test/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2RestTest.java
@@ -290,13 +290,14 @@ class BundleGroupsV2RestTest {
   }
 
   @Test
-  void listGroupFiles_clampsOversizedPageSize() {
+  void listGroupFiles_acceptsMaxPageSize() {
+    // Bean Validation (@Max(1000)) rejects pageSize > 1000 at the JAX-RS layer.
+    // Unit tests bypass BV, so we verify the boundary value (1000) passes correctly.
     when(fileBundleReferenceDAO.findByAppId(BUNDLE_APP_ID)).thenReturn(existingBundle());
     when(fileGroupService.findBundleAppIdForGroup(GROUP_APP_ID)).thenReturn(BUNDLE_APP_ID);
     when(fileGroupService.countFiles(GROUP_APP_ID)).thenReturn(0L);
 
-    // pageSize=9999 should be clamped to 1000, not rejected
-    var r = resource.listGroupFiles(BUNDLE_APP_ID, GROUP_APP_ID, 0, 9999, securityContext);
+    var r = resource.listGroupFiles(BUNDLE_APP_ID, GROUP_APP_ID, 0, BundleGroupsV2Rest.MAX_FILES_PAGE_SIZE, securityContext);
     assertEquals(200, r.getStatus());
     var envelope = (PagedFilesIO) r.getEntity();
     assertEquals(BundleGroupsV2Rest.MAX_FILES_PAGE_SIZE, envelope.getSize());


### PR DESCRIPTION
## What

Replace boxed `Integer` pagination params + manual null-clamping in
`BundleGroupsV2Rest.listGroupFiles()` with the canonical primitive `int` +
Bean Validation constraint pattern used by every other v2 paginated endpoint.

**Backlog row:** `APISIMP-BUNDLE-GROUP-FILES-INTEGER-PARAMS`
**Size:** XS
**Fire:** 463

## Why

`GET /v2/bundles/{bundleAppId}/groups/{groupAppId}/files` was the only v2
paginated endpoint that used boxed `Integer` params with manual null-clamping:

```java
@QueryParam("page") @DefaultValue("0") Integer page,
@QueryParam("pageSize") @DefaultValue("200") Integer pageSize,
// …
int pageIdx = (page == null || page < 0) ? 0 : page;
int effectiveSize = (pageSize == null) ? DEFAULT_FILES_PAGE_SIZE
    : Math.min(MAX_FILES_PAGE_SIZE, Math.max(1, pageSize));
```

The `@DefaultValue` annotations already make the null branches unreachable (JAX-RS
fills in the default when the param is absent). The clamping duplicates what
`@PositiveOrZero`, `@Min(1)`, `@Max(1000)` express declaratively — producing
slightly different behaviour (silent clamping vs. standard 400 rejection).

## Changes

- `BundleGroupsV2Rest.java`
  - `Integer page` → `@PositiveOrZero int page`
  - `Integer pageSize` → `@Min(1) @Max(1000) int pageSize`
  - Added `import jakarta.validation.constraints.PositiveOrZero`
  - Removed manual null-clamp block; use params directly

- `BundleGroupsV2RestTest.java`
  - Replaced `clampsOversizedPageSize` test (old clamping behaviour) with
    `acceptsMaxPageSize` test (valid boundary value at 1000) + BV comment

## AC

- `listGroupFiles` uses primitive `int` + Bean Validation constraints
- Manual null-clamp block removed
- `mvn verify -pl backend` green (CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JGehVkZmxazg2dJcLTrwzo)_