### PR TITLE
feat(APISIMP-LIST-XCOUNT-RESIDUAL): add X-Total-Count header to 6 list/batch endpoints

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -490,7 +490,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/agent-findings/apisimp-sweep-2026-06-30.md`](agent-findings/apisimp-sweep-2026-06-30.md) | API Simplification Sweep — fire-313 (2026-06-30) | 2026-06-30 | 2026-07-07 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-01.md`](agent-findings/apisimp-sweep-2026-07-01.md) | APISIMP sweep — 2026-07-01 (fire-338) | 2026-07-01 | 2026-07-07 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-08-fire481.md`](agent-findings/apisimp-sweep-2026-07-08-fire481.md) | APISIMP sweep — fire-481 (2026-07-08) | 2026-07-08 | 2026-07-08 |
-| [`aidocs/agent-findings/apisimp-sweep-2026-07-09.md`](agent-findings/apisimp-sweep-2026-07-09.md) | APISIMP Sweep — fire-488 (2026-07-09) | 2026-07-09 | — |
+| [`aidocs/agent-findings/apisimp-sweep-2026-07-09.md`](agent-findings/apisimp-sweep-2026-07-09.md) | APISIMP Sweep — fire-488 (2026-07-09) | 2026-07-09 | 2026-07-09 |
 | [`aidocs/agent-findings/apisimp-sweep-fire341-2026-07-01.md`](agent-findings/apisimp-sweep-fire341-2026-07-01.md) | API Simplification Sweep — fire-341 (2026-07-01) | 2026-07-01 | 2026-07-07 |
 | [`aidocs/agent-findings/apisimp-sweep-fire342-2026-07-01.md`](agent-findings/apisimp-sweep-fire342-2026-07-01.md) | APISIMP Sweep — 2026-07-01 (fire-342) | 2026-07-01 | 2026-07-07 |
 | [`aidocs/agent-findings/apisimp-sweep-fire353-2026-07-01.md`](agent-findings/apisimp-sweep-fire353-2026-07-01.md) | APISIMP Sweep — fire-353 (2026-07-01) | 2026-07-01 | 2026-07-07 |

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4487,7 +4487,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/quality/io/DQRIO.java`; `aidocs/agent-findings/apisimp-sweep-fire483-2026-07-08.md §F4`.
 
 ## APISIMP-LIST-XCOUNT-RESIDUAL — 6 list/batch endpoints emit PagedResponseIO but omit X-Total-Count response header (size: XS, sweep: fire-488)
-- **Status:** ⏳ queued — next fire (fire-489) dispatches this row.
+- **Status:** 🔄 in-flight — PR opened fire-489 on branch `APISIMP-LIST-XCOUNT-RESIDUAL`.
 - **Why:** `ContainersV2Rest` (3 endpoints), `CrossDoBulkDataRest` (1 endpoint), and `DataObjectV2Rest` (2 endpoints) each return `PagedResponseIO` in the body but never chain `.header("X-Total-Count", (long) size)` on the `Response` builder, and their `@APIResponse(responseCode="200")` annotations lack the formal `headers = @Header(name="X-Total-Count", ...)` declaration. Every other post-APISIMP-XCOUNT-OPENAPI-HEADER list endpoint carries both; these 6 were missed because they are non-standard list shapes (file-version list, linked-DO list, bulk channel-data POST, cross-DO bulk POST, predecessor-chain, successor-chain).
 - **Fix:** For each of the 6 endpoints: (1) chain `.header("X-Total-Count", (long) <size-var>)` before `.build()`; (2) add `headers = @Header(name = "X-Total-Count", description = "Total number of items.", schema = @Schema(type = SchemaType.INTEGER))` to the `@APIResponse(responseCode = "200")` annotation. Import `Header`, `Schema`, `SchemaType` from MicroProfile OpenAPI where needed.
 - **AC:** All 6 endpoints return `X-Total-Count` in their response headers; generated OpenAPI spec declares the header for each; `mvn verify -pl backend` green. No runtime behaviour change beyond the added header.

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -499,7 +499,8 @@ public class ContainersV2Rest {
   @APIResponse(
     responseCode = "200",
     description = "Version list (may be empty).",
-    content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
+    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)),
+    headers = @Header(name = "X-Total-Count", description = "Total version count.", schema = @Schema(type = SchemaType.INTEGER))
   )
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Read on the container.")
@@ -525,7 +526,9 @@ public class ContainersV2Rest {
           "Container kind '" + resolved.get().handler().kind() + "' does not support payload versioning");
     }
     List<PayloadVersionIO> versionList = versionsOpt.get();
-    return Response.ok(new PagedResponseIO<>(versionList, versionList.size(), 0, versionList.size())).build();
+    return Response.ok(new PagedResponseIO<>(versionList, versionList.size(), 0, versionList.size()))
+        .header("X-Total-Count", (long) versionList.size())
+        .build();
   }
 
   // ─── stats ───────────────────────────────────────────────────────────────
@@ -584,7 +587,8 @@ public class ContainersV2Rest {
   @APIResponse(
     responseCode = "200",
     description = "List of linked DataObjects (may be empty).",
-    content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
+    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)),
+    headers = @Header(name = "X-Total-Count", description = "Total linked DataObject count.", schema = @Schema(type = SchemaType.INTEGER))
   )
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Read on the container.")
@@ -606,7 +610,9 @@ public class ContainersV2Rest {
           "Container kind '" + resolved.get().handler().kind() + "' has no linked-DataObject concept");
     }
     List<DataObjectIO> linkedList = linkedOpt.get();
-    return Response.ok(new PagedResponseIO<>(linkedList, linkedList.size(), 0, linkedList.size())).build();
+    return Response.ok(new PagedResponseIO<>(linkedList, linkedList.size(), 0, linkedList.size()))
+        .header("X-Total-Count", (long) linkedList.size())
+        .build();
   }
 
   // ─── channel endpoints (APISIMP-CONT-NS-COLLAPSE-2) ────────────────────────
@@ -763,7 +769,8 @@ public class ContainersV2Rest {
   @APIResponse(
     responseCode = "200",
     description = "Raw data for all resolved channels.",
-    content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
+    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)),
+    headers = @Header(name = "X-Total-Count", description = "Number of resolved channel series returned.", schema = @Schema(type = SchemaType.INTEGER))
   )
   @APIResponse(responseCode = "400", description = "Validation error on request body.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
@@ -789,7 +796,9 @@ public class ContainersV2Rest {
           "Container kind '" + resolved.get().handler().kind() + "' has no channel concept");
     }
     var out = result.get();
-    return Response.ok(new PagedResponseIO<>(out, out.size(), 0, out.size())).build();
+    return Response.ok(new PagedResponseIO<>(out, out.size(), 0, out.size()))
+        .header("X-Total-Count", (long) out.size())
+        .build();
   }
 
   @POST

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
@@ -891,7 +891,8 @@ public class DataObjectV2Rest {
   @APIResponse(
     responseCode = "200",
     description = "Predecessor chain (may be empty when no predecessors exist).",
-    content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
+    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)),
+    headers = @Header(name = "X-Total-Count", description = "Total chain length returned.", schema = @Schema(type = SchemaType.INTEGER))
   )
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Read permission.")
@@ -912,7 +913,9 @@ public class DataObjectV2Rest {
     List<DataObject> chain = dataObjectDAO.findPredecessorChain(dataObjectAppId, depth);
     List<DataObjectSummaryIO> result = new ArrayList<>(chain.size());
     for (DataObject d : chain) result.add(new DataObjectSummaryIO(d));
-    return Response.ok(new PagedResponseIO<>(result, result.size(), 0, result.size())).build();
+    return Response.ok(new PagedResponseIO<>(result, result.size(), 0, result.size()))
+        .header("X-Total-Count", (long) result.size())
+        .build();
   }
 
   @GET
@@ -932,7 +935,8 @@ public class DataObjectV2Rest {
   @APIResponse(
     responseCode = "200",
     description = "Successor chain (may be empty when no successors exist).",
-    content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
+    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)),
+    headers = @Header(name = "X-Total-Count", description = "Total chain length returned.", schema = @Schema(type = SchemaType.INTEGER))
   )
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Read permission.")
@@ -953,7 +957,9 @@ public class DataObjectV2Rest {
     List<DataObject> chain = dataObjectDAO.findSuccessorChain(dataObjectAppId, depth);
     List<DataObjectSummaryIO> result = new ArrayList<>(chain.size());
     for (DataObject d : chain) result.add(new DataObjectSummaryIO(d));
-    return Response.ok(new PagedResponseIO<>(result, result.size(), 0, result.size())).build();
+    return Response.ok(new PagedResponseIO<>(result, result.size(), 0, result.size()))
+        .header("X-Total-Count", (long) result.size())
+        .build();
   }
 
   // ── helpers ───────────────────────────────────────────────────────────────

--- a/backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRest.java
@@ -28,7 +28,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -103,7 +105,8 @@ public class CrossDoBulkDataRest {
   @APIResponse(
     responseCode = "200",
     description = "Resolved series across the requested DataObjects.",
-    content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
+    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)),
+    headers = @Header(name = "X-Total-Count", description = "Number of series entries returned (one per DataObject in request order).", schema = @Schema(type = SchemaType.INTEGER))
   )
   @APIResponse(responseCode = "400", description = "Validation error on request body.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
@@ -170,7 +173,9 @@ public class CrossDoBulkDataRest {
       out.add(new CrossDoSeriesIO(doAppId, doName, predicate, pick.symbolicName(), points));
     }
 
-    return Response.ok(new PagedResponseIO<>(out, out.size(), 0, out.size())).build();
+    return Response.ok(new PagedResponseIO<>(out, out.size(), 0, out.size()))
+        .header("X-Total-Count", (long) out.size())
+        .build();
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes `APISIMP-LIST-XCOUNT-RESIDUAL` (XS, sweep fire-488).

Six endpoints that wrap responses in `PagedResponseIO` (which carries a `total` field) were missing the parallel `X-Total-Count` HTTP response header. This is the residual set from `APISIMP-XCOUNT-OPENAPI-HEADER` (#2411) — 38 endpoints got the header declared then; these 6 were missed.

**Endpoints patched:**

| File | Endpoint | Variable |
|------|----------|----------|
| `ContainersV2Rest` | `listVersions` (`GET /{appId}/files/{fileName}/versions`) | `versionList.size()` |
| `ContainersV2Rest` | `getContainerLinkedDataObjects` (`GET /{appId}/linked-data-objects`) | `linkedList.size()` |
| `ContainersV2Rest` | `getContainerBulkChannelData` (`POST /{appId}/channels/data/bulk`) | `out.size()` |
| `CrossDoBulkDataRest` | `getCrossDoBulkData` (`POST /v2/data-objects/cross-timeseries-bulk`) | `out.size()` |
| `DataObjectV2Rest` | `predecessorChain` (`GET /{dataObjectAppId}/predecessor-chain`) | `result.size()` |
| `DataObjectV2Rest` | `successorChain` (`GET /{dataObjectAppId}/successor-chain`) | `result.size()` |

**Changes per endpoint:**
1. Chain `.header("X-Total-Count", (long) <size>)` before `.build()` in the response builder
2. Add `headers = @Header(name = "X-Total-Count", description = "...", schema = @Schema(type = SchemaType.INTEGER))` to the `@APIResponse(responseCode = "200")` annotation

`CrossDoBulkDataRest` gains two new imports (`Header`, `SchemaType`) previously unused in that file. The other two files already had both imports.

No runtime behaviour change beyond the added header; no v1 surface touched.

## Test plan

- [ ] `mvn verify -pl backend` green on CI (JUnit + JaCoCo + SpotBugs)
- [ ] Generated OpenAPI spec shows `X-Total-Count` header in the 200 response for all 6 operationIds: `listVersions`, `getContainerLinkedDataObjects`, `getContainerBulkChannelData`, `getCrossDoBulkData`, `predecessorChain`, `successorChain`
- [ ] No change to existing test expectations (header is additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1CQWWAp4oixtwp8t49H9D

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1CQWWAp4oixtwp8t49H9D)_