### PR TITLE
fix(APISIMP-COLL-NAME-TO-Q): rename ?name= → ?q= on GET /v2/collections, deprecate ?name= alias

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4671,7 +4671,7 @@ picks these up. Terse by design.
 - **First refs:** `plugins/git/src/main/java/de/dlr/shepard/v2/git/resources/GitReferenceRest.java`; `aidocs/agent-findings/apisimp-sweep-fire501-2026-07-09.md §F3`.
 
 ## APISIMP-COLL-NAME-TO-Q — rename `?name=` → `?q=` text filter on `GET /v2/collections` (size: XS, sweep: fire-516)
-- **Status:** queued (fire-516).
+- **Status:** in-progress (fire-517, PR branch `APISIMP-COLL-NAME-TO-Q-1`).
 - **Why:** `CollectionV2Rest.java:172` uses `@QueryParam(Constants.QP_NAME)` (`?name=`) as its text filter. APISIMP-CONTAINERS-NAME-TO-Q (fire-510) and APISIMP-DO-NAME-TO-Q (fire-510) renamed `?name=` on containers and data-objects; collections is the third endpoint still using the non-standard param name.
 - **Fix:** Rename the param to `@QueryParam("q") String q`; add a `@Deprecated @QueryParam("name") String nameLegacy` backward-compat alias that produces `Deprecation: true` response header. Update OpenAPI description. Same pattern as the two already-merged siblings.
 - **AC:** `grep -n '"name"' backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionV2Rest.java | grep '@QueryParam'` returns only the deprecated-alias line; `mvn verify -pl backend` green; `npm run test` green.

--- a/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionV2Rest.java
@@ -145,7 +145,9 @@ public class CollectionV2Rest {
       "`status`, …) with `orderDesc=true` for a sorted result.\n\n" +
       "Pagination: omit `page` / `pageSize` to get the first 50; supply both to paginate. " +
       "The server caps `pageSize` at 200 to avoid unbounded result sets.\n\n" +
-      "Filtering: `name` does a case-insensitive substring match.\n\n" +
+      "Filtering: `q` (preferred) or deprecated `name` — case-insensitive substring match " +
+      "on Collection name. Using `?name=` emits `Deprecation: true` response header; " +
+      "migrate callers to `?q=`.\n\n" +
       "Each returned `CollectionV2IO` carries `appId` (canonical UUID v7) as the " +
       "stable identifier; use the matching `/v2/...` endpoints for follow-up calls.\n\n" +
       "Auth: no role gate — the result is filtered server-side to entities the caller " +
@@ -168,8 +170,10 @@ public class CollectionV2Rest {
   @APIResponse(responseCode = "401",
     description = "Authentication required (no JWT and no X-API-KEY).")
   public Response list(
-    @Parameter(description = "Optional case-insensitive substring filter on Collection name. Omit to return all collections the caller can read.")
-    @QueryParam(Constants.QP_NAME) String name,
+    @Parameter(description = "Optional case-insensitive substring filter on Collection name. Preferred over `name`.")
+    @QueryParam("q") String q,
+    @Parameter(description = "Deprecated alias for `q`. Accepted for one release cycle; prefer `q`. Presence adds `Deprecation: true` response header.")
+    @Deprecated @QueryParam(Constants.QP_NAME) String nameLegacy,
     @Parameter(description = "0-based page index. Default 0. Negative values are rejected (400).")
     @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
     @Parameter(description = "Page size. Default 50. Must be between 1 and 200 inclusive (400 otherwise).")
@@ -177,17 +181,19 @@ public class CollectionV2Rest {
   ) {
 
     var params = new QueryParamHelper();
-    if (name != null) params = params.withName(name);
+    String nameFilter = q != null ? q : nameLegacy;
+    if (nameFilter != null) params = params.withName(nameFilter);
 
     long total = collectionService.countAllCollections(params);
     var items = collectionService.getAllCollections(params.withPageAndSize(page, pageSize)).stream()
         .map(CollectionV2IO::new)
         .toList();
 
-    return Response.ok(new PagedResponseIO<>(items, total, page, pageSize))
+    Response.ResponseBuilder rb = Response.ok(new PagedResponseIO<>(items, total, page, pageSize))
       .header("X-Total-Count", total)  // kept during deprecation window (APISIMP-PAGINATION-ENVELOPE)
-      .header("Cache-Control", "max-age=300, must-revalidate")
-      .build();
+      .header("Cache-Control", "max-age=300, must-revalidate");
+    if (nameLegacy != null && q == null) rb = rb.header("Deprecation", "true");
+    return rb.build();
   }
 
   @GET

--- a/backend/src/test/java/de/dlr/shepard/v2/collection/resources/CollectionV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/collection/resources/CollectionV2RestTest.java
@@ -2,6 +2,7 @@ package de.dlr.shepard.v2.collection.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -96,7 +97,7 @@ class CollectionV2RestTest {
     when(collectionService.countAllCollections(any())).thenReturn(1L);
     when(collectionService.getAllCollections(any())).thenReturn(List.of(c));
 
-    Response r = resource.list(null, 0, 50);
+    Response r = resource.list(null, null, 0, 50);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -115,7 +116,7 @@ class CollectionV2RestTest {
     when(collectionService.countAllCollections(any())).thenReturn(0L);
     when(collectionService.getAllCollections(any())).thenReturn(List.of());
 
-    Response r = resource.list(null, 0, 50);
+    Response r = resource.list(null, null, 0, 50);
 
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -125,8 +126,46 @@ class CollectionV2RestTest {
   }
 
   @Test
+  void list_qParam_noDeprecationHeader() {
+    when(collectionService.countAllCollections(any())).thenReturn(0L);
+    when(collectionService.getAllCollections(any())).thenReturn(List.of());
+
+    Response r = resource.list("search-term", null, 0, 50);
+
+    assertEquals(200, r.getStatus());
+    // ?q= is the preferred param; no Deprecation header must be emitted
+    assertNull(r.getHeaderString("Deprecation"),
+        "Deprecation header must NOT be present when using preferred ?q= param");
+  }
+
+  @Test
+  void list_legacyNameParam_emitsDeprecationHeader() {
+    when(collectionService.countAllCollections(any())).thenReturn(0L);
+    when(collectionService.getAllCollections(any())).thenReturn(List.of());
+
+    Response r = resource.list(null, "legacy-name", 0, 50);
+
+    assertEquals(200, r.getStatus());
+    assertEquals("true", r.getHeaderString("Deprecation"),
+        "Deprecation: true must be emitted when caller uses deprecated ?name= param");
+  }
+
+  @Test
+  void list_qParamWinsOverLegacyName() {
+    when(collectionService.countAllCollections(any())).thenReturn(0L);
+    when(collectionService.getAllCollections(any())).thenReturn(List.of());
+
+    // When both are supplied ?q= wins and Deprecation header is NOT emitted
+    Response r = resource.list("preferred", "legacy", 0, 50);
+
+    assertEquals(200, r.getStatus());
+    assertNull(r.getHeaderString("Deprecation"),
+        "Deprecation header must NOT be present when ?q= overrides ?name=");
+  }
+
+  @Test
   void list_pageSizeParam_hasMinConstraint() throws NoSuchMethodException {
-    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, int.class, int.class);
+    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, String.class, int.class, int.class);
     java.lang.reflect.Parameter param = java.util.Arrays.stream(m.getParameters())
         .filter(p -> { var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class); return qp != null && "pageSize".equals(qp.value()); })
         .findFirst().orElse(null);
@@ -137,7 +176,7 @@ class CollectionV2RestTest {
 
   @Test
   void list_pageSizeParam_hasMaxConstraint() throws NoSuchMethodException {
-    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, int.class, int.class);
+    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, String.class, int.class, int.class);
     java.lang.reflect.Parameter param = java.util.Arrays.stream(m.getParameters())
         .filter(p -> { var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class); return qp != null && "pageSize".equals(qp.value()); })
         .findFirst().orElse(null);
@@ -542,22 +581,32 @@ class CollectionV2RestTest {
   // ─── APISIMP-REMAINING-PARAMS reflection guards ────────────────────────────
 
   @Test
-  void list_nameParam_hasParameterAnnotationWithDescription() throws NoSuchMethodException {
-    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, int.class, int.class);
+  void list_qParam_hasParameterAnnotationWithDescription() throws NoSuchMethodException {
+    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, String.class, int.class, int.class);
+    java.lang.reflect.Parameter param = java.util.Arrays.stream(m.getParameters())
+        .filter(p -> { var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class); return qp != null && "q".equals(qp.value()); })
+        .findFirst().orElse(null);
+    assertNotNull(param, "list.q must carry @QueryParam(\"q\")");
+    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
+    assertNotNull(ann, "list.q must carry @Parameter annotation");
+    assertTrue(ann.description() != null && !ann.description().isBlank(), "@Parameter.description must be non-blank for list.q");
+  }
+
+  @Test
+  void list_legacyNameParam_isDeprecated() throws NoSuchMethodException {
+    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, String.class, int.class, int.class);
     java.lang.reflect.Parameter param = java.util.Arrays.stream(m.getParameters())
         .filter(p -> { var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class); return qp != null && "name".equals(qp.value()); })
         .findFirst().orElse(null);
-    assertNotNull(param, "list.name must carry @QueryParam");
-    var ann = param.getAnnotation(org.eclipse.microprofile.openapi.annotations.parameters.Parameter.class);
-    assertNotNull(ann, "list.name must carry @Parameter annotation");
-    assertTrue(ann.description() != null && !ann.description().isBlank(), "@Parameter.description must be non-blank for list.name");
+    assertNotNull(param, "list.name (legacy) must still carry @QueryParam(\"name\")");
+    assertNotNull(param.getAnnotation(Deprecated.class), "list.name must be annotated @Deprecated");
   }
 
   // ─── APISIMP-COLLECTION-LIST-BUNDLE-SIZE-PAGESIZE reflection guards ────────
 
   @Test
   void list_pageParam_hasParameterAnnotationWithDescription() throws NoSuchMethodException {
-    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, int.class, int.class);
+    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, String.class, int.class, int.class);
     java.lang.reflect.Parameter param = java.util.Arrays.stream(m.getParameters())
         .filter(p -> { var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class); return qp != null && "page".equals(qp.value()); })
         .findFirst().orElse(null);
@@ -569,7 +618,7 @@ class CollectionV2RestTest {
 
   @Test
   void list_pageSizeParam_hasParameterAnnotationWithDescription() throws NoSuchMethodException {
-    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, int.class, int.class);
+    java.lang.reflect.Method m = CollectionV2Rest.class.getMethod("list", String.class, String.class, int.class, int.class);
     java.lang.reflect.Parameter param = java.util.Arrays.stream(m.getParameters())
         .filter(p -> { var qp = p.getAnnotation(jakarta.ws.rs.QueryParam.class); return qp != null && "pageSize".equals(qp.value()); })
         .findFirst().orElse(null);


### PR DESCRIPTION
## Summary

- Adds `?q=` as the preferred case-insensitive substring-filter query param on `GET /v2/collections`
- Keeps `?name=` as a one-release-cycle deprecated alias; when used without `?q=`, the response includes `Deprecation: true`
- When both are supplied, `?q=` wins and no deprecation header is emitted

## Pattern

Mirrors the existing `DataObjectV2Rest.list()` dual-param / header-flag pattern identically — zero new mechanism, just propagation of the established convention.

## Tests added

| Test | Verifies |
|------|----------|
| `list_qParam_noDeprecationHeader` | `?q=` alone → no `Deprecation` header |
| `list_legacyNameParam_emitsDeprecationHeader` | `?name=` alone → `Deprecation: true` |
| `list_qParamWinsOverLegacyName` | both params → `?q=` wins, no header |
| `list_legacyNameParam_isDeprecated` | `@Deprecated` annotation present on `name` param via reflection |

## Backlog row

`APISIMP-COLL-NAME-TO-Q` in `aidocs/16-dispatcher-backlog.md` — status set to `in-progress (fire-517, PR branch APISIMP-COLL-NAME-TO-Q-1)`.

## Frozen surface

No changes to `/shepard/api/` v1 wire shape. Only `GET /v2/collections` touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APi3SHJ9V3kgVTfUDAUoyk)_