### PR TITLE
refactor(APISIMP-SCHEMA-MISSING-IO): add @Schema(description) to 19 admin+quality IO classes (wave 1 of 2)

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4478,8 +4478,10 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java:118`; `aidocs/agent-findings/apisimp-sweep-fire483-2026-07-08.md §F3`.
 
 ## APISIMP-SCHEMA-MISSING-IO — 37 v2 IO response classes lack class-level @Schema(description) annotation (size: M, sweep: fire-483)
-- **Status:** ⏳ queued.
+- **Status:** 🚧 in-flight — wave 1 (admin+quality, 19 files) dispatched in PR #2420 (fire-486); wave 2 (remaining packages, ~18 files) queued for next fire.
 - **Why:** 37 of ~175 IO classes in `de.dlr.shepard.v2.*.io` have no `@Schema(description = "...")` at the class level, leaving generated OpenAPI output incomplete for those types. Examples: `DQRIO.java`, `AutosweepConfigIO.java`, `InstanceRegistryIO.java`, and 34 others across quality, admin, and plugin packages.
 - **Fix:** Add `@Schema(description = "<one-line description>")` to each of the 37 IO classes; descriptions from class name and existing endpoint docs. Batch as XS PRs per domain package.
-- **AC:** `find . -path '*/v2/*/io/*.java' | xargs grep -L '@Schema'` returns empty; `mvn verify -pl backend` green.
+- **Wave 1 (fire-486, PR #2420):** 15 admin IO + 4 quality IO classes annotated. `IndependenceProofQuery` excluded — it is a Cypher-constants utility class, not a wire response type.
+- **Wave 2 (next fire):** Remaining ~18 IO classes in other packages (mappings, importer, file, timeseries, etc.).
+- **AC:** `find . -path '*/v2/*/io/*.java' | xargs grep -L '@Schema'` returns empty (excluding utility constants classes); `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/quality/io/DQRIO.java`; `aidocs/agent-findings/apisimp-sweep-fire483-2026-07-08.md §F4`.

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/instance/io/InstanceRegistryIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/instance/io/InstanceRegistryIO.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.admin.instance.io;
 
 import java.util.List;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * FE-PROV-INSTANCE-REGISTRY — response shape for
@@ -16,6 +17,7 @@ import java.util.List;
  * unchanged. No element-level merge is performed; the entire list is
  * replaced atomically.
  */
+@Schema(description = "Registry of peer Shepard instances for cross-instance provenance attribution.")
 public record InstanceRegistryIO(
   List<RegisteredInstanceIO> instances
 ) {}

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/instance/io/InstanceRegistryPatchIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/instance/io/InstanceRegistryPatchIO.java
@@ -3,6 +3,7 @@ package de.dlr.shepard.v2.admin.instance.io;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import java.util.List;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * FE-PROV-INSTANCE-REGISTRY — request body for
@@ -19,6 +20,7 @@ import java.util.List;
  * The {@code instancesTouched} flag distinguishes "absent" from "explicit
  * null" so the REST layer can apply the correct RFC 7396 action.
  */
+@Schema(description = "RFC 7396 merge-patch body for PATCH /v2/admin/instances; replaces the registered peer-instance list atomically.")
 public final class InstanceRegistryPatchIO {
 
   private List<RegisteredInstanceIO> instances;

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/instance/io/RegisteredInstanceIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/instance/io/RegisteredInstanceIO.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.admin.instance.io;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * FE-PROV-INSTANCE-REGISTRY — a single registered peer Shepard instance.
@@ -22,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  *       Not validated; purely informational.</li>
  * </ul>
  */
+@Schema(description = "A single registered peer Shepard instance entry in the instance registry.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record RegisteredInstanceIO(
   String instanceId,

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/jupyter/io/JupyterConfigIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/jupyter/io/JupyterConfigIO.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.admin.jupyter.io;
 
 import de.dlr.shepard.v2.admin.jupyter.entities.JupyterConfig;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * J1e — JSON shape returned by {@code GET/PATCH /v2/admin/jupyter/config}.
@@ -17,6 +18,7 @@ import de.dlr.shepard.v2.admin.jupyter.entities.JupyterConfig;
  *   <li>{@link #hubUrl} — serialises as {@code "hubUrl"}</li>
  * </ul>
  */
+@Schema(description = "Runtime configuration for the JupyterHub integration; returned by GET/PATCH /v2/admin/jupyter/config.")
 public record JupyterConfigIO(
   boolean enabled,
   String hubUrl

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/jupyter/io/JupyterConfigPatchIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/jupyter/io/JupyterConfigPatchIO.java
@@ -3,6 +3,7 @@ package de.dlr.shepard.v2.admin.jupyter.io;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * J1e — request body for {@code PATCH /v2/admin/jupyter/config}
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.annotation.Nulls;
  * {@code @JsonSetter(nulls = SET)} to distinguish "absent" (leave
  * alone) from "explicit null" (clear to default).
  */
+@Schema(description = "RFC 7396 merge-patch body for PATCH /v2/admin/jupyter/config.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class JupyterConfigPatchIO {
 

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/provenance/io/ProvenanceConfigIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/provenance/io/ProvenanceConfigIO.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.admin.provenance.io;
 
 import de.dlr.shepard.v2.admin.provenance.entities.ProvenanceConfig;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * FTOGGLE-PROV-1 — JSON shape for {@code GET|PATCH /v2/admin/config/provenance}.
@@ -9,6 +10,7 @@ import de.dlr.shepard.v2.admin.provenance.entities.ProvenanceConfig;
  * are resolved to deploy-time defaults by the service before being projected
  * here. Consumers see a fully-resolved config snapshot.
  */
+@Schema(description = "Runtime provenance-capture configuration; returned by GET/PATCH /v2/admin/config/provenance.")
 public record ProvenanceConfigIO(
   boolean enabled,
   boolean captureReads,

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/qualityscoring/io/TimeseriesQualityScoringConfigIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/qualityscoring/io/TimeseriesQualityScoringConfigIO.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.admin.qualityscoring.io;
 
 import de.dlr.shepard.v2.admin.qualityscoring.entities.TimeseriesQualityScoringConfig;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * FTOGGLE-QS-1 — JSON shape for
@@ -19,6 +20,7 @@ import de.dlr.shepard.v2.admin.qualityscoring.entities.TimeseriesQualityScoringC
  * is deploy-time-only and is not exposed here — changing it requires a
  * restart; see CLAUDE.md "Pre-startup ordering invariants" exception.
  */
+@Schema(description = "Runtime configuration for the AI-powered timeseries quality-scoring background job.")
 public record TimeseriesQualityScoringConfigIO(
   boolean enabled,
   int batchSize

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/ror/io/InstanceRorConfigIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/ror/io/InstanceRorConfigIO.java
@@ -2,6 +2,7 @@ package de.dlr.shepard.v2.admin.ror.io;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.dlr.shepard.v2.admin.ror.entities.InstanceRorConfig;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * ROR1 — JSON shape returned by {@code GET/PATCH /v2/admin/instance/ror}.
@@ -15,6 +16,7 @@ import de.dlr.shepard.v2.admin.ror.entities.InstanceRorConfig;
  * ({@code rorId}, {@code organizationName}, {@code rorUrl}) are
  * omitted when not configured.
  */
+@Schema(description = "ROR (Research Organization Registry) identity configuration for this Shepard instance.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record InstanceRorConfigIO(
   String rorId,

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/ror/io/InstanceRorConfigPatchIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/ror/io/InstanceRorConfigPatchIO.java
@@ -3,6 +3,7 @@ package de.dlr.shepard.v2.admin.ror.io;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * ROR1 — request body for {@code PATCH /v2/admin/instance/ror}
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.annotation.Nulls;
  * <p>Validation of {@code rorId} is done by the REST resource: must
  * match {@code [A-Za-z0-9]{1,9}} when non-null/non-blank.
  */
+@Schema(description = "RFC 7396 merge-patch body for PATCH /v2/admin/instance/ror.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class InstanceRorConfigPatchIO {
 

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/sqltimeseries/io/SqlTimeseriesConfigIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/sqltimeseries/io/SqlTimeseriesConfigIO.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.admin.sqltimeseries.io;
 
 import de.dlr.shepard.v2.admin.sqltimeseries.entities.SqlTimeseriesConfig;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * P10c / FTOGGLE-SQL-ENABLE-1 — JSON shape returned by
@@ -19,6 +20,7 @@ import de.dlr.shepard.v2.admin.sqltimeseries.entities.SqlTimeseriesConfig;
  *       stored as {@code maxDurationIso} in the entity to avoid confusion)</li>
  * </ul>
  */
+@Schema(description = "Runtime configuration for the SQL timeseries backend; returned by GET/PATCH /v2/admin/config/sql-timeseries.")
 public record SqlTimeseriesConfigIO(
   boolean enabled,
   long maxRows,

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/sqltimeseries/io/SqlTimeseriesConfigPatchIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/sqltimeseries/io/SqlTimeseriesConfigPatchIO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * P10c — request body for {@code PATCH /v2/admin/sql-timeseries/config}
@@ -31,6 +32,7 @@ import com.fasterxml.jackson.annotation.Nulls;
  * {@code maxRows} must be {@literal >} 0 when non-null;
  * {@code maxDuration} must be parseable by {@link java.time.Duration#parse} when non-null.
  */
+@Schema(description = "RFC 7396 merge-patch body for PATCH /v2/admin/sql-timeseries/config.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class SqlTimeseriesConfigPatchIO {
 

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/storage/io/AutosweepConfigIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/storage/io/AutosweepConfigIO.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.admin.storage.io;
 
 import de.dlr.shepard.v2.admin.storage.entities.AutosweepConfig;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * FTOGGLE-AUTOSWEEP-1 — JSON shape for {@code GET|PATCH /v2/admin/config/autosweep}.
@@ -9,6 +10,7 @@ import de.dlr.shepard.v2.admin.storage.entities.AutosweepConfig;
  * are resolved to deploy-time defaults by the service before being projected
  * here. Consumers see a fully-resolved config snapshot.
  */
+@Schema(description = "Runtime configuration for the autosweep file-migration background job.")
 public record AutosweepConfigIO(
   boolean enabled,
   String source,

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/storage/io/FileMigrationRollbackResultIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/storage/io/FileMigrationRollbackResultIO.java
@@ -1,3 +1,7 @@
 package de.dlr.shepard.v2.admin.storage.io;
 
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/** Result of rolling back a single file's storage-backend migration. */
+@Schema(description = "Result of rolling back a single file's storage-backend migration.")
 public record FileMigrationRollbackResultIO(String appId, String status) {}

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/thermography/io/ThermographyConfigIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/thermography/io/ThermographyConfigIO.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.admin.thermography.io;
 
 import de.dlr.shepard.v2.admin.thermography.entities.ThermographyConfig;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * MFFD-NDT-ADMIN-CONFIG-1 — JSON shape returned by
@@ -20,6 +21,7 @@ import de.dlr.shepard.v2.admin.thermography.entities.ThermographyConfig;
  *   <li>{@link #gridHeight} — effective plate-grid row count</li>
  * </ul>
  */
+@Schema(description = "Runtime configuration for the MFFD thermography NDT analysis; returned by GET/PATCH /v2/admin/thermography/config.")
 public record ThermographyConfigIO(
   String appId,
   double thresholdC,

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/thermography/io/ThermographyConfigPatchIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/thermography/io/ThermographyConfigPatchIO.java
@@ -3,6 +3,7 @@ package de.dlr.shepard.v2.admin.thermography.io;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * MFFD-NDT-ADMIN-CONFIG-1 — request body for
@@ -21,6 +22,7 @@ import com.fasterxml.jackson.annotation.Nulls;
  * {@code @JsonSetter(nulls = SET)} to distinguish "absent" (leave alone)
  * from "explicit null" (revert to deploy-time default).
  */
+@Schema(description = "RFC 7396 merge-patch body for PATCH /v2/admin/thermography/config.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class ThermographyConfigPatchIO {
 

--- a/backend/src/main/java/de/dlr/shepard/v2/quality/io/CreateDQRIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/quality/io/CreateDQRIO.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * TPL10 — request body for creating a new Data Quality Requirement.
  *
  * <p>Submitted as JSON to {@code POST /v2/collections/{appId}/dqr}.
  */
+@Schema(description = "Request body for creating a Data Quality Requirement on a Collection.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CreateDQRIO(
 

--- a/backend/src/main/java/de/dlr/shepard/v2/quality/io/DQRIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/quality/io/DQRIO.java
@@ -2,6 +2,7 @@ package de.dlr.shepard.v2.quality.io;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.dlr.shepard.v2.quality.entities.DataQualityRequirement;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * TPL10 — wire representation of a persisted Data Quality Requirement.
@@ -9,6 +10,7 @@ import de.dlr.shepard.v2.quality.entities.DataQualityRequirement;
  * <p>Returned by GET and POST endpoints under
  * {@code /v2/collections/{appId}/dqr}.
  */
+@Schema(description = "Persisted Data Quality Requirement returned by GET/POST endpoints under /v2/collections/{appId}/dqr.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DQRIO(
   String dqrAppId,

--- a/backend/src/main/java/de/dlr/shepard/v2/quality/io/DQRResultIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/quality/io/DQRResultIO.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.quality.io;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * TPL10 — a single evaluation result for one DQR × DataObject pair.
@@ -12,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * that DataObject. A result where {@code passed == false} means the rule was
  * violated; {@code message} carries a human-readable explanation.
  */
+@Schema(description = "Single DQR evaluation result for one rule-DataObject pair.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DQRResultIO(
   /** AppId of the evaluated DQR. */

--- a/backend/src/main/java/de/dlr/shepard/v2/quality/io/DQRResultsIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/quality/io/DQRResultsIO.java
@@ -1,6 +1,7 @@
 package de.dlr.shepard.v2.quality.io;
 
 import java.util.List;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * APISIMP-DQR-EVALUATE-BARE-LIST — envelope returned by
@@ -9,6 +10,7 @@ import java.util.List;
  * <p>{@code total} is the uncapped result count; when {@code truncated} is
  * {@code true} the caller should increase {@code ?limit=} or add async evaluation.
  */
+@Schema(description = "Envelope returned by POST /v2/collections/{collectionAppId}/dqr/evaluate, containing all DQR results with truncation metadata.")
 public record DQRResultsIO(
     List<DQRResultIO> results,
     boolean truncated,


### PR DESCRIPTION
## Summary

Wave 1 of `APISIMP-SCHEMA-MISSING-IO` (backlog §F4, fire-483 sweep). Adds `@Schema(description = "...")` to the 19 admin and quality IO classes that had no class-level annotation, leaving the generated OpenAPI spec incomplete for those types.

**Admin package (15 files):**
- `InstanceRegistryIO`, `InstanceRegistryPatchIO`, `RegisteredInstanceIO`
- `JupyterConfigIO`, `JupyterConfigPatchIO`
- `ProvenanceConfigIO`
- `TimeseriesQualityScoringConfigIO`
- `InstanceRorConfigIO`, `InstanceRorConfigPatchIO`
- `SqlTimeseriesConfigIO`, `SqlTimeseriesConfigPatchIO`
- `AutosweepConfigIO`, `FileMigrationRollbackResultIO`
- `ThermographyConfigIO`, `ThermographyConfigPatchIO`

**Quality package (4 files):**
- `CreateDQRIO`, `DQRIO`, `DQRResultIO`, `DQRResultsIO`

`IndependenceProofQuery` excluded — it is a Cypher-constants utility class, not a wire response type.

### AC

- [x] `find . -path '*/v2/admin/*/io/*.java' | xargs grep -L '@Schema'` returns empty
- [x] `find . -path '*/v2/quality/io/*.java' | xargs grep -L '@Schema'` returns empty (excluding `IndependenceProofQuery`)
- [x] No v1 `/shepard/api/` wire shape touched
- [x] `mvn verify -pl backend` expected green on CI (local verify skipped — plugin JARs not in local Maven cache, known environment limitation)

### aidocs/16

- `APISIMP-SCHEMA-MISSING-IO` → 🚧 in-flight (wave 1 of 2; wave 2 covers ~18 remaining IO classes in other packages)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJVz7KLNnM1SvCuWMXYxFo)_