### PR TITLE
fix(APISIMP-DMP-FQN-SCHEMATYPE): replace inline FQN SchemaType.STRING with imported short name in DmpSnippetV2Rest

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/fair/resources/DmpSnippetV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/fair/resources/DmpSnippetV2Rest.java
@@ -23,6 +23,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.Optional;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -115,7 +116,7 @@ public class DmpSnippetV2Rest {
     responseCode = "200",
     description = "DMP snippet as Markdown (text/markdown) or JSON wrapper (application/json).",
     content = {
-      @Content(mediaType = "text/markdown", schema = @Schema(type = org.eclipse.microprofile.openapi.annotations.enums.SchemaType.STRING)),
+      @Content(mediaType = "text/markdown", schema = @Schema(type = SchemaType.STRING)),
       @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = DmpSnippetIO.class))
     }
   )


### PR DESCRIPTION
## Summary

Fixes the one remaining inline FQN OpenAPI annotation in the v2 REST surface, found during the fire-494 APISIMP sweep (`aidocs/agent-findings/apisimp-sweep-2026-07-09-fire494.md §F1`).

**Change:** `DmpSnippetV2Rest.java` line 118 had:
```java
@Content(mediaType = "text/markdown", schema = @Schema(type = org.eclipse.microprofile.openapi.annotations.enums.SchemaType.STRING)),
```

After this PR:
```java
import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
// ...
@Content(mediaType = "text/markdown", schema = @Schema(type = SchemaType.STRING)),
```

- 1 import added, 1 FQN reference replaced with short name
- Zero logic change — annotation semantics are identical
- Same pattern as APISIMP-MAPPINGS-FQN-ANNOTATIONS (PR #2425, fire-494)

**Backlog row:** `APISIMP-DMP-FQN-SCHEMATYPE` (XS) in `aidocs/16-dispatcher-backlog.md`

**AC:** `grep -n "org.eclipse.microprofile.openapi.annotations.enums.SchemaType" DmpSnippetV2Rest.java` returns the import line only (zero body usages); `mvn verify` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFnkkhSoqFSZp6Tr5fpdBH)_