### PR TITLE
fix(apisimp): annotation minor batch 1 — tag pageSize cap + neo4jNodeId deprecated

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/admin/io/PermissionAuditEntryIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/io/PermissionAuditEntryIO.java
@@ -20,8 +20,10 @@ public class PermissionAuditEntryIO {
   @Schema(
     required = true,
     nullable = true,
+    deprecated = true,
     description =
-      "Neo4j internal node id of the orphan entity — exposed here as a triage handle when appId is null (pre-migration rows)."
+      "Neo4j internal node id of the orphan entity — exposed here as a triage handle when appId is null (pre-migration rows). " +
+      "Will be removed once all entities carry a non-null appId (post-L2 migration)."
   )
   private Long neo4jNodeId;
 

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
@@ -292,8 +292,8 @@ public class ShepardTemplateRest {
     operationId = "tags",
     summary = "Distinct list of tags across all non-retired templates.",
     description = "Used by the picker UI's tag-autocomplete. Optionally narrow to one templateKind. " +
-    "Server-side cap: at most 500 distinct tags are returned (alphabetically first 500). " +
-    "Pagination: `page` (0-based, default 0) and `pageSize` (1–500, default 50). " +
+    "Server-side cap: at most 200 distinct tags are returned (alphabetically first 200). " +
+    "Pagination: `page` (0-based, default 0) and `pageSize` (1–200, default 50). " +
     "`X-Total-Count` header carries the total before paging."
   )
   @APIResponse(
@@ -305,7 +305,7 @@ public class ShepardTemplateRest {
   public Response tags(
     @Parameter(description = "Filter to a single templateKind.") @QueryParam("kind") String kind,
     @Parameter(description = "Zero-based page index.") @DefaultValue("0") @QueryParam("page") @PositiveOrZero int page,
-    @Parameter(description = "Page size (1–500). Default 50.") @DefaultValue("50") @QueryParam("pageSize") @Min(1) @Max(500) int pageSize,
+    @Parameter(description = "Page size (1–200). Default 50.") @DefaultValue("50") @QueryParam("pageSize") @Min(1) @Max(200) int pageSize,
     @Context SecurityContext securityContext
   ) {
     if (securityContext.getUserPrincipal() == null) return problem(PT_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, null);

--- a/backend/src/test/java/de/dlr/shepard/v2/admin/io/PermissionAuditEntryIOTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/admin/io/PermissionAuditEntryIOTest.java
@@ -24,4 +24,12 @@ class PermissionAuditEntryIOTest {
     org.junit.jupiter.api.Assertions.assertNull(io.getLabels());
     org.junit.jupiter.api.Assertions.assertNull(io.getName());
   }
+
+  @Test
+  void neo4jNodeId_schemaAnnotation_isDeprecated() throws NoSuchFieldException {
+    var field = PermissionAuditEntryIO.class.getDeclaredField("neo4jNodeId");
+    var schema = field.getAnnotation(org.eclipse.microprofile.openapi.annotations.media.Schema.class);
+    org.junit.jupiter.api.Assertions.assertNotNull(schema, "neo4jNodeId must have @Schema annotation");
+    org.junit.jupiter.api.Assertions.assertTrue(schema.deprecated(), "neo4jNodeId @Schema must be deprecated=true (will be removed post-L2 migration)");
+  }
 }

--- a/backend/src/test/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRestTest.java
@@ -291,6 +291,19 @@ class ShepardTemplateRestTest {
   }
 
   @Test
+  void tags_pageSizeParam_hasMaxConstraintOf200() throws NoSuchMethodException {
+    java.lang.reflect.Method m = ShepardTemplateRest.class.getMethod(
+        "tags", String.class, int.class, int.class, jakarta.ws.rs.core.SecurityContext.class);
+    java.lang.reflect.Parameter param = java.util.Arrays.stream(m.getParameters())
+        .filter(p -> { var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class); return qp != null && "pageSize".equals(qp.value()); })
+        .findFirst().orElse(null);
+    assertNotNull(param, "tags.pageSize must carry @QueryParam");
+    var max = param.getAnnotation(jakarta.validation.constraints.Max.class);
+    assertNotNull(max, "tags.pageSize must have @Max constraint");
+    assertEquals(200L, max.value(), "tags.pageSize @Max must be 200 (same as list endpoint)");
+  }
+
+  @Test
   void createReturns400OnMalformedJson() {
     var body = new CreateShepardTemplateIO("Recipe", "EXPERIMENT_RECIPE", "{ not valid json", null, null, null, null);
     Response r = resource.create(body, securityContext);


### PR DESCRIPTION
## Summary

Two XS annotation fixes from the fire-478 APISIMP sweep (`apisimp-sweep-fire478-2026-07-08.md`):

### APISIMP-TPLREST-TAG-PAGECAP
`ShepardTemplateRest.tags()` (`GET /v2/templates/tags`) declared `@Max(500)` on `pageSize` while `GET /v2/templates` on the same class and 32 other v2 list endpoints all use `@Max(200)`. No documented reason for the divergent cap.

- `@Max(500)` → `@Max(200)` on `pageSize` parameter
- Description strings updated: "at most 500 distinct tags" → "at most 200 distinct tags", "1–500" → "1–200" in two places
- Reflection test added: `tags_pageSizeParam_hasMaxConstraintOf200` (same pattern as `CollectionV2RestTest.list_pageSizeParam_hasMaxConstraint`)

### APISIMP-PERM-AUDIT-DEPRECATED
`PermissionAuditEntryIO.neo4jNodeId` exposes a raw Neo4j internal node ID on the v2 wire. The field is intentional for pre-migration (L2) triage rows, but the `@Schema` lacked `deprecated = true`, signalling no removal intent once the L2 migration completes and all entities carry a non-null `appId`.

- Added `deprecated = true` to the `@Schema` annotation
- Description extended with removal note: "Will be removed once all entities carry a non-null appId (post-L2 migration)"
- Reflection test added: `neo4jNodeId_schemaAnnotation_isDeprecated`

## Test plan

- [x] `ShepardTemplateRestTest` — 33 tests pass (includes new `tags_pageSizeParam_hasMaxConstraintOf200`)
- [x] `PermissionAuditEntryIOTest` — 3 tests pass (includes new `neo4jNodeId_schemaAnnotation_isDeprecated`)
- [ ] CI unit-test gate green

## Backlog rows

- `APISIMP-TPLREST-TAG-PAGECAP` (XS) — this PR
- `APISIMP-PERM-AUDIT-DEPRECATED` (XS) — this PR
- `APISIMP-PROBLEM-DEDUP` (M) — queued, next batch
- `APISIMP-XCOUNT-OPENAPI-HEADER` (M) — queued, next batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiybtpUfnUd7V5PcEsETFU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiybtpUfnUd7V5PcEsETFU)_