### PR TITLE
fix(APISIMP-PROV-CURSOR-PAGENAME): rename ?limit= → ?pageSize= on 6 ProvenanceRest cursor-pagination endpoints

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4543,7 +4543,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/admin/plugins/PluginsAdminRest.java:145`; `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:223`; `backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferencesV2Rest.java:481,483`; `aidocs/agent-findings/apisimp-sweep-2026-07-09-fire496.md §F4.1–F4.3`.
 
 ## APISIMP-PROV-CURSOR-PAGENAME — `ProvenanceRest` cursor-pagination endpoints use `?limit=` instead of v2 standard `?pageSize=` (size: S, sweep: fire-496)
-- **Status:** queued.
+- **Status:** in-flight — branch `APISIMP-PROV-CURSOR-PAGENAME-1`, fire-498.
 - **Why:** `ProvenanceRest.java` at lines 134, 202, 248, 301, 347, 382 declares `@QueryParam("limit")` for its cursor-pagination window across six cursor-backed list endpoints (`GET /v2/provenance/activities`, `/v2/provenance/activities/{appId}/predecessors`, etc.). Every other v2 list endpoint that accepts a page-size param uses `?pageSize=`. Cursor pagination is intentional and correct; the naming divergence is the issue — a caller who reads one v2 endpoint's docs expects `pageSize` and will silently get defaults when they pass `pageSize=` to a provenance endpoint.
 - **Fix:** Rename `@QueryParam("limit")` → `@QueryParam("pageSize")` (and update `@Parameter(description)` strings) at all 6 sites in `ProvenanceRest.java`. Update any existing callers in the frontend composables (`useProvenance*.ts`) to use `pageSize=` instead of `limit=`.
 - **AC:** `grep -n '"limit"' backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java` returns zero `@QueryParam` usages; `grep -rn "limit=" frontend/composables/provenance/` returns zero; `mvn verify -pl backend` green; `npm run test` green.

--- a/backend-client/src/apis/ProvenanceApi.ts
+++ b/backend-client/src/apis/ProvenanceApi.ts
@@ -38,7 +38,7 @@ export interface CountActivitiesRequest {
 
 export interface ListActivitiesRequest {
     agent?: string;
-    limit?: number;
+    pageSize?: number;
     since?: number;
     targetAppId?: string;
     targetKind?: string;
@@ -47,7 +47,7 @@ export interface ListActivitiesRequest {
 
 export interface ListEntityActivitiesRequest {
     appId: string;
-    limit?: number;
+    pageSize?: number;
     since?: number;
     until?: number;
 }
@@ -135,8 +135,8 @@ export class ProvenanceApi extends runtime.BaseAPI {
             queryParameters['agent'] = requestParameters['agent'];
         }
 
-        if (requestParameters['limit'] != null) {
-            queryParameters['limit'] = requestParameters['limit'];
+        if (requestParameters['pageSize'] != null) {
+            queryParameters['pageSize'] = requestParameters['pageSize'];
         }
 
         if (requestParameters['since'] != null) {
@@ -202,8 +202,8 @@ export class ProvenanceApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (requestParameters['limit'] != null) {
-            queryParameters['limit'] = requestParameters['limit'];
+        if (requestParameters['pageSize'] != null) {
+            queryParameters['pageSize'] = requestParameters['pageSize'];
         }
 
         if (requestParameters['since'] != null) {

--- a/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
@@ -116,7 +116,7 @@ public class ProvenanceRest {
   @APIResponse(
     responseCode = "200",
     description = "Matching activities, sorted by startedAt DESC. " +
-    "Envelope: `pageSize` reflects the `?limit=` window; `total` reflects rows returned (not true DB total — cursor mode). " +
+    "Envelope: `pageSize` reflects the `?pageSize=` window; `total` reflects rows returned (not true DB total — cursor mode). " +
     "Response header `X-Has-More: true` when the window is full and more rows may exist; use the `X-Next-Cursor` epoch-ms value as `?until=` on the next call.",
     content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
   )
@@ -131,7 +131,7 @@ public class ProvenanceRest {
     @Parameter(description = "Filter to a specific target-entity appId.") @QueryParam("targetAppId") String targetAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @Context SecurityContext securityContext
   ) {
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
@@ -154,13 +154,13 @@ public class ProvenanceRest {
 
     OutputProfile prof = outputProfile.getProfile();
     List<ActivityIO> rows = provenance
-      .list(agent, targetKind, targetAppId, since, until, limit)
+      .list(agent, targetKind, targetAppId, since, until, pageSize)
       .stream()
       .map(ActivityIO::from)
       .map(io -> applyProfile(io, prof))
       .toList();
-    boolean hasMore = rows.size() >= limit;
-    var rb = Response.ok(new PagedResponseIO<>(rows, rows.size(), 0, limit))
+    boolean hasMore = rows.size() >= pageSize;
+    var rb = Response.ok(new PagedResponseIO<>(rows, rows.size(), 0, pageSize))
         .header("X-Has-More", hasMore);
     if (hasMore) {
       rb.header("X-Next-Cursor", rows.get(rows.size() - 1).getStartedAtMillis());
@@ -199,7 +199,7 @@ public class ProvenanceRest {
     @Parameter(description = "Filter to a specific target-entity appId.") @QueryParam("targetAppId") String targetAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @Context SecurityContext securityContext
   ) {
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
@@ -216,7 +216,7 @@ public class ProvenanceRest {
     try { since = parseTimestamp(sinceRaw); until = parseTimestamp(untilRaw); }
     catch (IllegalArgumentException e) { return badTimestamp(e.getMessage()); }
 
-    List<Activity> rows = provenance.list(agent, targetKind, targetAppId, since, until, limit);
+    List<Activity> rows = provenance.list(agent, targetKind, targetAppId, since, until, pageSize);
     return Response.ok(provJsonRenderer.render(rows)).type(ProvJsonRenderer.MEDIA_TYPE).build();
   }
 
@@ -245,7 +245,7 @@ public class ProvenanceRest {
     @Parameter(description = "Filter to a specific target-entity appId.") @QueryParam("targetAppId") String targetAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @HeaderParam(HttpHeaders.ACCEPT) String acceptHeader,
     @Context SecurityContext securityContext
   ) {
@@ -267,7 +267,7 @@ public class ProvenanceRest {
     if (profileError != null) return profileError;
     ProvJsonLdRenderer.ProfileChoice profile = ProvJsonLdRenderer.resolveProfile(acceptHeader);
 
-    List<Activity> rows = provenance.list(agent, targetKind, targetAppId, since, until, limit);
+    List<Activity> rows = provenance.list(agent, targetKind, targetAppId, since, until, pageSize);
     return Response.ok(provJsonLdRenderer.render(rows, profile))
       .type(jsonLdMediaTypeFor(profile))
       .build();
@@ -288,7 +288,7 @@ public class ProvenanceRest {
   @APIResponse(
     responseCode = "200",
     description = "Activities targeting the entity, sorted by startedAt DESC. " +
-    "Envelope: `pageSize` reflects the `?limit=` window; `total` reflects rows returned (cursor mode, not true DB total). " +
+    "Envelope: `pageSize` reflects the `?pageSize=` window; `total` reflects rows returned (cursor mode, not true DB total). " +
     "Header `X-Has-More: true` when window is full; use `X-Next-Cursor` epoch-ms as `?until=` on the next call.",
     content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
   )
@@ -298,7 +298,7 @@ public class ProvenanceRest {
     @Parameter(description = "Target entity's appId.", required = true) @PathParam("appId") String entityAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @Context SecurityContext securityContext
   ) {
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
@@ -314,13 +314,13 @@ public class ProvenanceRest {
 
     OutputProfile prof = outputProfile.getProfile();
     List<ActivityIO> rows = provenance
-      .list(agentFilter, null, entityAppId, since, until, limit)
+      .list(agentFilter, null, entityAppId, since, until, pageSize)
       .stream()
       .map(ActivityIO::from)
       .map(io -> applyProfile(io, prof))
       .toList();
-    boolean hasMore = rows.size() >= limit;
-    var rb = Response.ok(new PagedResponseIO<>(rows, rows.size(), 0, limit))
+    boolean hasMore = rows.size() >= pageSize;
+    var rb = Response.ok(new PagedResponseIO<>(rows, rows.size(), 0, pageSize))
         .header("X-Has-More", hasMore);
     if (hasMore) {
       rb.header("X-Next-Cursor", rows.get(rows.size() - 1).getStartedAtMillis());
@@ -344,7 +344,7 @@ public class ProvenanceRest {
     @Parameter(description = "Target entity's appId.", required = true) @PathParam("appId") String entityAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @Context SecurityContext securityContext
   ) {
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
@@ -357,7 +357,7 @@ public class ProvenanceRest {
     try { since = parseTimestamp(sinceRaw); until = parseTimestamp(untilRaw); }
     catch (IllegalArgumentException e) { return badTimestamp(e.getMessage()); }
 
-    List<Activity> rows = provenance.list(agentFilter, null, entityAppId, since, until, limit);
+    List<Activity> rows = provenance.list(agentFilter, null, entityAppId, since, until, pageSize);
     return Response.ok(provJsonRenderer.render(rows)).type(ProvJsonRenderer.MEDIA_TYPE).build();
   }
 
@@ -379,7 +379,7 @@ public class ProvenanceRest {
     @Parameter(description = "Target entity's appId.", required = true) @PathParam("appId") String entityAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @HeaderParam(HttpHeaders.ACCEPT) String acceptHeader,
     @Context SecurityContext securityContext
   ) {
@@ -397,7 +397,7 @@ public class ProvenanceRest {
     if (profileError != null) return profileError;
     ProvJsonLdRenderer.ProfileChoice profile = ProvJsonLdRenderer.resolveProfile(acceptHeader);
 
-    List<Activity> rows = provenance.list(agentFilter, null, entityAppId, since, until, limit);
+    List<Activity> rows = provenance.list(agentFilter, null, entityAppId, since, until, pageSize);
     return Response.ok(provJsonLdRenderer.render(rows, profile))
       .type(jsonLdMediaTypeFor(profile))
       .build();

--- a/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestParamAnnotationTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestParamAnnotationTest.java
@@ -43,7 +43,7 @@ class ProvenanceRestParamAnnotationTest {
       "listActivitiesProvJson",
       String.class, String.class, String.class, String.class, String.class,
       int.class, jakarta.ws.rs.core.SecurityContext.class);
-    assertDocumented(queryParam(m, "limit"), "listActivitiesProvJson.limit");
+    assertDocumented(queryParam(m, "pageSize"), "listActivitiesProvJson.pageSize");
   }
 
   @Test
@@ -52,7 +52,7 @@ class ProvenanceRestParamAnnotationTest {
       "listActivitiesJsonLd",
       String.class, String.class, String.class, String.class, String.class,
       int.class, String.class, jakarta.ws.rs.core.SecurityContext.class);
-    assertDocumented(queryParam(m, "limit"), "listActivitiesJsonLd.limit");
+    assertDocumented(queryParam(m, "pageSize"), "listActivitiesJsonLd.pageSize");
   }
 
   @Test
@@ -70,7 +70,7 @@ class ProvenanceRestParamAnnotationTest {
       "listEntityActivitiesProvJson",
       String.class, String.class, String.class, int.class,
       jakarta.ws.rs.core.SecurityContext.class);
-    assertDocumented(queryParam(m, "limit"), "listEntityActivitiesProvJson.limit");
+    assertDocumented(queryParam(m, "pageSize"), "listEntityActivitiesProvJson.pageSize");
   }
 
   @Test
@@ -88,7 +88,7 @@ class ProvenanceRestParamAnnotationTest {
       "listEntityActivitiesJsonLd",
       String.class, String.class, String.class, int.class, String.class,
       jakarta.ws.rs.core.SecurityContext.class);
-    assertDocumented(queryParam(m, "limit"), "listEntityActivitiesJsonLd.limit");
+    assertDocumented(queryParam(m, "pageSize"), "listEntityActivitiesJsonLd.pageSize");
   }
 
   @Test
@@ -97,7 +97,7 @@ class ProvenanceRestParamAnnotationTest {
       "listEntityActivities",
       String.class, String.class, String.class, int.class,
       jakarta.ws.rs.core.SecurityContext.class);
-    assertDocumented(queryParam(m, "limit"), "listEntityActivities.limit");
+    assertDocumented(queryParam(m, "pageSize"), "listEntityActivities.pageSize");
   }
 
   @Test

--- a/frontend/composables/context/admin/useFetchAdminActivities.ts
+++ b/frontend/composables/context/admin/useFetchAdminActivities.ts
@@ -22,7 +22,7 @@ export function useFetchAdminActivities() {
         agent: filterAgent.value || undefined,
         targetKind: filterTargetKind.value || undefined,
         targetAppId: filterTargetAppId.value || undefined,
-        limit: limit.value,
+        pageSize: limit.value,
       });
       activities.value = Array.isArray(paged) ? paged : ((paged as unknown as { items?: Activity[] })?.items ?? []);
       hasMore.value = (Array.isArray(paged) ? paged.length : ((paged as unknown as { items?: Activity[] })?.items?.length ?? 0)) >= limit.value;

--- a/frontend/tests/unit/useFetchAdminActivities.test.ts
+++ b/frontend/tests/unit/useFetchAdminActivities.test.ts
@@ -41,13 +41,13 @@ function makePaged(items: ReturnType<typeof makeActivity>[]) {
 }
 
 describe("useFetchAdminActivities — initial load", () => {
-  it("calls listActivities on construction with default limit=100", async () => {
+  it("calls listActivities on construction with default pageSize=100", async () => {
     mockListActivities.mockResolvedValue(makePaged([]));
     useFetchAdminActivities();
     await flush();
     expect(mockListActivities).toHaveBeenCalledTimes(1);
     expect(mockListActivities).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: 100 }),
+      expect.objectContaining({ pageSize: 100 }),
     );
   });
 
@@ -151,12 +151,12 @@ describe("useFetchAdminActivities — filter params passed to API", () => {
 
     // bump limit to 200
     await loadMore();
-    let lastLimit = mockListActivities.mock.calls.at(-1)?.[0].limit;
+    let lastLimit = mockListActivities.mock.calls.at(-1)?.[0].pageSize;
     expect(lastLimit).toBe(200);
 
     // apply filters should reset to 100
     await applyFilters();
-    lastLimit = mockListActivities.mock.calls.at(-1)?.[0].limit;
+    lastLimit = mockListActivities.mock.calls.at(-1)?.[0].pageSize;
     expect(lastLimit).toBe(100);
   });
 });
@@ -168,11 +168,11 @@ describe("useFetchAdminActivities — loadMore", () => {
     await flush();
 
     await loadMore();
-    let lastLimit = mockListActivities.mock.calls.at(-1)?.[0].limit;
+    let lastLimit = mockListActivities.mock.calls.at(-1)?.[0].pageSize;
     expect(lastLimit).toBe(200);
 
     await loadMore();
-    lastLimit = mockListActivities.mock.calls.at(-1)?.[0].limit;
+    lastLimit = mockListActivities.mock.calls.at(-1)?.[0].pageSize;
     expect(lastLimit).toBe(300);
   });
 });
@@ -198,6 +198,6 @@ describe("useFetchAdminActivities — resetFilters", () => {
     expect(lastCall.agent).toBeUndefined();
     expect(lastCall.targetKind).toBeUndefined();
     expect(lastCall.targetAppId).toBeUndefined();
-    expect(lastCall.limit).toBe(100);
+    expect(lastCall.pageSize).toBe(100);
   });
 });


### PR DESCRIPTION
## Summary

Six `ProvenanceRest` cursor-pagination endpoints declared `@QueryParam("limit")` while every other v2 paginated endpoint uses `@QueryParam("pageSize")`. A caller who reads any other v2 endpoint first will expect `?pageSize=` and pass it — but the provenance endpoints silently ignore it and return the server default.

**Slice:** `APISIMP-PROV-CURSOR-PAGENAME` (size S, fire-498)  
**AC:** `grep -n '"limit"' .../ProvenanceRest.java` returns zero `@QueryParam` usages; `mvn verify -pl backend` green; `npm run test` green.

## Changes

| File | What changed |
|------|-------------|
| `ProvenanceRest.java` | `@QueryParam("limit")` → `@QueryParam("pageSize")` at 6 sites; local variable + description strings updated |
| `ProvenanceApi.ts` (generated client) | `ListActivitiesRequest.limit` + `ListEntityActivitiesRequest.limit` → `pageSize`; `queryParameters` mappings updated |
| `useFetchAdminActivities.ts` | API call property key `limit:` → `pageSize:` |
| `useFetchAdminActivities.test.ts` | All assertions updated from `.limit` to `.pageSize` |
| `ProvenanceRestParamAnnotationTest.java` | Reflection queries updated from `"limit"` to `"pageSize"` |
| `aidocs/16-dispatcher-backlog.md` | `APISIMP-PROV-CURSOR-PAGENAME` status: `queued` → `in-flight` |

## No v1 wire-shape changes

Only `/v2/provenance/` endpoints are touched. The frozen `/shepard/api/` surface is untouched.

## Test plan

- [ ] `mvn -q -DnoPlugins compile` (backend) — passes ✓ (verified locally)
- [ ] `mvn verify -pl backend` — CI
- [ ] `npm run lint` (frontend) — CI
- [ ] `npm run test` (frontend/Vitest) — CI
- [ ] `npm run typecheck` (frontend) — CI

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9CgiPBLWU5s1KPc6tfLVE)_