### PR TITLE
fix(APISIMP-PUBLICATIONS-KIND-410): tombstone GET /v2/{kind}/{appId}/publications with 410 (XS)

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4599,7 +4599,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/bundle/io/PagedFilesIO.java`; `aidocs/agent-findings/apisimp-sweep-2026-07-09-fire500.md §F2`.
 
 ## APISIMP-BUNDLES-FILES-PAGESIZE-UNCLAMPED — add `@Min(1) @Max(1000)` to `BundleGroupsV2Rest.listFiles()` `pageSize` (size: XS, sweep: fire-500)
-- **Status:** queued.
+- **Status:** done (fire-505, self-resolved — `@Min(1) @Max(1000)` already present in `BundleGroupsV2Rest.java` line 369 with matching `@Schema(minimum="1",maximum="1000")` on the `listGroupFiles` method; row pre-dates the fix).
 - **Why:** `BundleGroupsV2Rest.java` lines 354–359: `listFiles()` declares `@QueryParam("pageSize") @DefaultValue("200") Integer pageSize` and clamps via `Math.min(MAX, Math.max(1, pageSize))` in Java, emitting no OpenAPI constraint. The sibling `listGroups()` endpoint correctly carries `@Min(1) @Max(200)`. OpenAPI consumers (generated SDK, Swagger UI) see an unconstrained integer on the files endpoint.
 - **Fix:** Add `@Min(1) @Max(1000)` (or whatever `MAX` constant is in scope) to the `pageSize` parameter declaration; add the corresponding `@Schema` constraint in the `@Operation` if needed.
 - **AC:** `grep "@Min" BundleGroupsV2Rest.java` matches on both `listGroups` and `listFiles` pageSize params; OpenAPI spec shows `minimum: 1, maximum: 1000` for the files endpoint; `mvn verify -pl backend` green.
@@ -4620,7 +4620,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java:203`; `aidocs/agent-findings/apisimp-sweep-2026-07-09-fire500.md §F4-2`.
 
 ## APISIMP-PUBLICATIONS-KIND-410 — tombstone `GET /v2/{kind}/{appId}/publications` with 410 → `Location: /v2/publications` (size: XS, sweep: fire-500)
-- **Status:** queued.
+- **Status:** shipped (fire-505).
 - **Why:** `PublicationsListRest.java` exposes `GET /v2/{kind}/{appId}/publications`, already marked `deprecated = true` in the OpenAPI operation. The canonical surface is `GET /v2/publications` via `FlatPublicationsRest`. Despite APISIMP-PUBS-ALIAS-HARDCODED-LIMIT (fire-461) adding pagination to the canonical endpoint, this deprecated alias still returns live data — old callers never discover the migration path.
 - **Fix:** Replace the live `PagedResponseIO` response with a 410 Gone + `Location: /v2/publications` (ProblemResponse pattern). Verify no frontend caller still uses the per-kind path.
 - **AC:** `GET /v2/containers/{appId}/publications` → 410 with `Location: /v2/publications`; `GET /v2/publications` → 200; frontend composables use only the canonical path; `mvn verify -pl backend` green.

--- a/backend/src/main/java/de/dlr/shepard/v2/publish/resources/PublicationsListRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/publish/resources/PublicationsListRest.java
@@ -1,73 +1,29 @@
 package de.dlr.shepard.v2.publish.resources;
 
-import de.dlr.shepard.auth.permission.services.PermissionsService;
-import de.dlr.shepard.common.exceptions.ProblemJson;
-import de.dlr.shepard.common.identifier.EntityIdResolver;
-import de.dlr.shepard.common.util.AccessType;
-import de.dlr.shepard.publish.PublishableKindRegistry;
-import de.dlr.shepard.publish.daos.PublicationDAO;
-import de.dlr.shepard.publish.entities.Publication;
-import de.dlr.shepard.v2.publish.io.PublicationIO;
-import de.dlr.shepard.v2.common.io.PagedResponseIO;
+import de.dlr.shepard.v2.common.ProblemResponse;
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.inject.Inject;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
-import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.eclipse.microprofile.openapi.annotations.headers.Header;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
-import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
- * KIP1k — {@code GET /v2/{kind}/{appId}/publications} list endpoint.
+ * APISIMP-PUBLICATIONS-KIND-410 — tombstone.
  *
- * <p>Returns every {@link Publication} attached to the entity, ordered
- * {@code mintedAt DESC} (most-recent first — the "current" Publication
- * per the KIP1a append-only convention). The list includes retired rows
- * (so the caller can render the full history); callers that want only
- * active Publications should filter by {@code digitalObjectMutability != "retired"}.
+ * <p>{@code GET /v2/{kind}/{appId}/publications} is superseded by the
+ * kind-agnostic flat alias {@code GET /v2/publications?entityAppId={appId}}
+ * which does not require the caller to know the entity-kind URL segment.
  *
- * <p>This is the "GET helper" the {@link PublishButton} JSDoc
- * (KIP1e {@code KIP1a wire reality} scope-down note) anticipated:
- * <pre>
- *   "A future slice can wire a GET /v2/{kind}/{appId}/publications helper
- *    (or expose HAS_PUBLICATION on the v2 entity-detail shape) and upgrade
- *    the button to show 'Published — view PID' + the popover."
- * </pre>
- *
- * <p>Auth: caller must hold {@code Read} on the entity (same predicate
- * as other v2 GET endpoints that return entity state). This is intentionally
- * less restrictive than {@code POST /publish} (Write/Manage) — a reader
- * should be able to see whether something is published without being
- * a writer.
- *
- * <p>Pagination: optional {@code page}/{@code pageSize} params (default 0/50, max 500).
- * The response envelope is {@link PagedResponseIO} matching the canonical flat alias
- * {@code GET /v2/publications?entityAppId=…}.
- *
- * <p>No sorting or filter query params are exposed — clients that want
- * only active rows filter on {@code digitalObjectMutability} client-side.
- * The DAO already orders by {@code mintedAt DESC} so index [0] is always
- * the most-recent (potentially "current") Publication.
+ * <p>All requests to this path return 410 Gone with a {@code Location} header
+ * pointing to the canonical successor.
  */
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/v2/{kind}/{appId}/publications")
@@ -75,112 +31,44 @@ import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 @Tag(name = "Publish")
 public class PublicationsListRest {
 
-  static final String PT_UNAUTHORIZED = "/problems/publish.unauthorized";
-  static final String PT_NOT_FOUND = "/problems/publish.not-found";
-  static final String PT_KIND_UNSUPPORTED = "/problems/publish.kind.unsupported";
-  static final String PT_FORBIDDEN = "/problems/publish.forbidden";
+  private static final String SUCCESSOR = "/v2/publications";
 
-  @Inject
-  PublishableKindRegistry kindRegistry;
+  private static final String GONE_DETAIL =
+    "This endpoint is deprecated and removed. " +
+    "Use GET /v2/publications?entityAppId={appId} instead — it returns the same data " +
+    "without requiring the entity-kind URL segment.";
 
-  @Inject
-  PublicationDAO publicationDAO;
-
-  @Inject
-  PermissionsService permissionsService;
-
-  @Inject
-  EntityIdResolver entityIdResolver;
+  private static Response gone() {
+    return ProblemResponse.problemBuilder(
+        "urn:shepard:error:gone", "Gone", Response.Status.GONE.getStatusCode(), GONE_DETAIL)
+      .header("Location", SUCCESSOR)
+      .header("Link", "<" + SUCCESSOR + ">; rel=\"successor-version\"")
+      .build();
+  }
 
   @GET
   @Operation(
-    operationId = "listPublications",
-    summary = "List Publications attached to an entity (most-recent first).",
-    description = "Returns :Publication rows attached to the entity ordered by mintedAt DESC. " +
-    "Includes retired rows (digitalObjectMutability = 'retired') so callers can render the full " +
-    "publication history. Clients wanting only active Publications should filter " +
-    "digitalObjectMutability != 'retired' client-side. " +
-    "Auth: Read permission on the entity. Optional page/pageSize params (default 0/50, max 500); " +
-    "response is a PagedResponseIO envelope matching GET /v2/publications.\n\n" +
-    "DEPRECATED (APISIMP-PUBLICATIONS-KIND-PATH-SEGMENT): use the kind-agnostic alias " +
-    "GET /v2/publications?entityAppId={appId} instead — it does not require the caller to " +
-    "know the entity-kind URL segment. This path is kept for backward compatibility.",
+    operationId = "listPublicationsByKind",
+    summary = "[GONE] List Publications by entity kind — use GET /v2/publications?entityAppId=…",
     deprecated = true
   )
-  @APIResponse(
-    responseCode = "200",
-    description = "Paged list of Publications, most-recent first.",
-    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)),
-    headers = @Header(
-      name = "X-Total-Count",
-      description = "Total element count before paging.",
-      schema = @Schema(type = SchemaType.INTEGER)
-    )
-  )
-  @APIResponse(responseCode = "401", description = "Authentication required.")
-  @APIResponse(responseCode = "403", description = "Caller lacks Read permission on the entity.")
-  @APIResponse(responseCode = "404", description = "Unsupported `{kind}` segment, or no entity with `{appId}` of that kind.")
+  @APIResponse(responseCode = "410", description = "Endpoint removed. Use GET /v2/publications?entityAppId={appId}.")
   public Response list(
-    @Parameter(description = "Entity-kind URL segment (e.g. 'data-objects', 'collections').", required = true)
     @PathParam("kind") String kind,
-    @Parameter(description = "AppId of the entity whose Publications to list.", required = true)
     @PathParam("appId") String appId,
-    @Parameter(description = "Zero-based page index (default 0).")
-    @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
-    @Parameter(description = "Page size, 1–500 (default 50).")
-    @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(500) int pageSize,
-    @Context SecurityContext securityContext,
-    @Context UriInfo uriInfo
+    @QueryParam("page") @DefaultValue("0") int page,
+    @QueryParam("pageSize") @DefaultValue("50") int pageSize
   ) {
-    String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
-    if (caller == null) return problem(Response.Status.UNAUTHORIZED, PT_UNAUTHORIZED, "Authentication required",
-        "Authentication is required to list publications.");
-
-    var kindOpt = kindRegistry.bySegment(kind);
-    if (kindOpt.isEmpty()) {
-      return problem(Response.Status.NOT_FOUND, PT_KIND_UNSUPPORTED, "Unsupported publishable kind",
-        "No publishable kind matches URL segment '" + kind + "'. Supported: " +
-        String.join(", ", kindRegistry.supportedSegments()) + ".");
-    }
-    // Resolve the OGM id so we can check permissions via PermissionsService.
-    // The EntityIdResolver throws NotFoundException when the entity doesn't
-    // exist; we surface that as 404 (same handling as PublishRest).
-    long ogmId;
-    try {
-      ogmId = entityIdResolver.resolveLong(appId);
-    } catch (NotFoundException nfe) {
-      return problem(Response.Status.NOT_FOUND, PT_NOT_FOUND, "Entity not found",
-          "No entity with appId '" + appId + "' found.");
-    }
-    // Read permission is sufficient for listing Publications — a researcher
-    // who can see the entity should be able to see its PID history.
-    if (!permissionsService.isAccessTypeAllowedForUser(ogmId, AccessType.Read, caller)) {
-      return problem(Response.Status.FORBIDDEN, PT_FORBIDDEN, "Access denied",
-          "Caller '" + caller + "' lacks Read permission on entity '" + appId + "'.");
-    }
-
-    long total = publicationDAO.countByEntityAppId(appId);
-    // Widen to long before multiplying to prevent integer overflow;
-    // clamp to total so skip never exceeds the actual result-set size.
-    int skip = (int) Math.min((long) page * pageSize, total);
-    List<PublicationIO> items = publicationDAO.findByEntityAppId(appId, skip, pageSize)
-      .stream()
-      .map(p -> {
-        String resolverUrl = absoluteUrl(uriInfo, "/v2/.well-known/kip/" + p.getPid());
-        return PublicationIO.from(p, resolverUrl);
-      })
-      .toList();
-
-    return Response.ok(new PagedResponseIO<>(items, total, page, pageSize))
-      .header("X-Total-Count", total)
-      .build();
+    return gone();
   }
 
   /**
    * Build a fully-qualified URL at the supplied application-relative path
-   * using the request's own scheme + host + port. Mirrors the same helper
-   * in {@link PublishRest} and {@code KipResolverRest} — kept local to
-   * avoid promoting it to a public cross-module API.
+   * using the request's own scheme + host + port.
+   *
+   * <p>Used by {@link FlatPublicationsRest} for KIP resolver URL construction.
+   * Kept here during the tombstone phase; will move to a shared utility once
+   * a logical home exists.
    */
   static String absoluteUrl(UriInfo uriInfo, String applicationPath) {
     if (uriInfo == null) return applicationPath;
@@ -196,5 +84,4 @@ public class PublicationsListRest {
     sb.append(applicationPath.startsWith("/") ? applicationPath : "/" + applicationPath);
     return sb.toString();
   }
-
 }

--- a/backend/src/test/java/de/dlr/shepard/v2/publish/resources/PublicationsListRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/publish/resources/PublicationsListRestTest.java
@@ -1,231 +1,59 @@
 package de.dlr.shepard.v2.publish.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import de.dlr.shepard.auth.permission.services.PermissionsService;
-import de.dlr.shepard.common.identifier.EntityIdResolver;
-import de.dlr.shepard.common.util.AccessType;
-import de.dlr.shepard.publish.PublishableKindRegistry;
-import de.dlr.shepard.publish.daos.PublicationDAO;
-import de.dlr.shepard.publish.entities.Publication;
-import de.dlr.shepard.v2.common.io.PagedResponseIO;
-import de.dlr.shepard.v2.publish.io.PublicationIO;
-import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.SecurityContext;
-import jakarta.ws.rs.core.UriInfo;
-import java.net.URI;
-import java.security.Principal;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * KIP1k unit tests for {@link PublicationsListRest}.
+ * APISIMP-PUBLICATIONS-KIND-410 unit tests for the tombstoned {@link PublicationsListRest}.
  *
- * <p>Pattern mirrors {@link PublishRestTest}: real
- * {@code PublishableKindRegistry} (small + safe), all other
- * collaborators mocked.
+ * <p>All calls must return 410 Gone with a {@code Location} header pointing to
+ * {@code /v2/publications} and a problem+json body.
  */
 class PublicationsListRestTest {
 
   private PublicationsListRest rest;
-  private PublishableKindRegistry kindRegistry;
-  private PublicationDAO publicationDAO;
-  private PermissionsService permissionsService;
-  private EntityIdResolver entityIdResolver;
-  private SecurityContext securityContext;
-  private UriInfo uriInfo;
 
   @BeforeEach
   void setUp() {
     rest = new PublicationsListRest();
-    kindRegistry = new PublishableKindRegistry();
-    publicationDAO = mock(PublicationDAO.class);
-    permissionsService = mock(PermissionsService.class);
-    entityIdResolver = mock(EntityIdResolver.class);
-    securityContext = mock(SecurityContext.class);
-    uriInfo = mock(UriInfo.class);
-
-    rest.kindRegistry = kindRegistry;
-    rest.publicationDAO = publicationDAO;
-    rest.permissionsService = permissionsService;
-    rest.entityIdResolver = entityIdResolver;
-
-    Principal alice = () -> "alice";
-    when(securityContext.getUserPrincipal()).thenReturn(alice);
-    when(uriInfo.getBaseUri()).thenReturn(URI.create("https://shepard.example.dlr.de:8443/shepard/api/"));
-  }
-
-  private Publication publication(String pid, long mintedAt) {
-    Publication p = new Publication();
-    p.setAppId("pub-" + pid.hashCode());
-    p.setPid(pid);
-    p.setMintedAt(mintedAt);
-    p.setMinterId("local");
-    p.setPublishedBy("alice");
-    p.setEntityKind("data-objects");
-    p.setEntityAppId("01HF-A");
-    p.setVersionNumber(1);
-    return p;
-  }
-
-  /** Stub count + bounded DAO overload used by PublicationsListRest (default page=0, pageSize=50). */
-  private void stubBoundedDao(String appId, List<Publication> pubs) {
-    when(publicationDAO.countByEntityAppId(eq(appId))).thenReturn((long) pubs.size());
-    when(publicationDAO.findByEntityAppId(eq(appId), eq(0), eq(50))).thenReturn(pubs);
   }
 
   @Test
-  void happyPathReturns200WithListAndResolverUrls() {
-    when(entityIdResolver.resolveLong("01HF-A")).thenReturn(42L);
-    when(permissionsService.isAccessTypeAllowedForUser(eq(42L), eq(AccessType.Read), eq("alice")))
-      .thenReturn(true);
-    Publication pub = publication("shepard:dlr.de/shepard-prod:data-objects:01HF-A:v1", 1_747_000_000_000L);
-    stubBoundedDao("01HF-A", List.of(pub));
-
-    Response r = rest.list("data-objects", "01HF-A", 0, 50, securityContext, uriInfo);
-
-    assertEquals(200, r.getStatus());
-    @SuppressWarnings("unchecked")
-    PagedResponseIO<PublicationIO> body = (PagedResponseIO<PublicationIO>) r.getEntity();
-    assertEquals(1, body.total());
-    assertEquals(1, body.items().size());
-    assertEquals("shepard:dlr.de/shepard-prod:data-objects:01HF-A:v1", body.items().get(0).pid());
-    assertTrue(
-      body.items().get(0).resolverUrl().endsWith(
-        "/v2/.well-known/kip/shepard:dlr.de/shepard-prod:data-objects:01HF-A:v1"
-      ),
-      "resolverUrl should point to the KIP resolver path"
-    );
+  void anyCallReturns410Gone() {
+    Response r = rest.list("data-objects", "01HF-A", 0, 50);
+    assertEquals(410, r.getStatus());
   }
 
   @Test
-  void emptyListWhenNeverPublished() {
-    when(entityIdResolver.resolveLong("01HF-NEW")).thenReturn(99L);
-    when(permissionsService.isAccessTypeAllowedForUser(eq(99L), eq(AccessType.Read), eq("alice")))
-      .thenReturn(true);
-    stubBoundedDao("01HF-NEW", List.of());
-
-    Response r = rest.list("data-objects", "01HF-NEW", 0, 50, securityContext, uriInfo);
-
-    assertEquals(200, r.getStatus());
-    @SuppressWarnings("unchecked")
-    PagedResponseIO<PublicationIO> body = (PagedResponseIO<PublicationIO>) r.getEntity();
-    assertEquals(0, body.total());
-    assertTrue(body.items().isEmpty(), "Unpublished entity should return an empty list");
+  void responseHasLocationHeader() {
+    Response r = rest.list("data-objects", "01HF-A", 0, 50);
+    assertEquals("/v2/publications", r.getHeaderString("Location"));
   }
 
   @Test
-  void multiplePublicationsReturnedMostRecentFirst() {
-    when(entityIdResolver.resolveLong("01HF-A")).thenReturn(42L);
-    when(permissionsService.isAccessTypeAllowedForUser(eq(42L), eq(AccessType.Read), eq("alice")))
-      .thenReturn(true);
-    Publication v2 = publication("shepard:dlr.de/shepard-prod:data-objects:01HF-A:v2", 1_747_100_000_000L);
-    v2.setVersionNumber(2);
-    Publication v1 = publication("shepard:dlr.de/shepard-prod:data-objects:01HF-A:v1", 1_747_000_000_000L);
-    // DAO returns most-recent first (matches PublicationDAO.findByEntityAppId ordering)
-    stubBoundedDao("01HF-A", List.of(v2, v1));
-
-    Response r = rest.list("data-objects", "01HF-A", 0, 50, securityContext, uriInfo);
-
-    assertEquals(200, r.getStatus());
-    @SuppressWarnings("unchecked")
-    PagedResponseIO<PublicationIO> body = (PagedResponseIO<PublicationIO>) r.getEntity();
-    assertEquals(2, body.total());
-    assertEquals(2, body.items().size());
-    assertTrue(body.items().get(0).pid().endsWith(":v2"), "First item should be most-recent (v2)");
-    assertTrue(body.items().get(1).pid().endsWith(":v1"), "Second item should be v1");
+  void responseIsApplicationProblemJson() {
+    Response r = rest.list("data-objects", "01HF-A", 0, 50);
+    assertNotNull(r.getMediaType());
+    assertTrue(r.getMediaType().toString().contains("problem+json"),
+      "Response media type should be application/problem+json");
   }
 
   @Test
-  void retiredPublicationIncludedInList() {
-    when(entityIdResolver.resolveLong("01HF-A")).thenReturn(42L);
-    when(permissionsService.isAccessTypeAllowedForUser(eq(42L), eq(AccessType.Read), eq("alice")))
-      .thenReturn(true);
-    Publication retired = publication("shepard:dlr.de/shepard-prod:data-objects:01HF-A:v1", 1_747_000_000_000L);
-    retired.setDigitalObjectMutability("retired");
-    stubBoundedDao("01HF-A", List.of(retired));
-
-    Response r = rest.list("data-objects", "01HF-A", 0, 50, securityContext, uriInfo);
-
-    assertEquals(200, r.getStatus());
-    @SuppressWarnings("unchecked")
-    PagedResponseIO<PublicationIO> body = (PagedResponseIO<PublicationIO>) r.getEntity();
-    assertEquals(1, body.total());
-    assertEquals(1, body.items().size(), "Retired publications should still appear in the list");
-    assertEquals("retired", body.items().get(0).digitalObjectMutability());
+  void differentKindAndAppIdStillReturns410() {
+    Response r = rest.list("collections", "01COLL-A", 0, 50);
+    assertEquals(410, r.getStatus());
+    assertEquals("/v2/publications", r.getHeaderString("Location"));
   }
 
   @Test
-  void missingAuthReturns401() {
-    when(securityContext.getUserPrincipal()).thenReturn(null);
-    Response r = rest.list("data-objects", "01HF-A", 0, 50, securityContext, uriInfo);
-    assertEquals(401, r.getStatus());
-  }
-
-  @Test
-  void unsupportedKindReturns404WithProblemJson() {
-    Response r = rest.list("file-references", "01HF-A", 0, 50, securityContext, uriInfo);
-    assertEquals(404, r.getStatus());
-    assertEquals("application/problem+json", r.getMediaType().toString());
-    assertTrue(r.getEntity().toString().contains("publish.kind.unsupported"));
-  }
-
-  @Test
-  void missingEntityReturns404() {
-    when(entityIdResolver.resolveLong("01HF-MISSING")).thenThrow(new NotFoundException("nope"));
-    Response r = rest.list("data-objects", "01HF-MISSING", 0, 50, securityContext, uriInfo);
-    assertEquals(404, r.getStatus());
-  }
-
-  @Test
-  void permissionDeniedReturns403() {
-    when(entityIdResolver.resolveLong("01HF-A")).thenReturn(42L);
-    when(permissionsService.isAccessTypeAllowedForUser(eq(42L), eq(AccessType.Read), eq("alice")))
-      .thenReturn(false);
-    Response r = rest.list("data-objects", "01HF-A", 0, 50, securityContext, uriInfo);
-    assertEquals(403, r.getStatus());
-  }
-
-  @Test
-  void collectionsKindIsAccepted() {
-    when(entityIdResolver.resolveLong("01COLL-A")).thenReturn(55L);
-    when(permissionsService.isAccessTypeAllowedForUser(eq(55L), eq(AccessType.Read), eq("alice")))
-      .thenReturn(true);
-    Publication pub = publication("shepard:dlr.de/shepard-prod:collections:01COLL-A:v1", 1_747_000_000_000L);
-    pub.setEntityKind("collections");
-    pub.setEntityAppId("01COLL-A");
-    stubBoundedDao("01COLL-A", List.of(pub));
-
-    Response r = rest.list("collections", "01COLL-A", 0, 50, securityContext, uriInfo);
-
-    assertEquals(200, r.getStatus());
-  }
-
-  @Test
-  void paginationParamsForwardedToDao() {
-    when(entityIdResolver.resolveLong("01HF-A")).thenReturn(42L);
-    when(permissionsService.isAccessTypeAllowedForUser(eq(42L), eq(AccessType.Read), eq("alice")))
-      .thenReturn(true);
-    // Simulate 75 publications total; request page 1, pageSize 25 → skip=25.
-    when(publicationDAO.countByEntityAppId(eq("01HF-A"))).thenReturn(75L);
-    Publication pub = publication("shepard:dlr.de/shepard-prod:data-objects:01HF-A:v26", 1_747_000_000_000L);
-    when(publicationDAO.findByEntityAppId(eq("01HF-A"), eq(25), eq(25))).thenReturn(List.of(pub));
-
-    Response r = rest.list("data-objects", "01HF-A", 1, 25, securityContext, uriInfo);
-
-    assertEquals(200, r.getStatus());
-    @SuppressWarnings("unchecked")
-    PagedResponseIO<PublicationIO> body = (PagedResponseIO<PublicationIO>) r.getEntity();
-    assertEquals(75L, body.total());
-    assertEquals(1, body.page());
-    assertEquals(25, body.pageSize());
-    assertEquals(1, body.items().size());
-    assertEquals("75", r.getHeaderString("X-Total-Count"));
+  void problemBodyContainsGoneType() {
+    Response r = rest.list("data-objects", "01HF-A", 0, 50);
+    String body = r.getEntity().toString();
+    assertTrue(body.contains("urn:shepard:error:gone"), "Problem body should contain gone type");
   }
 }


### PR DESCRIPTION
## Summary

- **Tombstones** `GET /v2/{kind}/{appId}/publications` → 410 Gone + `Location: /v2/publications`.
- `PublicationsListRest` business logic removed; all injected fields dropped. Single `gone()` helper returns 410 with `Location` + `Link; rel="successor-version"` headers and a `application/problem+json` body.
- **Keeps** `absoluteUrl()` static helper in place — `FlatPublicationsRest` calls it for KIP resolver URL construction.
- **Updates** `PublicationsListRestTest` — replaces 9 live-data scenario tests with 5 focused tombstone tests (410 status, Location header, problem+json content-type, kind-agnostic, problem body type).
- **Marks** `APISIMP-BUNDLES-FILES-PAGESIZE-UNCLAMPED` as self-resolved in `aidocs/16` (the `@Min(1) @Max(1000)` annotation was already in `BundleGroupsV2Rest.java:369` before the row was filed).

## Backlog row

`APISIMP-PUBLICATIONS-KIND-410` (XS) — `aidocs/16-dispatcher-backlog.md`

## Checklist

- [x] No `/shepard/api/` v1 surface touched
- [x] No new `@Path(Constants.SHEPARD_API + ...)` added
- [x] `FlatPublicationsRest` still compiles — `absoluteUrl()` retained
- [x] Frontend has zero callers of `/v2/{kind}/{appId}/publications` (confirmed by grep)
- [x] `mvn -q -DnoPlugins compile` green (production code only; `SpatialDataReferenceIT` test-compile failure is pre-existing, spatial plugin artifacts absent from local cache)
- [x] `aidocs/16` backlog rows updated

---
_Generated by the V2CONV+APISIMP hourly pipeline (fire-505)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXtajzoDT9iw2r7rga3Bxb)_