### PR TITLE
fix(APISIMP-DEAD-SCHEMATYPE-IMPORTS): remove unused SchemaType imports from 9 v2 REST resources

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/admin/semantic/OntologyGitSourceRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/semantic/OntologyGitSourceRest.java
@@ -35,7 +35,6 @@ import jakarta.ws.rs.DefaultValue;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;

--- a/backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java
@@ -45,7 +45,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionV2Rest.java
@@ -46,7 +46,6 @@ import de.dlr.shepard.v2.common.io.PagedResponseIO;
 import java.io.IOException;
 import java.util.Set;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
@@ -29,7 +29,6 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;

--- a/backend/src/main/java/de/dlr/shepard/v2/notifications/resources/NotificationRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/notifications/resources/NotificationRest.java
@@ -26,7 +26,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;

--- a/backend/src/main/java/de/dlr/shepard/v2/notifications/transport/resources/NotificationTransportRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/notifications/transport/resources/NotificationTransportRest.java
@@ -26,7 +26,6 @@ import jakarta.ws.rs.core.Response.Status;
 import java.util.List;
 import java.util.Optional;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;

--- a/backend/src/main/java/de/dlr/shepard/v2/project/resources/ProjectsRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/project/resources/ProjectsRest.java
@@ -23,7 +23,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/CollectionTemplatesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/CollectionTemplatesRest.java
@@ -30,7 +30,6 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.util.List;
 import java.util.Optional;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;

--- a/backend/src/main/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRest.java
@@ -26,7 +26,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;


### PR DESCRIPTION
## Summary

- Nine v2 REST resources imported `org.eclipse.microprofile.openapi.annotations.enums.SchemaType` but had **zero body references** to `SchemaType.*` — dead code left over from APISIMP refactors that migrated list endpoints to `PagedResponseIO` or removed `SchemaType.ARRAY` annotations.
- Detected by fire-470 APISIMP sweep (`aidocs/agent-findings/apisimp-sweep-fire470-2026-07-08.md §A1`).
- Tracked as `APISIMP-DEAD-SCHEMATYPE-IMPORTS` in `aidocs/16`.

**Files changed (9 deletions, 1 per file):**

| File | Import removed |
|------|----------------|
| `v2/watches/resources/CollectionWatchesRest.java` | list endpoint already uses `@Schema(implementation=PagedResponseIO.class)` |
| `v2/labjournal/resources/CollectionLabJournalEntriesRest.java` | dead import |
| `v2/notifications/resources/NotificationRest.java` | dead import |
| `v2/notifications/transport/resources/NotificationTransportRest.java` | dead import |
| `v2/project/resources/ProjectsRest.java` | dead import |
| `v2/admin/semantic/OntologyGitSourceRest.java` | dead import |
| `v2/bundle/resources/BundleGroupsV2Rest.java` | dead import |
| `v2/collection/resources/CollectionV2Rest.java` | dead import |
| `v2/template/resources/CollectionTemplatesRest.java` | dead import |

**No runtime change.** Annotation-only cleanup. All 5581 unit tests pass; `mvn compile` clean.

**Files legitimately keeping `SchemaType` (not touched):** `NotebookRest` (ARRAY for bare list), `AdminUserGitCredentialRest` (ARRAY for bounded bare list), `AdminConfigRest` (ARRAY), `OntologyAlignmentRest` (ARRAY), `DataObjectV2Rest` (documented deviation), `DataObjectBatchV2Rest` (ARRAY in @RequestBody, not @APIResponse), `ImportDiagnosticsV2Rest` (ARRAY for diagnostics), `ContainersV2Rest` (STRING for binary), `LabJournalRenderRest` (STRING for HTML), `DmpSnippetV2Rest` (STRING for Markdown), `TemplatePortabilityRest` (STRING for YAML).

---
_Generated by [Claude Code](https://claude.ai/code/session_0137uELqpQmD8SprCjEoZfw3)_