### PR TITLE
feat(APISIMP-DO-NAME-TO-Q): rename ?name= → ?q= text filter on GET /v2/data-objects

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -453,7 +453,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/00-doc-stages.md`](00-doc-stages.md) | 00 — Doc lifecycle stages (taxonomy SSOT) | 2026-05-23 | 2026-07-08 |
 | [`aidocs/00-index.md`](00-index.md) | aidocs — Index | 2026-05-23 | 2026-07-08 |
 | [`aidocs/100-ui-annoyances.md`](100-ui-annoyances.md) | 100 — Shepard UI annoyances (live captured) | 2026-05-23 | 2026-07-08 |
-| [`aidocs/16-dispatcher-backlog.md`](16-dispatcher-backlog.md) | 16 — Dispatcher Backlog | 2026-05-23 | 2026-07-09 |
+| [`aidocs/16-dispatcher-backlog.md`](16-dispatcher-backlog.md) | 16 — Dispatcher Backlog | 2026-05-23 | 2026-07-10 |
 | [`aidocs/34-upstream-upgrade-path.md`](34-upstream-upgrade-path.md) | Upstream upgrade path — `dlr-shepard/shepard 5.2.0` → `noheton/shepard main` | 2026-05-23 | 2026-07-09 |
 | [`aidocs/40-ecosystem.md`](40-ecosystem.md) | 40 — Shepard ecosystem | 2026-05-23 | 2026-07-08 |
 | [`aidocs/41-synergy-sweep.md`](41-synergy-sweep.md) | 41 — Synergy sweep: collapse-where-generalisation-helps | 2026-05-23 | 2026-07-08 |

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4613,7 +4613,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:455`; `aidocs/agent-findings/apisimp-sweep-2026-07-09-fire500.md §F4-1`.
 
 ## APISIMP-DO-NAME-TO-Q — rename `?name=` → `?q=` text filter on `GET /v2/data-objects` (size: S, sweep: fire-500)
-- **Status:** queued.
+- **Status:** shipped (fire-510).
 - **Why:** `DataObjectV2Rest.java` line 203: `GET /v2/data-objects?name=…` uses `Constants.QP_NAME` ("name") as the substring filter. Same inconsistency as APISIMP-CONTAINERS-NAME-TO-Q — forces SDK consumers to remember a per-endpoint param name instead of the `?q=` convention.
 - **Fix:** Add `@QueryParam("q")` alias (reading from `Constants.QP_Q` or inline); deprecate `Constants.QP_NAME` usage on this endpoint for one release cycle. Update frontend composables and OpenAPI spec.
 - **AC:** `GET /v2/data-objects?q=foo` works; `?name=` still accepted with deprecation warning; `mvn verify -pl backend` green; `npm run typecheck` green.

--- a/backend-client/.openapi-source/openapi.json
+++ b/backend-client/.openapi-source/openapi.json
@@ -29083,8 +29083,17 @@
           },
           {
             "description": "Optional display-name filter (case-insensitive substring match). Omit to return all DataObjects.",
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Deprecated alias for `q`. Accepted for one release cycle; prefer `q`. Presence adds `Deprecation: true` response header.",
             "name": "name",
             "in": "query",
+            "deprecated": true,
             "schema": {
               "type": "string"
             }

--- a/backend-client/src/apis/DataObjectsApi.ts
+++ b/backend-client/src/apis/DataObjectsApi.ts
@@ -84,6 +84,9 @@ export interface ListDataObjectsRequest {
     createdBefore?: string;
     fields?: string;
     include?: string;
+    /** Preferred display-name filter (case-insensitive substring match). */
+    q?: string;
+    /** @deprecated Use `q` instead. Kept for one release cycle; adds `Deprecation: true` response header. */
     name?: string;
     page?: number;
     pageSize?: number;
@@ -509,6 +512,10 @@ export class DataObjectsApi extends runtime.BaseAPI {
 
         if (requestParameters['include'] != null) {
             queryParameters['include'] = requestParameters['include'];
+        }
+
+        if (requestParameters['q'] != null) {
+            queryParameters['q'] = requestParameters['q'];
         }
 
         if (requestParameters['name'] != null) {

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
@@ -163,7 +163,8 @@ public class DataObjectV2Rest {
       "envelope is absent. Migration to `PagedResponseIO` is tracked as " +
       "`APISIMP-DO-LIST-CONTENT-RANGE` in the backlog (a coordinated backend + " +
       "frontend two-commit change).\n\n" +
-      "Filtering: `name` does a case-insensitive substring match.\n\n" +
+      "Filtering: `q` (preferred) or deprecated `name` — case-insensitive substring match on display name. " +
+      "Using `?name=` emits `Deprecation: true` response header; migrate callers to `?q=`.\n\n" +
       "Optional enrichment via `?include=time-bounds`: adds `timeBoundsStart` and " +
       "`timeBoundsEnd` (epoch nanoseconds) to each item, reflecting the earliest and " +
       "latest data-point timestamps across all timeseries channels. Null on items " +
@@ -206,7 +207,9 @@ public class DataObjectV2Rest {
   public Response list(
     @PathParam("collectionAppId") @NotBlank String collectionAppId,
     @Parameter(description = "Optional display-name filter (case-insensitive substring match). Omit to return all DataObjects.")
-    @QueryParam(Constants.QP_NAME) String name,
+    @QueryParam("q") String q,
+    @Parameter(description = "Deprecated alias for `q`. Accepted for one release cycle; prefer `q`. Presence adds `Deprecation: true` response header.")
+    @Deprecated @QueryParam(Constants.QP_NAME) String nameLegacy,
     @Parameter(description = "Lifecycle status filter. Accepted values: DRAFT, IN_REVIEW, READY, PUBLISHED, ARCHIVED, FAILED, NCR_OPEN, ON_HOLD, REJECTED, CERTIFIED. Unrecognised values silently return an empty page (no 400).")
     @QueryParam("status") String status,
     @Parameter(description = "Zero-based page index (default 0). Negative values are clamped to 0.")
@@ -250,7 +253,8 @@ public class DataObjectV2Rest {
     if (gate != null) return gate;
 
     var params = new QueryParamHelper();
-    if (name != null) params = params.withName(name);
+    String nameFilter = q != null ? q : nameLegacy;
+    if (nameFilter != null) params = params.withName(nameFilter);
     if (status != null) params = params.withStatus(status);
     if (annotationFilter != null) params = params.withAnnotationFilter(annotationFilter);
     if (createdAfter != null || createdBefore != null) params = params.withCreatedRange(createdAfter, createdBefore);
@@ -363,12 +367,13 @@ public class DataObjectV2Rest {
         Response.Status.INTERNAL_SERVER_ERROR, "Failed to serialise DataObject list response");
     }
 
-    return Response.ok(body, MediaType.APPLICATION_JSON)
+    Response.ResponseBuilder rb = Response.ok(body, MediaType.APPLICATION_JSON)
       .header("Content-Range", contentRange)
       .header("X-Total-Count", total)
       .header("Cache-Control", "max-age=300, must-revalidate")
-      .header("X-Shepard-Payload-Diet", fields != null && !fields.isBlank() ? "fields" : (includeFull ? "full" : "default-trim"))
-      .build();
+      .header("X-Shepard-Payload-Diet", fields != null && !fields.isBlank() ? "fields" : (includeFull ? "full" : "default-trim"));
+    if (nameLegacy != null && q == null) rb = rb.header("Deprecation", "true");
+    return rb.build();
   }
 
   @GET

--- a/backend/src/test/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2RestTest.java
@@ -151,7 +151,7 @@ class DataObjectV2RestTest {
   @Test
   void listReturns404WhenCollectionUnknown() {
     when(entityIdResolver.resolveLong(COLL_APP_ID)).thenThrow(new NotFoundException());
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
     assertEquals(404, r.getStatus());
     verify(dataObjectService, never()).getAllDataObjectsByShepardIds(anyLong(), any(), any());
   }
@@ -161,7 +161,7 @@ class DataObjectV2RestTest {
     when(entityIdResolver.resolveLong(COLL_APP_ID)).thenReturn(COLL_OGM_ID);
     when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
       .thenReturn(false);
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
     assertEquals(403, r.getStatus());
   }
 
@@ -174,7 +174,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), any(), eq(null)))
       .thenReturn(List.of(d));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -195,7 +195,7 @@ class DataObjectV2RestTest {
     when(dataObjectDAO.findRefCountsByAppIds(List.of(DO_APP_ID)))
       .thenReturn(Map.of(DO_APP_ID, new long[] { 3L, 5L, 2L }));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -222,7 +222,7 @@ class DataObjectV2RestTest {
     when(timeseriesDataPointRepository.findTimeBoundsByContainerIds(List.of(containerNeo4jId)))
       .thenReturn(Map.of(containerNeo4jId, new long[] { 1_000_000L, 9_000_000L }));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, "time-bounds", null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, "time-bounds", null, null, null, null, null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -245,7 +245,7 @@ class DataObjectV2RestTest {
     when(dataObjectDAO.countByCollectionByShepardIds(eq(COLL_OGM_ID), any())).thenReturn(8514L);
 
     // page=3, size=25 → firstIndex=75, lastIndex=75 (1 item)
-    Response r = resource.list(COLL_APP_ID, null, null, 3, 25, null, null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 3, 25, null, null, null, null, null, null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     // Content-Range must be present with format "dataobjects firstIndex-lastIndex/total"
@@ -268,7 +268,7 @@ class DataObjectV2RestTest {
       .thenReturn(Collections.emptyList());
     when(dataObjectDAO.countByCollectionByShepardIds(eq(COLL_OGM_ID), any())).thenReturn(0L);
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 25, null, null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 25, null, null, null, null, null, null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     String contentRange = (String) r.getHeaders().getFirst("Content-Range");
@@ -288,7 +288,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), any(), eq(null)))
       .thenReturn(List.of(d));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -310,7 +310,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
       .thenReturn(List.of(d));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null,
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null,
       "urn:shepard:mffd:process-type=afp-course", null, null, null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -328,7 +328,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), any(), eq(null)))
       .thenReturn(Collections.emptyList());
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null,
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null,
       "malformed-no-equals", null, null, null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -343,7 +343,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
       .thenReturn(Collections.emptyList());
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     assertFalse(paramsCaptor.getValue().hasAnnotationFilter());
@@ -360,7 +360,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
       .thenReturn(Collections.emptyList());
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null,
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null,
       "2024-06-02T00:00:00Z", "2024-06-03T00:00:00Z", null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -379,7 +379,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
       .thenReturn(Collections.emptyList());
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null,
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null,
       "2024-06-02T00:00:00Z", null, null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -395,7 +395,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
       .thenReturn(Collections.emptyList());
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null,
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null,
       "not-a-date", "also-not-a-date", null, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -414,7 +414,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
       .thenReturn(List.of(d));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, null, true, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, null, true, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     QueryParamHelper captured = paramsCaptor.getValue();
@@ -436,7 +436,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
       .thenReturn(List.of(child));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, parentAppId, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, parentAppId, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     QueryParamHelper captured = paramsCaptor.getValue();
@@ -452,7 +452,7 @@ class DataObjectV2RestTest {
       .thenReturn(true);
     when(dataObjectDAO.findByAppId(parentAppId)).thenReturn(null);
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, parentAppId, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, parentAppId, null, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
     assertEquals("[]", r.getEntity());
@@ -469,7 +469,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
       .thenReturn(List.of(d));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null,
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null,
       null, null, "018f9c5a-7e26-7000-a000-0000000042ff", true, null, null, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -494,7 +494,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
       .thenReturn(List.of(child));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null,
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null,
       null, null, null, null, predAppId, null, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -511,7 +511,7 @@ class DataObjectV2RestTest {
       .thenReturn(true);
     when(dataObjectDAO.findByAppId(predAppId)).thenReturn(null);
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null,
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null,
       null, null, null, null, predAppId, null, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -533,7 +533,7 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
       .thenReturn(List.of(pred));
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null,
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null,
       null, null, null, null, null, succAppId, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -550,7 +550,7 @@ class DataObjectV2RestTest {
       .thenReturn(true);
     when(dataObjectDAO.findByAppId(succAppId)).thenReturn(null);
 
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null,
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null,
       null, null, null, null, null, succAppId, securityContext);
 
     assertEquals(200, r.getStatus());
@@ -1148,7 +1148,7 @@ class DataObjectV2RestTest {
   @Test
   void listDefaultTrimDropsHeavyFields() {
     stubListSingleDataObject();
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
     assertEquals(200, r.getStatus());
     String body = (String) r.getEntity();
     // Heavy fields gone by default
@@ -1171,7 +1171,7 @@ class DataObjectV2RestTest {
   @Test
   void listIncludeFullReturnsFullShape() {
     stubListSingleDataObject();
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, "full", null, null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, "full", null, null, null, null, null, null, null, null, securityContext);
     assertEquals(200, r.getStatus());
     String body = (String) r.getEntity();
     // All fields back including the heavy ones
@@ -1184,7 +1184,7 @@ class DataObjectV2RestTest {
   @Test
   void listFieldsParamLimitsToRequestedFields() {
     stubListSingleDataObject();
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "appId,name,createdAt", null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, "appId,name,createdAt", null, null, null, null, null, null, null, securityContext);
     assertEquals(200, r.getStatus());
     String body = (String) r.getEntity();
     org.junit.jupiter.api.Assertions.assertTrue(body.contains("\"appId\""));
@@ -1202,7 +1202,7 @@ class DataObjectV2RestTest {
   void listFieldsParamAlwaysIncludesIdentity() {
     stubListSingleDataObject();
     // Ask only for createdAt; id, appId, name should still come back as identity guarantees.
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "createdAt", null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, "createdAt", null, null, null, null, null, null, null, securityContext);
     assertEquals(200, r.getStatus());
     String body = (String) r.getEntity();
     org.junit.jupiter.api.Assertions.assertTrue(body.contains("\"appId\""));
@@ -1217,7 +1217,7 @@ class DataObjectV2RestTest {
   @Test
   void listFieldsParamEmptyStringTreatedAsAbsent() {
     stubListSingleDataObject();
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "", null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, "", null, null, null, null, null, null, null, securityContext);
     assertEquals(200, r.getStatus());
     // Empty fields → default-trim mode (not 400, not "fields" mode)
     assertEquals("default-trim", r.getHeaders().getFirst("X-Shepard-Payload-Diet"));
@@ -1228,7 +1228,7 @@ class DataObjectV2RestTest {
     when(entityIdResolver.resolveLong(COLL_APP_ID)).thenReturn(COLL_OGM_ID);
     when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
       .thenReturn(true);
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "appId,bogusField,name", null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, "appId,bogusField,name", null, null, null, null, null, null, null, securityContext);
     assertEquals(400, r.getStatus());
     // 400 returns ProblemJson entity with the offending field name in 'detail'
     de.dlr.shepard.common.exceptions.ProblemJson body = (de.dlr.shepard.common.exceptions.ProblemJson) r.getEntity();
@@ -1243,7 +1243,7 @@ class DataObjectV2RestTest {
   void listFieldsParamWhitespaceTolerated() {
     stubListSingleDataObject();
     // Whitespace around commas should not produce 400.
-    Response r = resource.list(COLL_APP_ID, null, null, 0, 50, null, "appId, name , createdAt", null, null, null, null, null, null, null, securityContext);
+    Response r = resource.list(COLL_APP_ID, null, null, null, 0, 50, null, "appId, name , createdAt", null, null, null, null, null, null, null, securityContext);
     assertEquals(200, r.getStatus());
     assertEquals("fields", r.getHeaders().getFirst("X-Shepard-Payload-Diet"));
   }
@@ -1263,8 +1263,8 @@ class DataObjectV2RestTest {
     when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), any(), eq(null)))
       .thenReturn(List.of(d, d, d, d, d));
 
-    String trimmed = (String) resource.list(COLL_APP_ID, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext).getEntity();
-    String full = (String) resource.list(COLL_APP_ID, null, null, 0, 50, "full", null, null, null, null, null, null, null, null, securityContext).getEntity();
+    String trimmed = (String) resource.list(COLL_APP_ID, null, null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext).getEntity();
+    String full = (String) resource.list(COLL_APP_ID, null, null, null, 0, 50, "full", null, null, null, null, null, null, null, null, securityContext).getEntity();
     System.out.printf(
       "DB-OPT5 end-to-end measurement (5 DOs, 800-char description + 12-attr map per DO): full=%d B, default-trim=%d B (%.1f%% smaller)%n",
       full.length(), trimmed.length(), 100.0 * (full.length() - trimmed.length()) / full.length()
@@ -1279,7 +1279,7 @@ class DataObjectV2RestTest {
 
   private static java.lang.reflect.Parameter listParam(String qpName) throws NoSuchMethodException {
     java.lang.reflect.Method m = DataObjectV2Rest.class.getMethod(
-        "list", String.class, String.class, String.class, int.class, int.class,
+        "list", String.class, String.class, String.class, String.class, int.class, int.class,
         String.class, String.class, String.class, String.class, String.class,
         String.class, Boolean.class, String.class, String.class,
         jakarta.ws.rs.core.SecurityContext.class);
@@ -1294,6 +1294,7 @@ class DataObjectV2RestTest {
     assertTrue(ann.description() != null && !ann.description().isBlank(), label + " @Parameter.description must be non-blank");
   }
 
+  @Test void list_qParamIsDocumented() throws NoSuchMethodException { assertParamDocumented(listParam("q"), "list.q"); }
   @Test void list_nameParamIsDocumented() throws NoSuchMethodException { assertParamDocumented(listParam("name"), "list.name"); }
   @Test void list_statusParamIsDocumented() throws NoSuchMethodException { assertParamDocumented(listParam("status"), "list.status"); }
   @Test void list_pageParamIsDocumented() throws NoSuchMethodException { assertParamDocumented(listParam("page"), "list.page"); }
@@ -1307,6 +1308,61 @@ class DataObjectV2RestTest {
   @Test void list_topLevelParamIsDocumented() throws NoSuchMethodException { assertParamDocumented(listParam("topLevel"), "list.topLevel"); }
   @Test void list_predecessorAppIdParamIsDocumented() throws NoSuchMethodException { assertParamDocumented(listParam("predecessorAppId"), "list.predecessorAppId"); }
   @Test void list_successorAppIdParamIsDocumented() throws NoSuchMethodException { assertParamDocumented(listParam("successorAppId"), "list.successorAppId"); }
+
+  // ── APISIMP-DO-NAME-TO-Q: ?q= preferred filter, ?name= legacy alias ──────
+
+  @Test
+  void list_returns200WithQFilter() {
+    when(entityIdResolver.resolveLong(COLL_APP_ID)).thenReturn(COLL_OGM_ID);
+    when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
+      .thenReturn(true);
+    ArgumentCaptor<QueryParamHelper> paramsCaptor = ArgumentCaptor.forClass(QueryParamHelper.class);
+    when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
+      .thenReturn(Collections.emptyList());
+
+    Response r = resource.list(COLL_APP_ID, "afp-run", null, null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
+
+    assertEquals(200, r.getStatus());
+    QueryParamHelper captured = paramsCaptor.getValue();
+    assertTrue(captured.hasName(), "q param must produce a name filter");
+    assertEquals("afp-run", captured.getName());
+    assertNull(r.getHeaders().getFirst("Deprecation"), "no Deprecation header when only q= is used");
+  }
+
+  @Test
+  void list_legacyNameAliasesQAndAddsDeprecationHeader() {
+    when(entityIdResolver.resolveLong(COLL_APP_ID)).thenReturn(COLL_OGM_ID);
+    when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
+      .thenReturn(true);
+    ArgumentCaptor<QueryParamHelper> paramsCaptor = ArgumentCaptor.forClass(QueryParamHelper.class);
+    when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
+      .thenReturn(Collections.emptyList());
+
+    Response r = resource.list(COLL_APP_ID, null, "afp-run", null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
+
+    assertEquals(200, r.getStatus());
+    QueryParamHelper captured = paramsCaptor.getValue();
+    assertTrue(captured.hasName(), "legacy name= param must produce a name filter");
+    assertEquals("afp-run", captured.getName());
+    assertEquals("true", String.valueOf(r.getHeaders().getFirst("Deprecation")), "Deprecation header must be present when only name= is used");
+  }
+
+  @Test
+  void list_qTakesPrecedenceOverLegacyName() {
+    when(entityIdResolver.resolveLong(COLL_APP_ID)).thenReturn(COLL_OGM_ID);
+    when(permissionsService.isAccessTypeAllowedForUser(eq(COLL_OGM_ID), eq(AccessType.Read), eq(CALLER)))
+      .thenReturn(true);
+    ArgumentCaptor<QueryParamHelper> paramsCaptor = ArgumentCaptor.forClass(QueryParamHelper.class);
+    when(dataObjectService.getAllDataObjectsByShepardIds(eq(COLL_OGM_ID), paramsCaptor.capture(), eq(null)))
+      .thenReturn(Collections.emptyList());
+
+    Response r = resource.list(COLL_APP_ID, "q-val", "legacy-val", null, 0, 50, null, null, null, null, null, null, null, null, null, securityContext);
+
+    assertEquals(200, r.getStatus());
+    QueryParamHelper captured = paramsCaptor.getValue();
+    assertEquals("q-val", captured.getName(), "q must win over name when both are supplied");
+    assertNull(r.getHeaders().getFirst("Deprecation"), "no Deprecation header when q= is also present");
+  }
 
   @Test
   void predecessorChain_depthParamIsDocumented() throws NoSuchMethodException {

--- a/frontend/composables/context/usePagedDataObjects.ts
+++ b/frontend/composables/context/usePagedDataObjects.ts
@@ -122,7 +122,7 @@ export function usePagedDataObjects(opts: PagedDataObjectsOptions): PagedDataObj
       const identifier = appId ?? String(collectionId);
       const raw = await v2Api.value.listDataObjectsRaw({
         collectionAppId: identifier,
-        name: nameFilter,
+        q: nameFilter,
         status: statusFilter,
         annotationFilter: annotationFilter?.value || undefined,
         createdAfter: createdAfter?.value || undefined,


### PR DESCRIPTION
## Summary

Aligns `GET /v2/collections/{collectionAppId}/data-objects` with the `?q=` text-filter convention already used by `GET /v2/containers` and `GET /v2/user-groups`.

- `?q=` is the new primary filter (case-insensitive substring match on `name`)
- `?name=` is kept as a one-release-cycle alias; its presence adds a `Deprecation: true` response header
- When both are supplied, `?q=` wins and no `Deprecation` header is emitted

## Changes

| File | Change |
|------|--------|
| `DataObjectV2Rest.java` | Add `@QueryParam("q")` param; deprecate `?name=`; emit `Deprecation` header only when `?name=` used without `?q=` |
| `DataObjectV2RestTest.java` | Fix `listParam()` `getMethod()` signature (15→16 params); add `list_qParamIsDocumented` + 3 behavioural tests |
| `openapi.json` | Add `q` param entry; mark `name` `deprecated: true` |
| `DataObjectsApi.ts` | Expose `q?: string` as primary field; keep `name?` with `@deprecated` JSDoc |
| `usePagedDataObjects.ts` | Switch call site from `name: nameFilter` → `q: nameFilter` |
| `aidocs/16` | Mark `APISIMP-DO-NAME-TO-Q` shipped (fire-510) |

## Test plan

- [ ] `mvn verify -pl backend` — JUnit tests include 3 new behavioural tests + reflection doc test for `q`
- [ ] `npm run lint` + `npm run test` in `frontend/` — composable change is a 1-line key rename with no logic change
- [ ] `npm run typecheck` — `q?: string` added to `ListDataObjectsRequest`; `usePagedDataObjects.ts` uses it
- [ ] Existing callers using `?name=` continue to work (backward-compat alias); no forced migration

Part of the APISIMP pipeline: fire-509 shipped containers (`APISIMP-CONTAINERS-NAME-TO-Q`); this fire ships the DataObject endpoint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScJTpVhocUb4iPpbdWzFEY)_