### PR TITLE
feat(APISIMP-PROBLEM-DEDUP): extract shared ProblemResponse utility from 74 v2 REST classes

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4385,9 +4385,9 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/admin/config/resources/AdminConfigRest.java:90`; apisimp-sweep-fire477-2026-07-08.md §F1.
 
 ## APISIMP-PROBLEM-DEDUP — 76 v2 REST classes each copy an identical `problem()` helper; no shared utility (size: M, sweep: fire-478)
-- **Status:** 🔄 queued.
+- **Status:** ✅ shipped (fire-480, PR #2413, branch `APISIMP-PROBLEM-DEDUP-1`).
 - **Why:** Every v2 REST class defines the same private `static Response problem(String type, String title, Response.Status status, String detail)` three-liner that calls `new ProblemJson(...)` and sets `application/problem+json`. There is no shared utility at `de.dlr.shepard.v2.common`. 76 independent copies found via grep. This is pure duplication with no semantic variation — all copies call `new ProblemJson(type, title, status.getStatusCode(), detail)` and `.type(MediaType.APPLICATION_JSON)`.
-- **Fix:** Create `de.dlr.shepard.v2.common.ProblemResponse.java` with a `public static Response problem(String type, String title, Response.Status status, String detail)` method. Replace each of the 76 copies with `import static de.dlr.shepard.v2.common.ProblemResponse.problem;` and delete the local method. Batch PR touching 76 files but each diff is trivially small (+1 import, -4 lines).
+- **Fix:** Created `de.dlr.shepard.v2.common.ProblemResponse.java` with 5 overloads covering all variant signatures found in the codebase (4-arg `(String,String,Status,String)`, `(Status,String,String,String)`, `(String,String,int,String)`, 5-arg with `Map<String,Object> ext`, and 2-arg `(Status,String)` with status→type switch). Replaced 74 files (71 in-tree + 6 plugins; 3 files had 2 problem() methods) with `import static de.dlr.shepard.v2.common.ProblemResponse.problem;` and deleted all local methods.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionContainersRest.java:115`; apisimp-sweep-fire478-2026-07-08.md §F1.
 
 ## APISIMP-XCOUNT-OPENAPI-HEADER — 37 list endpoints emit X-Total-Count but omit the formal @Header OpenAPI declaration (size: M, sweep: fire-478)

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/jupyter/resources/JupyterConfigPublicRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/jupyter/resources/JupyterConfigPublicRest.java
@@ -18,6 +18,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * J1e — public read-only view of the {@code :JupyterConfig} singleton
@@ -80,8 +81,4 @@ public class JupyterConfigPublicRest {
     return Response.ok(JupyterConfigIO.from(cfg, service.getDefaultHubUrl())).build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/ledger/LedgerAnchorRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/ledger/LedgerAnchorRest.java
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * Admin endpoints for distributed-ledger anchoring of {@code prov:Activity} records.
@@ -50,11 +51,6 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 public class LedgerAnchorRest {
 
   private static final String PT_NOT_IMPLEMENTED = "/problems/ledger.not-implemented";
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 
   // -----------------------------------------------------------------------
   // POST /v2/admin/ledger/anchor

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/resources/InstanceAdminRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/resources/InstanceAdminRest.java
@@ -49,6 +49,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * The {@code /v2/admin/instance-admins} + {@code /v2/admin/permission-audit}
@@ -69,11 +70,6 @@ public class InstanceAdminRest {
 
   private static final String PT_NOT_FOUND = "/problems/instance-admin.not-found";
   private static final String PT_BAD_REQUEST = "/problems/instance-admin.bad-request";
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 
   @Inject
   InstanceAdminService instanceAdminService;

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/users/AdminUserGitCredentialRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/users/AdminUserGitCredentialRest.java
@@ -34,6 +34,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * Admin preseed endpoint for git credentials — lets an instance-admin set a
@@ -295,11 +296,6 @@ public class AdminUserGitCredentialRest {
     String encrypted = AesGcmCipher.encrypt(body.newPat(), key);
     gitCredentialDAO.rotateByUserAndAppId(targetUsername, credAppId, encrypted);
     return Response.noContent().build();
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   private byte[] resolveKey() {

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/users/AdminUserOrcidRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/users/AdminUserOrcidRest.java
@@ -21,6 +21,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * U1a-admin — instance-admin route to set ORCID on someone else's
@@ -94,8 +95,4 @@ public class AdminUserOrcidRest {
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java
@@ -54,6 +54,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * SEMA-V6-004 — polymorphic REST surface for semantic annotations.
@@ -1102,11 +1103,6 @@ public class SemanticAnnotationV2Rest {
   private static Response notFound(String kind, String id) {
     return problem(PROBLEM_TYPE_NOT_FOUND, "Not found",
       Response.Status.NOT_FOUND, kind + " with appId '" + id + "' not found.");
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   private static boolean blank(String s) {

--- a/backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java
@@ -55,6 +55,7 @@ import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * Groups sub-resource for {@code FileBundleReference} under the unified
@@ -462,11 +463,6 @@ public class BundleGroupsV2Rest {
           "Caller does not have " + accessType + " access to the parent DataObject.");
     }
     return null;
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   private Map<String, Object> jsonNodeToMap(JsonNode node) {

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionContainersRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionContainersRest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * CC2 — list containers referenced within a Collection.
@@ -119,8 +120,4 @@ public class CollectionContainersRest {
       .build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionCrossTimelineRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionCrossTimelineRest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * COLL-TIMELINE-CROSS-1 — {@code GET /v2/collections/timeline}.
@@ -199,8 +200,4 @@ public class CollectionCrossTimelineRest {
     return out;
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionExportUrlRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionExportUrlRest.java
@@ -34,6 +34,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * FS1g — {@code POST /v2/collections/{appId}/export-url}.
@@ -180,8 +181,4 @@ public class CollectionExportUrlRest {
     return name.replaceAll("[^a-zA-Z0-9._-]", "_");
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionPermissionsRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionPermissionsRest.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code /v2/collections/{appId}/permissions} and
@@ -195,8 +196,4 @@ public class CollectionPermissionsRest {
       Response.Status.FORBIDDEN, "caller lacks required access on Collection '" + appId + "'");
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionPropertiesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionPropertiesRest.java
@@ -25,6 +25,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code /v2/collections/{appId}/properties} REST surface for the
@@ -155,8 +156,4 @@ public class CollectionPropertiesRest {
     return Response.ok(CollectionPropertiesIO.from(saved)).build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionPublicationStateRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionPublicationStateRest.java
@@ -33,6 +33,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.neo4j.ogm.model.Result;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * #27-ARCHIVED — owner-or-instance-admin gated PATCH for a Collection's
@@ -208,8 +209,4 @@ public class CollectionPublicationStateRest {
     );
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionSceneGraphRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionSceneGraphRest.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * V2CONV-B4 — {@code /v2/collections/{appId}/scene-graph} REST surface for the
@@ -226,11 +227,6 @@ public class CollectionSceneGraphRest {
 
   private static String callerOf(SecurityContext sc) {
     return sc != null && sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   /** For status codes not in the JAX-RS 3.1 Status enum (e.g. 422 Unprocessable Entity). */

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionStreamExportRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionStreamExportRest.java
@@ -22,6 +22,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * EXPORT-V2-STREAM — {@code GET /v2/collections/{appId}/export}.
@@ -112,8 +113,4 @@ public class CollectionStreamExportRest {
     return name.replaceAll("[^a-zA-Z0-9_-]", "_");
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionTimelineRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionTimelineRest.java
@@ -30,6 +30,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * COLL-TIMELINE-1 — {@code GET /v2/collections/{appId}/timeline}.
@@ -157,8 +158,4 @@ public class CollectionTimelineRest {
       .build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionV2Rest.java
@@ -55,6 +55,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * L2d Phase A — {@code /v2/collections}: the canonical Collection CRUD on
@@ -428,8 +429,4 @@ public class CollectionV2Rest {
     return null;
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-        .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/resources/CollectionWatchersRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/resources/CollectionWatchersRest.java
@@ -32,6 +32,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * CW1 — Collection watching (user subscribes to a Collection) REST surface.
@@ -199,8 +200,4 @@ public class CollectionWatchersRest {
       Response.Status.NOT_FOUND, detail);
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/common/ProblemResponse.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/common/ProblemResponse.java
@@ -1,0 +1,49 @@
+package de.dlr.shepard.v2.common;
+
+import de.dlr.shepard.common.exceptions.ProblemJson;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+
+/** Shared RFC 7807 problem-response factory; replaces per-class private {@code problem()} helpers. */
+public final class ProblemResponse {
+
+  private static final String PROBLEM_JSON = "application/problem+json";
+
+  private ProblemResponse() {}
+
+  public static Response problem(String type, String title, Response.Status status, String detail) {
+    return Response.status(status).type(PROBLEM_JSON)
+        .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
+  }
+
+  public static Response problem(Response.Status status, String type, String title, String detail) {
+    return problem(type, title, status, detail);
+  }
+
+  public static Response problem(String type, String title, int status, String detail) {
+    return Response.status(status).type(PROBLEM_JSON)
+        .entity(new ProblemJson(type, title, status, detail, null)).build();
+  }
+
+  public static Response problem(String type, String title, Response.Status status, String detail,
+      Map<String, Object> ext) {
+    return Response.status(status).type(PROBLEM_JSON)
+        .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null, ext)).build();
+  }
+
+  /** Derives {@code type} and {@code title} from the HTTP status. */
+  public static Response problem(Response.Status status, String detail) {
+    String type = switch (status) {
+      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
+      case FORBIDDEN -> "urn:shepard:error:forbidden";
+      case BAD_REQUEST -> "urn:shepard:error:validation";
+      case NOT_FOUND -> "urn:shepard:error:not-found";
+      case CONFLICT -> "urn:shepard:error:conflict";
+      case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
+      default -> "urn:shepard:error:internal";
+    };
+    return Response.status(status).type(PROBLEM_JSON)
+        .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
+        .build();
+  }
+}

--- a/backend/src/main/java/de/dlr/shepard/v2/container/resources/ContainerPublicationStateRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/container/resources/ContainerPublicationStateRest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.neo4j.ogm.model.Result;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * #27-ARCHIVED — owner-or-instance-admin gated PATCH for a Container's
@@ -210,8 +211,4 @@ public class ContainerPublicationStateRest {
     );
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/handlers/TimeseriesContainerKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/handlers/TimeseriesContainerKindHandler.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * V2CONV-A3 — in-tree {@link ContainerKindHandler} for {@code kind=timeseries}.
@@ -78,12 +79,6 @@ public class TimeseriesContainerKindHandler implements ContainerKindHandler {
 
   private static final String PT_NOT_FOUND =
       "/problems/timeseries-container-annotations.not-found";
-
-  private static Response problem(
-      String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   @Inject
   TimeseriesContainerService service;

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -65,6 +65,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * V2CONV-A3 — the unified {@code /v2/containers} REST surface that converges
@@ -1590,11 +1591,6 @@ public class ContainersV2Rest {
   }
 
   // ─── helpers ───────────────────────────────────────────────────────────
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   private String callerOrNull(SecurityContext sc) {
     return sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectBatchV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectBatchV2Rest.java
@@ -37,6 +37,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * MFFD-BATCH-01 — {@code POST /v2/data-objects/batch}.
@@ -79,11 +80,6 @@ public class DataObjectBatchV2Rest {
 
   /** Maximum number of items accepted in a single batch request. */
   static final int MAX_BATCH_SIZE = 500;
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   @Inject
   DataObjectService dataObjectService;

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectRdfRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectRdfRest.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * SHAPES-V-PREFILL-2-RDF-ENDPOINT — flat {@code GET /v2/data-objects/{appId}/rdf}
@@ -164,11 +165,6 @@ public class DataObjectRdfRest {
     return Response.ok(turtle, "text/turtle")
       .header("Cache-Control", "max-age=60, must-revalidate")
       .build();
-  }
-
-  private static Response problem(Response.Status status, String type, String title, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   // ─── pure Turtle builder (unit-testable) ────────────────────────────

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
@@ -70,6 +70,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * L2d Phase A.2 — {@code /v2/collections/{collectionAppId}/data-objects}.
@@ -990,11 +991,6 @@ public class DataObjectV2Rest {
       return problem(PROBLEM_TYPE_FORBIDDEN, "Permission denied", Response.Status.FORBIDDEN, "Caller lacks the required permission on this DataObject");
     }
     return null;
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   /**

--- a/backend/src/main/java/de/dlr/shepard/v2/export/rep/RepExportV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/export/rep/RepExportV2Rest.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * TPL14 — Regulatory Evidence Pack (REP) export.
@@ -156,8 +157,4 @@ public class RepExportV2Rest {
     );
   }
 
-  private static Response problem(Response.Status status, String type, String title, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/fair/resources/DmpSnippetV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/fair/resources/DmpSnippetV2Rest.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * FAIR7 — {@code GET /v2/collections/{appId}/dmp-snippet}.
@@ -158,8 +159,4 @@ public class DmpSnippetV2Rest {
     return Response.ok(io.getSnippet(), "text/markdown").build();
   }
 
-  private static Response problem(Response.Status status, String type, String title, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportDiagnosticsV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportDiagnosticsV2Rest.java
@@ -34,6 +34,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * IMP-DIAG — {@code /v2/import/diagnostics}: structured diagnostic log for import runs.
@@ -323,8 +324,4 @@ public class ImportDiagnosticsV2Rest {
       "authentication required");
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportJobsV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportJobsV2Rest.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * IMP2 — {@code POST /v2/import/jobs}: execute a previously-validated import plan.
@@ -251,16 +252,6 @@ public class ImportJobsV2Rest {
   }
 
   // ─── Private helpers ──────────────────────────────────────────────────────
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
-
-  private static Response problem(String type, String title, int status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status, detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   private static String caller(SecurityContext sc) {
     return sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;

--- a/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportLockV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportLockV2Rest.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * IMP-LOCK — {@code /v2/import/lock}: persistent import-in-progress lock.
@@ -275,11 +276,6 @@ public class ImportLockV2Rest {
   }
 
   // ─── Helpers ──────────────────────────────────────────────────────────────
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   private static String caller(SecurityContext sc) {
     return sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;

--- a/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportV2Rest.java
@@ -44,6 +44,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * IMP1 — {@code /v2/import}: dry-run import validation and plan inspection.
@@ -287,11 +288,6 @@ public class ImportV2Rest {
     String commitId = "INVALIDATED".equals(plan.getStatus()) ? null : plan.getCommitId();
 
     return new ImportPlanIO(commitId, plan.getStatus(), expiresAt, summary, warnings, errors);
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   private static String caller(SecurityContext sc) {

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
@@ -36,6 +36,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * UI-020 — bulk fetch of all lab journal entries within a single Collection.
@@ -155,8 +156,4 @@ public class CollectionLabJournalEntriesRest {
         .build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * J1d — {@code GET /v2/lab-journal/{entryAppId}/history}.
@@ -145,8 +146,4 @@ public class LabJournalHistoryRest {
         .build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalRenderRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalRenderRest.java
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * J1a — {@code GET /v2/lab-journal/{appId}/render}.
@@ -125,8 +126,4 @@ public class LabJournalRenderRest {
     return Response.ok(new LabJournalRenderIO(html, sourceLength)).build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/NotebookRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/NotebookRest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * J1b — {@code GET /v2/lab-journal/{dataObjectAppId}/notebooks}.
@@ -200,8 +201,4 @@ public class NotebookRest {
     return filename != null && filename.toLowerCase().endsWith(".ipynb");
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/me/resources/MeRoleInRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/me/resources/MeRoleInRest.java
@@ -20,6 +20,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code GET /v2/me/role-in/{collectionAppId}} — the data backing
@@ -111,8 +112,4 @@ public class MeRoleInRest {
     return Response.ok(new MeRoleInIO(collectionAppId, canRead, canWrite, canManage, isAdmin)).build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/notifications/resources/NotificationAdminRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/notifications/resources/NotificationAdminRest.java
@@ -29,6 +29,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -177,11 +178,6 @@ public class NotificationAdminRest {
     }
     recordTestOutcome(transport, "FAIL", "sender returned false (see backend logs)");
     return problem(PROBLEM_TYPE_BAD_GATEWAY, "Transport error", Response.Status.BAD_GATEWAY, "transport send returned false");
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   /** Persist last-test fields on the transport row. Best-effort — never throws. */

--- a/backend/src/main/java/de/dlr/shepard/v2/notifications/resources/NotificationRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/notifications/resources/NotificationRest.java
@@ -33,6 +33,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -171,8 +172,4 @@ public class NotificationRest {
     return sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/project/resources/ProjectsRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/project/resources/ProjectsRest.java
@@ -30,6 +30,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * PROJ-REST-1 + PROJ-REST-2 — dedicated REST namespace for Project-shaped
@@ -265,11 +266,6 @@ public class ProjectsRest {
     return problem(PROBLEM_TYPE_NOT_FOUND, "Not found",
       Response.Status.NOT_FOUND,
       "Project with appId '" + appId + "' not found.");
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   /** 422 Unprocessable Entity — not a standard {@link Response.Status} enum value. */

--- a/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
@@ -39,6 +39,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code /v2/provenance/...} read endpoints per
@@ -605,11 +606,6 @@ public class ProvenanceRest {
   /** Clamp a user-supplied millis-since-epoch value to a non-negative long. */
   private static long clampToNonNegative(long v) {
     return Math.max(0L, v);
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
   }
 
   private static Response badTimestamp(String raw) {

--- a/backend/src/main/java/de/dlr/shepard/v2/publish/resources/FlatPublicationsRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/publish/resources/FlatPublicationsRest.java
@@ -32,6 +32,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * APISIMP-PUBLICATIONS-KIND-PATH-SEGMENT — kind-agnostic flat alias for the
@@ -146,8 +147,4 @@ public class FlatPublicationsRest {
       .build();
   }
 
-  private static Response problem(Response.Status status, String type, String title, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/publish/resources/PublicationsListRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/publish/resources/PublicationsListRest.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * KIP1k — {@code GET /v2/{kind}/{appId}/publications} list endpoint.
@@ -196,8 +197,4 @@ public class PublicationsListRest {
     return sb.toString();
   }
 
-  private static Response problem(Response.Status status, String type, String title, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/publish/resources/PublishRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/publish/resources/PublishRest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * KIP1a publish surface: {@code POST /v2/{kind}/{appId}/publish}
@@ -266,8 +267,4 @@ public class PublishRest {
     return sb.toString();
   }
 
-  private static Response problem(Response.Status status, String type, String title, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/quality/resources/CollectionDQRRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/quality/resources/CollectionDQRRest.java
@@ -36,6 +36,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * TPL10 — Data Quality Requirements REST surface for Collections.
@@ -225,8 +226,4 @@ public class CollectionDQRRest {
         Response.Status.UNAUTHORIZED, "Authentication is required to access data quality requirements.");
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/quality/resources/IndependenceProofRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/quality/resources/IndependenceProofRest.java
@@ -20,6 +20,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * TPL11 — independence proof endpoint.
@@ -113,8 +114,4 @@ public class IndependenceProofRest {
     return Response.ok(result).build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferencesV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferencesV2Rest.java
@@ -44,6 +44,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * V2CONV-A2 — the unified {@code /v2/references} REST surface that converges
@@ -513,11 +514,6 @@ public class ReferencesV2Rest {
   }
 
   // ─── helpers ───────────────────────────────────────────────────────────
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   private String callerOrNull(SecurityContext sc) {
     return sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;

--- a/backend/src/main/java/de/dlr/shepard/v2/search/resources/SearchV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/search/resources/SearchV2Rest.java
@@ -42,6 +42,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * MISSING-V2-APPID-IN-SEARCH — global full-text search on the v2 surface.
@@ -192,8 +193,4 @@ public class SearchV2Rest {
         .build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/shapes/resources/ShapesApplicableRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/shapes/resources/ShapesApplicableRest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code GET /v2/shapes/applicable?focusAppId=…} — the unified
@@ -258,10 +259,4 @@ public class ShapesApplicableRest {
     }
   }
 
-  private static Response problem(String type, String title, int status, String detail) {
-    return Response.status(status)
-      .type("application/problem+json")
-      .entity(new ProblemJson(type, title, status, detail, null))
-      .build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/CollectionSnapshotRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/CollectionSnapshotRest.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * V2b — {@code /v2/collections/{collectionAppId}/snapshots}.
@@ -217,11 +218,6 @@ public class CollectionSnapshotRest {
   }
 
   // ── private helpers ───────────────────────────────────────────────────────
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   /**
    * Returns {@code null} when access is allowed; otherwise a short-circuit

--- a/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotDiffRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotDiffRest.java
@@ -29,6 +29,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * V2e — {@code GET /v2/snapshots/{aAppId}/diff/{bAppId}}.
@@ -82,11 +83,6 @@ public class SnapshotDiffRest {
 
   private static final String PT_UNAUTH = "/problems/snapshots.unauthorized";
   private static final String PT_NOT_FOUND = "/problems/snapshots.not-found";
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   /**
    * Diff two snapshots.

--- a/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotListRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotListRest.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * SNAPSHOT-LIST-1-REST — cross-collection paginated snapshot list at
@@ -95,11 +96,6 @@ public class SnapshotListRest {
 
   private static final String PT_UNAUTH = "/problems/snapshots.unauthorized";
   private static final String PT_NOT_FOUND = "/problems/snapshots.not-found";
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   @GET
   @Operation(

--- a/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotPinnedReadRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotPinnedReadRest.java
@@ -33,6 +33,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * V2c — {@code GET /v2/collections/{collectionAppId}/snapshots/{snapshotAppId}/data-objects}.
@@ -81,11 +82,6 @@ public class SnapshotPinnedReadRest {
   private static final String PT_FORBIDDEN = "/problems/snapshots.forbidden";
   private static final String PT_NOT_FOUND = "/problems/snapshots.not-found";
   private static final String PT_CONFLICT = "/problems/snapshots.ownership-conflict";
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   /**
    * Returns the DataObject {@code appId} list captured in a snapshot.

--- a/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotRest.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * V2b — {@code /v2/snapshots/{snapshotAppId}}.
@@ -75,11 +76,6 @@ public class SnapshotRest {
   private static final String PT_UNAUTH = "/problems/snapshots.unauthorized";
   private static final String PT_FORBIDDEN = "/problems/snapshots.forbidden";
   private static final String PT_NOT_FOUND = "/problems/snapshots.not-found";
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   /**
    * Read snapshot metadata.

--- a/backend/src/main/java/de/dlr/shepard/v2/sql/resources/SqlTimeseriesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/sql/resources/SqlTimeseriesRest.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * P10a/P10b — {@code POST /v2/sql/timeseries}: JSON DSL bulk read endpoint for timeseries data.
@@ -75,11 +76,6 @@ import java.util.Set;
 public class SqlTimeseriesRest {
 
   private static final String PT_NOT_FOUND = "/problems/sql-timeseries.not-found";
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   /** Hard cap on the number of container IDs per request. */
   private static final int MAX_CONTAINERS = 1000;

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/CollectionTemplatesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/CollectionTemplatesRest.java
@@ -38,6 +38,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code /v2/collections/{appId}/templates/...} — per-Collection
@@ -74,11 +75,6 @@ public class CollectionTemplatesRest {
 
   @Inject
   ShepardTemplateDAO templateDAO;
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   @Inject
   CollectionPropertiesDAO collectionPropsDAO;

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
@@ -41,6 +41,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * Admin-only CRUD over {@code :ShepardTemplate} per
@@ -332,14 +333,4 @@ public class ShepardTemplateRest {
 
   // ─── helpers ───────────────────────────────────────────────────────────────
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail,
-      java.util.Map<String, Object> ext) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null, ext)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateExcelExportRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateExcelExportRest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code GET /v2/templates/{templateAppId}/export?dataObjectAppId=…} —
@@ -225,8 +226,4 @@ public class TemplateExcelExportRest {
     return slug + "-" + dataObject.getAppId() + ".xlsx";
   }
 
-  private static Response problem(String type, String title, int status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status, detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateFormRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateFormRest.java
@@ -30,6 +30,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code GET /v2/templates/{templateAppId}/form} — the form-descriptor
@@ -192,8 +193,4 @@ public class TemplateFormRest {
     }
   }
 
-  private static Response problem(String type, String title, int status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status, detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateInstantiationRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateInstantiationRest.java
@@ -44,6 +44,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code POST /v2/collections/{collectionAppId}/data-objects/from-template/{templateAppId}}
@@ -336,16 +337,6 @@ public class TemplateInstantiationRest {
       return p.substring(1, p.length() - 1);
     }
     return p;
-  }
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
-
-  private static Response problem(String type, String title, int status, String detail) {
-    return Response.status(status).type("application/problem+json")
-      .entity(new ProblemJson(type, title, status, detail, null)).build();
   }
 
   /**

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplatePortabilityRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplatePortabilityRest.java
@@ -36,6 +36,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * YAML round-trip import / export for {@link ShepardTemplate} — the
@@ -370,8 +371,4 @@ public class TemplatePortabilityRest {
     return new ObjectMapper(factory);
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    return Response.status(status).type("application/problem+json")
-        .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null)).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/AnomalyDetectionRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/AnomalyDetectionRest.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * AI1b — rolling-median MAD anomaly detection endpoint.
@@ -65,11 +66,6 @@ public class AnomalyDetectionRest {
   private static final String PT_UNAUTHORIZED = "/problems/anomaly-detection.unauthorized";
   private static final String PT_NOT_FOUND    = "/problems/anomaly-detection.not-found";
   private static final String PT_FORBIDDEN    = "/problems/anomaly-detection.forbidden";
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   private TimeseriesReference resolveRef(String refAppId) {
     return timeseriesReferenceDAO.findByAppId(refAppId);

--- a/backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRest.java
@@ -33,6 +33,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * TS-CROSS-DO-VIEW-1 — cross-DataObject timeseries bulk-data endpoint.
@@ -62,11 +63,6 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 public class CrossDoBulkDataRest {
 
   private static final String PT_UNAUTHORIZED = "/problems/timeseries-cross-do.unauthorized";
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   /** Default LTTB target rows per series (per request body), per the GAP-2 brief. */
   static final int DEFAULT_DOWNSAMPLE_TO = 500;

--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/MePreferencesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/MePreferencesRest.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code GET/PATCH /v2/users/me/preferences} — per-user UI preference storage
@@ -51,11 +52,6 @@ public class MePreferencesRest {
 
   @Inject
   UserService userService;
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   @GET
   @Operation(

--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/MeRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/MeRest.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code PATCH /v2/users/me} — partial update of the caller's User
@@ -172,8 +173,4 @@ public class MeRest {
     return Response.ok(new UserIO(saved)).build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserAvatarByAppIdRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserAvatarByAppIdRest.java
@@ -15,6 +15,7 @@ import org.bson.types.Binary;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * U1e — public GET of another user's avatar by appId. Split out from
@@ -63,8 +64,4 @@ public class UserAvatarByAppIdRest {
         .build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserAvatarRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserAvatarRest.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * U1e — caller's avatar (PUT + DELETE).
@@ -129,8 +130,4 @@ public class UserAvatarRest {
     return Response.noContent().build();
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserGroupV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserGroupV2Rest.java
@@ -44,6 +44,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * V2-SWEEP-002 — appId-keyed user-group CRUD at {@code /v2/user-groups}.
@@ -74,11 +75,6 @@ public class UserGroupV2Rest {
 
   private static final String PT_BAD_REQUEST = "/problems/user-groups.bad-request";
   private static final int MAX_MEMBERS = 500;
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   @GET
   @Operation(

--- a/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserSearchV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/resources/UserSearchV2Rest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * SEARCH-V2-4-PRE — user search on the v2 surface.
@@ -118,8 +119,4 @@ public class UserSearchV2Rest {
     }
   }
 
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    var body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRest.java
@@ -34,6 +34,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * WATCH1 — Collection "watched containers" REST surface.
@@ -58,11 +59,6 @@ public class CollectionWatchesRest {
 
   @Inject
   WatchService service;
-
-  private static Response problem(String type, String title, Response.Status status, String detail) {
-    ProblemJson body = new ProblemJson(type, title, status.getStatusCode(), detail, null);
-    return Response.status(status).type("application/problem+json").entity(body).build();
-  }
 
   @GET
   @Operation(

--- a/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java
+++ b/plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/v2/resources/AasShellsRest.java
@@ -36,6 +36,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * AAS1a/AAS1b — {@code GET /v2/aas/shells}: IDTA AAS v3 Shell listing and single-Shell lookup.
@@ -222,21 +223,6 @@ public class AasShellsRest {
     return Response.ok(
         new PagedResponseIO<>(mappingService.toSubmodelRefs(dataObjects), total, page, pageSize)
     ).header("X-Total-Count", total).build();
-  }
-
-  private static Response problem(Response.Status status, String detail) {
-    String type = switch (status) {
-      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
-      case FORBIDDEN -> "urn:shepard:error:forbidden";
-      case BAD_REQUEST -> "urn:shepard:error:validation";
-      case NOT_FOUND -> "urn:shepard:error:not-found";
-      case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
-      default -> "urn:shepard:error:internal";
-    };
-    return Response.status(status)
-      .type("application/problem+json")
-      .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
-      .build();
   }
 
   /**

--- a/plugins/git/src/main/java/de/dlr/shepard/v2/git/resources/GitReferenceActionsRest.java
+++ b/plugins/git/src/main/java/de/dlr/shepard/v2/git/resources/GitReferenceActionsRest.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * APISIMP-GIT-REF-PATH — domain-specific action endpoints for GitReferences
@@ -183,17 +184,4 @@ public class GitReferenceActionsRest {
     return sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;
   }
 
-  private static Response problem(Response.Status status, String detail) {
-    String type = switch (status) {
-      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
-      case FORBIDDEN -> "urn:shepard:error:forbidden";
-      case BAD_REQUEST -> "urn:shepard:error:validation";
-      case NOT_FOUND -> "urn:shepard:error:not-found";
-      default -> "urn:shepard:error:internal";
-    };
-    return Response.status(status)
-      .type("application/problem+json")
-      .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
-      .build();
-  }
 }

--- a/plugins/git/src/main/java/de/dlr/shepard/v2/users/resources/MeCredentialsRest.java
+++ b/plugins/git/src/main/java/de/dlr/shepard/v2/users/resources/MeCredentialsRest.java
@@ -34,6 +34,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * {@code /v2/me/git-credentials} CRUD surface for per-host PAT storage
@@ -231,19 +232,4 @@ public class MeCredentialsRest {
     );
   }
 
-  private static Response problem(Response.Status status, String detail) {
-    String type = switch (status) {
-      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
-      case FORBIDDEN -> "urn:shepard:error:forbidden";
-      case BAD_REQUEST -> "urn:shepard:error:validation";
-      case NOT_FOUND -> "urn:shepard:error:not-found";
-      case CONFLICT -> "urn:shepard:error:conflict";
-      case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
-      default -> "urn:shepard:error:internal";
-    };
-    return Response.status(status)
-      .type("application/problem+json")
-      .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
-      .build();
-  }
 }

--- a/plugins/kip/src/main/java/de/dlr/shepard/plugins/kip/resources/KipResolverRest.java
+++ b/plugins/kip/src/main/java/de/dlr/shepard/plugins/kip/resources/KipResolverRest.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * KIP1a/b — the {@code GET /v2/.well-known/kip/{pid-suffix}} public
@@ -217,11 +218,4 @@ public class KipResolverRest {
     return sb.toString();
   }
 
-  private static Response problem(Response.Status status, String type, String title, String detail) {
-    return Response
-      .status(status)
-      .type("application/problem+json")
-      .entity(new ProblemJson(type, title, status.getStatusCode(), detail, null))
-      .build();
-  }
 }

--- a/plugins/spatiotemporal/src/main/java/de/dlr/shepard/v2/spatial/promote/SpatialPromoteRest.java
+++ b/plugins/spatiotemporal/src/main/java/de/dlr/shepard/v2/spatial/promote/SpatialPromoteRest.java
@@ -26,6 +26,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * SPATIAL-UNIFY-004 — the in-context "Promote to spatial" surface.
@@ -140,18 +141,4 @@ public class SpatialPromoteRest {
     }
   }
 
-  private static Response problem(Response.Status status, String detail) {
-    String type = switch (status) {
-      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
-      case FORBIDDEN -> "urn:shepard:error:forbidden";
-      case BAD_REQUEST -> "urn:shepard:error:validation";
-      case NOT_FOUND -> "urn:shepard:error:not-found";
-      case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
-      default -> "urn:shepard:error:internal";
-    };
-    return Response.status(status)
-      .type("application/problem+json")
-      .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
-      .build();
-  }
 }

--- a/plugins/wiki-writer/src/main/java/de/dlr/shepard/plugins/wikiwriter/resources/WikiWriterRest.java
+++ b/plugins/wiki-writer/src/main/java/de/dlr/shepard/plugins/wikiwriter/resources/WikiWriterRest.java
@@ -26,6 +26,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
  * WW1 — REST resource for the wiki-writer plugin.
@@ -143,18 +144,4 @@ public class WikiWriterRest {
     }
   }
 
-  private static Response problem(Response.Status status, String detail) {
-    String type = switch (status) {
-      case UNAUTHORIZED -> "urn:shepard:error:unauthorized";
-      case FORBIDDEN -> "urn:shepard:error:forbidden";
-      case BAD_REQUEST -> "urn:shepard:error:validation";
-      case NOT_FOUND -> "urn:shepard:error:not-found";
-      case SERVICE_UNAVAILABLE -> "urn:shepard:error:service-unavailable";
-      default -> "urn:shepard:error:internal";
-    };
-    return Response.status(status)
-      .type("application/problem+json")
-      .entity(new ProblemJson(type, status.getReasonPhrase(), status.getStatusCode(), detail, null))
-      .build();
-  }
 }


### PR DESCRIPTION
## Summary

Implements backlog row **APISIMP-PROBLEM-DEDUP** (fire-480).

Every `/v2/` REST class carried an identical private `problem()` helper method (74 copies, 5 distinct signatures). This PR extracts them into a single shared factory at `de.dlr.shepard.v2.common.ProblemResponse` and replaces every call site with `import static de.dlr.shepard.v2.common.ProblemResponse.problem;`.

### Changes

- **New**: `backend/src/main/java/de/dlr/shepard/v2/common/ProblemResponse.java` — 5 overloads covering every signature variant found in the codebase:
  - `problem(Response.Status, String detail)` — derives RFC 7807 `type` + `title` from HTTP status
  - `problem(String type, String title, Response.Status, String detail)`
  - `problem(Response.Status, String type, String title, String detail)` — param-order variant
  - `problem(String type, String title, int status, String detail)` — int-status overload
  - `problem(String type, String title, Response.Status, String detail, Map<String,Object> extensions)`

- **Modified**: 74 REST classes (68 in-tree backend, 6 plugin modules: aas, git ×2, kip, spatiotemporal, wiki-writer) — private `problem()` blocks removed, static import added

- **No wire change**: HTTP status codes, `Content-Type: application/problem+json`, and body field names are identical.

### Metrics

| | Before | After |
|---|---|---|
| Copies of `problem()` | 74+ method bodies | 1 factory |
| Lines (net) | — | −402 +125 |

### Backlog

Updates `aidocs/16` row `APISIMP-PROBLEM-DEDUP`: `🔄 queued` → `✅ shipped (fire-480, PR #2413)`

## Test plan

- [ ] CI `mvn verify -pl backend` — SpotBugs + JaCoCo gates
- [ ] CI `doc-stage-check` — index already current (no aidocs stage changes)
- [ ] Smoke: `POST /v2/data-objects/bad-id` returns `application/problem+json` with correct status

🤖 fire-480 pipeline dispatcher

https://claude.ai/code/session_017fxQZfkv4mgf1pDSkbhVnf

---
_Generated by [Claude Code](https://claude.ai/code/session_017fxQZfkv4mgf1pDSkbhVnf)_