### PR TITLE
refactor(APISIMP-LABJOURNALHISTORY-UNDOC-PARAMS): document @QueryParam page/pageSize in LabJournalHistoryRest

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4471,7 +4471,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/admin/config/resources/AdminConfigRest.java:183`; `aidocs/agent-findings/apisimp-sweep-fire483-2026-07-08.md §F2`.
 
 ## APISIMP-LABJOURNALHISTORY-UNDOC-PARAMS — @QueryParam page/pageSize in LabJournalHistoryRest have no @Parameter annotation (size: XS, sweep: fire-483)
-- **Status:** ⏳ queued.
+- **Status:** 🚧 in-flight — PR #2416, fire-483.
 - **Why:** `LabJournalHistoryRest.java:118–119` uses `@QueryParam("page")` and `@QueryParam("pageSize")` without `@Parameter` annotations. The sibling `CollectionLabJournalEntriesRest.java:114–117` already documents these params and is the template to copy from.
 - **Fix:** Add `@Parameter(description = "Zero-based page index (default 0).")` and `@Parameter(description = "Page size, 1–200 (default 50).")` before the two `@QueryParam` lines in `LabJournalHistoryRest`. Two-liner.
 - **AC:** `GET /v2/lab-journal/{entryAppId}/history` lists `page` and `pageSize` as documented optional integer parameters in the generated OpenAPI spec; `mvn verify -pl backend` green.

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -115,7 +116,9 @@ public class LabJournalHistoryRest {
   )
   public Response history(
       @PathParam("entryAppId") String entryAppId,
+      @Parameter(description = "Zero-based page index (default 0).")
       @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
+      @Parameter(description = "Page size, 1–200 (default 50).")
       @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize,
       @Context SecurityContext sc) {
     // 401 if unauthenticated


### PR DESCRIPTION
## Summary

- Adds `@Parameter(description = "...")` annotations to the two undocumented `@QueryParam` parameters (`page`, `pageSize`) in `LabJournalHistoryRest.history()`
- Matches the pattern already established in the sibling `CollectionLabJournalEntriesRest` (lines 114–117)
- No behaviour change — OpenAPI spec completeness only

## Motivation

`APISIMP-LABJOURNALHISTORY-UNDOC-PARAMS` (filed fire-483, `aidocs/agent-findings/apisimp-sweep-fire483-2026-07-08.md` §F3): the two pagination query params in `LabJournalHistoryRest` were missing `@Parameter` annotations, causing them to appear undocumented in the generated OpenAPI output.

## AC

- `@QueryParam("page")` and `@QueryParam("pageSize")` in `LabJournalHistoryRest` each have a preceding `@Parameter` ✓
- No v1 `/shepard/api/` wire shape touched ✓
- `mvn verify -pl backend` expected green on CI (local verify skipped — plugin JARs not in local Maven cache, known environment limitation same as PRs #2413–2415)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeXhbFowhVckhw3pYsN4Am)_