### PR TITLE
feat(APISIMP-XCOUNT-OPENAPI-HEADER-2): add @Header X-Total-Count to AAS plugin REST endpoints

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4397,7 +4397,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionContainersRest.java:76`; apisimp-sweep-fire478-2026-07-08.md §F2.
 
 ## APISIMP-XCOUNT-OPENAPI-HEADER-2 — Plugin REST classes missing formal @Header X-Total-Count declaration (size: XS, sweep: fire-479)
-- **Status:** ✅ shipped (fire-480, PR #TBD, branch `APISIMP-XCOUNT-OPENAPI-HEADER-2-1`).
+- **Status:** ✅ shipped (fire-480, PR #2412, branch `APISIMP-XCOUNT-OPENAPI-HEADER-2-1`).
 - **Why:** The fire-479 batch covered all `/v2/` in-tree REST classes. Two plugin REST classes also emit `X-Total-Count` at runtime but lack the formal `@Header` OpenAPI declaration: `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/resources/AasRegistrationAdminRest.java:85` and `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java:122,213`.
 - **Fix:** Same pattern as APISIMP-XCOUNT-OPENAPI-HEADER-1 — add `headers = @Header(...)` to each `@APIResponse(responseCode="200")` block. Import `Header` and `SchemaType` in each plugin file.
 - **First refs:** `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/resources/AasRegistrationAdminRest.java:85`; `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java:122,213`.

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4397,7 +4397,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionContainersRest.java:76`; apisimp-sweep-fire478-2026-07-08.md §F2.
 
 ## APISIMP-XCOUNT-OPENAPI-HEADER-2 — Plugin REST classes missing formal @Header X-Total-Count declaration (size: XS, sweep: fire-479)
-- **Status:** 🔄 queued (next fire).
+- **Status:** ✅ shipped (fire-480, PR #TBD, branch `APISIMP-XCOUNT-OPENAPI-HEADER-2-1`).
 - **Why:** The fire-479 batch covered all `/v2/` in-tree REST classes. Two plugin REST classes also emit `X-Total-Count` at runtime but lack the formal `@Header` OpenAPI declaration: `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/resources/AasRegistrationAdminRest.java:85` and `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java:122,213`.
 - **Fix:** Same pattern as APISIMP-XCOUNT-OPENAPI-HEADER-1 — add `headers = @Header(...)` to each `@APIResponse(responseCode="200")` block. Import `Header` and `SchemaType` in each plugin file.
 - **First refs:** `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/resources/AasRegistrationAdminRest.java:85`; `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java:122,213`.

--- a/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/resources/AasRegistrationAdminRest.java
+++ b/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/resources/AasRegistrationAdminRest.java
@@ -22,6 +22,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
@@ -67,7 +69,12 @@ public class AasRegistrationAdminRest {
   @APIResponse(
     responseCode = "200",
     description = "Paged outbox rows (may be empty if no collections exist or no registry is configured).",
-    content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
+    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)),
+    headers = @Header(
+      name = "X-Total-Count",
+      description = "Total element count before paging.",
+      schema = @Schema(type = SchemaType.INTEGER)
+    )
   )
   @APIResponse(responseCode = "403", description = "Caller lacks the instance-admin role.")
   public Response listRegistrations(

--- a/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java
+++ b/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java
@@ -30,6 +30,7 @@ import java.util.Base64;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
@@ -98,7 +99,12 @@ public class AasShellsRest {
       responseCode = "200",
       description = "Paged list of Shells readable by the caller. " +
           "Envelope: { items[], total, page, pageSize }.",
-      content = @Content(schema = @Schema(implementation = PagedResponseIO.class)))
+      content = @Content(schema = @Schema(implementation = PagedResponseIO.class)),
+      headers = @Header(
+          name = "X-Total-Count",
+          description = "Total element count before paging.",
+          schema = @Schema(type = SchemaType.INTEGER)
+      ))
   @APIResponse(responseCode = "401", description = "Authentication required.")
   public Response listShells(
       @Parameter(description = "Zero-based page number (default 0). Returns 400 when negative.")
@@ -186,7 +192,12 @@ public class AasShellsRest {
       responseCode = "200",
       description = "Paged Submodel references for the requested Shell. " +
           "Envelope: { items[], total, page, pageSize }.",
-      content = @Content(schema = @Schema(implementation = PagedResponseIO.class)))
+      content = @Content(schema = @Schema(implementation = PagedResponseIO.class)),
+      headers = @Header(
+          name = "X-Total-Count",
+          description = "Total element count before paging.",
+          schema = @Schema(type = SchemaType.INTEGER)
+      ))
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "404", description = "Shell not found or caller lacks read access.")
   public Response listSubmodels(


### PR DESCRIPTION
## Summary

Follow-up to PR #2411 (`APISIMP-XCOUNT-OPENAPI-HEADER-1`). The fire-479 batch covered all 37 in-tree `/v2/` REST classes; this XS slice covers the three plugin endpoints that also emit `X-Total-Count` at runtime but were missing the formal OpenAPI `@Header` declaration.

**Three endpoints patched:**
- `AasRegistrationAdminRest.listRegistrations` — `GET /v2/admin/aas/registrations`
- `AasShellsRest.listShells` — `GET /v2/aas/shells`
- `AasShellsRest.listSubmodels` — `GET /v2/aas/shells/{aasId}/submodels`

**Change per endpoint:** added `headers = @Header(name="X-Total-Count", description="Total element count before paging.", schema=@Schema(type=SchemaType.INTEGER))` to the `@APIResponse(responseCode="200")` block, plus the missing `Header` and `SchemaType` imports where absent.

No logic change — the runtime header was already emitted. This is a pure OpenAPI spec completeness fix so generated clients surface the `X-Total-Count` header from these plugin endpoints the same way they do from in-tree endpoints.

**Backlog row:** `APISIMP-XCOUNT-OPENAPI-HEADER-2` → shipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hncw1yCg4TZfLx4VCyHRge)_