### PR TITLE
feat(apisimp): add X-Total-Count header to GET /v2/admin/config (APISIMP-ADMIN-CONFIG-NO-XCOUNT)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/admin/config/resources/AdminConfigRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/config/resources/AdminConfigRest.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.core.Response.Status;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -78,7 +79,12 @@ public class AdminConfigRest {
   @APIResponse(
     responseCode = "200",
     description = "Registered config features.",
-    content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = ConfigFeatureIO.class))
+    content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = ConfigFeatureIO.class)),
+    headers = @Header(
+      name = "X-Total-Count",
+      description = "Total number of registered config features.",
+      schema = @Schema(type = SchemaType.INTEGER)
+    )
   )
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks the instance-admin role.")
@@ -87,7 +93,7 @@ public class AdminConfigRest {
       .stream()
       .map(d -> new ConfigFeatureIO(d.featureName(), d.description()))
       .toList();
-    return Response.ok(rows).build();
+    return Response.ok(rows).header("X-Total-Count", (long) rows.size()).build();
   }
 
   @GET

--- a/backend/src/test/java/de/dlr/shepard/v2/admin/config/resources/AdminConfigRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/admin/config/resources/AdminConfigRestTest.java
@@ -97,6 +97,24 @@ class AdminConfigRestTest {
   }
 
   @Test
+  void listFeaturesEmitsXTotalCountHeader() {
+    Mockito.when(registry.all()).thenReturn(List.of(new FakeDescriptor(), new FakeDescriptor()));
+    Response resp = rest.listFeatures();
+    assertEquals(200, resp.getStatus());
+    Object header = resp.getHeaders().getFirst("X-Total-Count");
+    assertNotNull(header, "X-Total-Count header must be present on GET /v2/admin/config");
+    assertEquals(2L, header);
+  }
+
+  @Test
+  void listFeaturesXTotalCountIsZeroWhenRegistryEmpty() {
+    Mockito.when(registry.all()).thenReturn(List.of());
+    Response resp = rest.listFeatures();
+    assertEquals(200, resp.getStatus());
+    assertEquals(0L, resp.getHeaders().getFirst("X-Total-Count"));
+  }
+
+  @Test
   void getKnownFeatureDelegatesToDescriptor() {
     Mockito.when(registry.resolve("fake")).thenReturn(Optional.of(new FakeDescriptor()));
     Response resp = rest.getConfig("fake");


### PR DESCRIPTION
## What

`GET /v2/admin/config` (`AdminConfigRest.listFeatures()`) returned a bare `List<ConfigFeatureIO>` without an `X-Total-Count` response header — inconsistent with every other v2 list endpoint after the fire-475 `APISIMP-XCOUNT-BATCH-2` batch.

Identified by `apisimp-sweep-fire477-2026-07-08.md §F1`.

## Changes

**`AdminConfigRest.java`**
- Chain `.header("X-Total-Count", (long) rows.size())` on the `listFeatures()` response builder.
- Add `@Header` annotation to the 200 `@APIResponse` so the OpenAPI spec documents the header.
- Import `org.eclipse.microprofile.openapi.annotations.headers.Header`.

**`AdminConfigRestTest.java`**
- `listFeaturesEmitsXTotalCountHeader()` — asserts header is present and equals the list size.
- `listFeaturesXTotalCountIsZeroWhenRegistryEmpty()` — edge case: empty registry → `X-Total-Count: 0`.

## Test results

```
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0  ← AdminConfigRestTest (all pass)
```

## Backlog

- Row `APISIMP-ADMIN-CONFIG-NO-XCOUNT` filed in `aidocs/16` (committed to main, fire-477 sweep).
- Sweep doc: `aidocs/agent-findings/apisimp-sweep-fire477-2026-07-08.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyMbgGup5DvF4ENbPwhd6Y)_