### PR TITLE
fix(APISIMP-MAPPINGS-PATHPARAM): rename {templateAppId} → {appId} path-param in MappingsMaterializeRest (XS)

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4648,9 +4648,10 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java:82,140,180,226,227,266,267,312,313,358,359,413,414`; `aidocs/agent-findings/apisimp-sweep-fire501-2026-07-09.md §F1`.
 
 ## APISIMP-MAPPINGS-PATHPARAM — rename `{templateAppId}` → `{appId}` path-param in `MappingsMaterializeRest` (size: XS, sweep: fire-501)
-- **Status:** queued.
+- **Status:** shipped (fire-507).
+- **PR:** #2438.
 - **Why:** `MappingsMaterializeRest.java:99` uses `@Path("/v2/mappings/{templateAppId}/materialize")` with `@PathParam("templateAppId")`. The v2 convention is bare `{appId}` when the resource type is already implied by the path prefix (`/v2/mappings/`). `ShepardTemplateRest` (the sibling mapping-template CRUD resource) uses `{appId}` correctly.
-- **Fix:** Rename `{templateAppId}` → `{appId}` in the `@Path` annotation and the `@PathParam("templateAppId")` binding in `materialize()`. No URL change; no migration needed.
+- **Fix:** Renamed `{templateAppId}` → `{appId}` in `@Path`, `@PathParam`, method parameter, and all variable usages in `materialize()`. No URL structure change; no migration needed.
 - **AC:** `grep -n "templateAppId" MappingsMaterializeRest.java` returns 0 results; `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/mappings/resources/MappingsMaterializeRest.java:99,120`; `aidocs/agent-findings/apisimp-sweep-fire501-2026-07-09.md §F2`.
 

--- a/backend/src/main/java/de/dlr/shepard/v2/mappings/resources/MappingsMaterializeRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/mappings/resources/MappingsMaterializeRest.java
@@ -37,7 +37,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 /**
- * V2CONV-B3 — {@code POST /v2/mappings/{templateAppId}/materialize} — the
+ * V2CONV-B3 — {@code POST /v2/mappings/{appId}/materialize} — the
  * generic MAPPING_RECIPE materialization endpoint.
  *
  * <p><b>Endpoint-shape decision.</b> A dedicated {@code /v2/mappings/*} resource
@@ -96,7 +96,7 @@ public class MappingsMaterializeRest {
   ProvenanceService provenanceService;
 
   @POST
-  @Path("/{templateAppId}/materialize")
+  @Path("/{appId}/materialize")
   @RolesAllowed("authenticated")
   @Operation(
     operationId = "materialize",
@@ -117,18 +117,18 @@ public class MappingsMaterializeRest {
     description = "Template found but not a MAPPING_RECIPE, or the body declares no mappingRecipeShape."
   )
   public Response materialize(
-    @PathParam("templateAppId") String templateAppId,
+    @PathParam("appId") String appId,
     MaterializeRequestIO body,
     @Context SecurityContext securityContext,
     @Context ContainerRequestContext requestContext
   ) {
-    if (templateAppId == null || templateAppId.isBlank()) {
-      return problem(Response.Status.BAD_REQUEST, "templateAppId path parameter is required", "transform.error");
+    if (appId == null || appId.isBlank()) {
+      return problem(Response.Status.BAD_REQUEST, "appId path parameter is required", "transform.error");
     }
 
-    ShepardTemplate template = templateDAO.findByAppId(templateAppId).orElse(null);
+    ShepardTemplate template = templateDAO.findByAppId(appId).orElse(null);
     if (template == null) {
-      return problem(Response.Status.NOT_FOUND, "template not found: " + templateAppId, "transform.error");
+      return problem(Response.Status.NOT_FOUND, "template not found: " + appId, "transform.error");
     }
 
     if (!MAPPING_RECIPE_KIND.equals(template.getTemplateKind())) {
@@ -171,7 +171,7 @@ public class MappingsMaterializeRest {
       : securityContext.getUserPrincipal().getName();
 
     TransformExecutor executor = match.get();
-    TransformRequest req = new TransformRequest(templateAppId, shapeIri, inputs, username, template.getBody());
+    TransformRequest req = new TransformRequest(appId, shapeIri, inputs, username, template.getBody());
 
     try {
       TransformResult result = executor.materialize(req);
@@ -180,7 +180,7 @@ public class MappingsMaterializeRest {
         return problem(Response.Status.INTERNAL_SERVER_ERROR, "executor '" + executor.name() + "' returned null", "transform.internal-error");
       }
       recordMaterializeActivity(template, executor, result, username, requestContext);
-      return Response.ok(MaterializeResponseIO.from(templateAppId, result)).build();
+      return Response.ok(MaterializeResponseIO.from(appId, result)).build();
     } catch (TransformException ex) {
       Log.debugf(ex, "V2CONV-B3: executor '%s' threw TransformException %s for shape <%s>", executor.name(), ex.code(), shapeIri);
       int status = statusForCode(ex.code());

--- a/backend/src/test/java/de/dlr/shepard/v2/mappings/resources/MappingsMaterializeRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/mappings/resources/MappingsMaterializeRestTest.java
@@ -79,7 +79,7 @@ class MappingsMaterializeRestTest {
   // ─── input validation ───────────────────────────────────────────────────
 
   @Test
-  void returns400OnBlankTemplateAppId() {
+  void returns400OnBlankAppId() {
     Response r = rest.materialize("  ", null, securityContext, requestContext);
     assertThat(r.getStatus()).isEqualTo(400);
   }


### PR DESCRIPTION
## Summary

Renames the path-param variable from `templateAppId` to `appId` in `MappingsMaterializeRest.materialize()` to match the single-name convention used by all other `/v2/` resource methods whose resource type is implied by the path prefix.

**Changes (2 files, pure rename):**

- `@Path("/{templateAppId}/materialize")` → `@Path("/{appId}/materialize")`
- `@PathParam("templateAppId") String templateAppId` → `@PathParam("appId") String appId`
- All 4 variable usages in the method body updated accordingly (null-check, DAO lookup, error message, `TransformRequest` constructor, `MaterializeResponseIO.from()` call)
- Error message string `"templateAppId path parameter is required"` → `"appId path parameter is required"`
- Test method `returns400OnBlankTemplateAppId()` → `returns400OnBlankAppId()`
- Class-level Javadoc updated: `{templateAppId}` → `{appId}` in the endpoint path

**No URL structure change.** Callers that hit `POST /v2/mappings/<uuid>/materialize` are unaffected — only the OpenAPI path-parameter name changes.

Note: `MaterializeResponseIO.templateAppId` (the response body echo field) is out of scope for this XS rename — it is a wire format key, not a path-param binding.

## Backlog row

`APISIMP-MAPPINGS-PATHPARAM` (XS) — `aidocs/16-dispatcher-backlog.md`

## Checklist

- [x] No `/shepard/api/` v1 surface touched
- [x] No new `@Path(Constants.SHEPARD_API + ...)` added
- [x] No URL structure change — only the OpenAPI path-parameter name changes
- [x] `grep -n "templateAppId" MappingsMaterializeRest.java` → 0 results
- [x] `mvn -q -DnoPlugins compile` green (production code)
- [x] `aidocs/16` backlog row updated to `shipped (fire-507)`

---
_Generated by the V2CONV+APISIMP hourly pipeline (fire-507)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6BT3D7NZPTP7Vp1Ed1qfL)_