### PR TITLE
fix(APISIMP-LABJOURNAL-PATHPARAM): rename {entryAppId} → {appId} in LabJournalHistoryRest

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4531,7 +4531,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/events/CollectionEventIO.java`; `backend/src/main/java/de/dlr/shepard/v2/export/rep/RepExportIO.java`; `aidocs/agent-findings/apisimp-sweep-2026-07-09-fire494.md §F2`.
 
 ## APISIMP-PREDICATES-PAGECAP — `ShapesPredicatesRest.predicates()` uses `@Max(500)` / "1–500" instead of the v2 standard `@Max(200)` / "1–200" (size: XS, sweep: fire-496)
-- **Status:** 🔄 in-flight (PR #2428) — CodeQL policy-check/scan race; rebased onto current main (fire-524) to trigger fresh CI run. All other checks green.
+- **Status:** 🔄 in-flight (PR #2428) — CodeQL policy-check/scan race; rebased onto current main (fire-525) to trigger fresh CI run. All other checks green.
 - **Why:** `ShapesPredicatesRest.java:106–107` declares `@Parameter(description = "Maximum entries per page (1–500). Default 200.")` and `@Max(500)` for the `pageSize` query param on `GET /v2/shapes/predicates`. Every other v2 list endpoint uses `@Max(200)` and the "1–200" description string — the 500 cap was introduced without justification when the endpoint was first written. Predicate vocabulary entries are lightweight (string label + URI); there is no performance or contract reason to diverge from the 200-cap standard. Same pattern as APISIMP-TPLREST-TAG-PAGECAP (fire-478, `ShepardTemplateRest.tags()`).
 - **Fix:** (1) Change `@Max(500)` → `@Max(200)` on the `pageSize` parameter in `ShapesPredicatesRest.java:107`. (2) Update the `@Parameter(description = "...")` string to replace "1–500" with "1–200". Two-character changes; zero logic change.
 - **AC:** `grep -n "Max(500)\|1.500" backend/src/main/java/de/dlr/shepard/v2/shapes/resources/ShapesPredicatesRest.java` returns zero; `mvn -q -DnoPlugins compile` green.
@@ -4707,7 +4707,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:651,1033,1154`; `aidocs/agent-findings/apisimp-sweep-2026-07-10-fire516.md §F4`.
 
 ## APISIMP-SNAPSHOT-PAGECAP — snapshot manifest `@Max(1000)` and pinned-read `@Max(2000)` → `@Max(200)` (size: XS, sweep: fire-516)
-- **Status:** 🔄 PR #2451 open (fire-520) — CodeQL race; rebased onto current main (fire-524); fresh CI triggered.
+- **Status:** 🔄 PR #2451 open (fire-520) — CodeQL race; rebased onto current main (fire-525); fresh CI triggered.
 - **Why:** `SnapshotRest.java:156` caps the manifest endpoint `pageSize` at `@Max(1000)` and `SnapshotPinnedReadRest.java:133` caps the pinned data-objects endpoint at `@Max(2000)`. The 1000-file bundle exception does not apply here. APISIMP-SNAPSHOT-MANIFEST-IN-MEMORY-PAGING (fire-422) fixed in-memory paging without changing the `@Max` cap; APISIMP-PAGESIZE-CAP-UNDOCUMENTED (fire-444) added OpenAPI documentation without normalising the value.
 - **Fix:** Change `@Max(1000)` → `@Max(200)` in `SnapshotRest.java:156` and `@Max(2000)` → `@Max(200)` in `SnapshotPinnedReadRest.java:133`; update description strings accordingly.
 - **AC:** `grep -n '@Max' backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotRest.java backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotPinnedReadRest.java | grep -E '1000|2000'` returns empty; `mvn verify -pl backend` green.
@@ -4721,7 +4721,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java:165`; `aidocs/agent-findings/apisimp-sweep-2026-07-10-fire516.md §F6`.
 
 ## APISIMP-ADMIN-AUDIT-PAGECAP — `InstanceAdminRest` permission-audit endpoints `@Max(500)` → `@Max(200)` (size: XS, sweep: fire-516)
-- **Status:** 🔄 PR #2455 open (fire-523) — CodeQL race; rebased onto current main (fire-524); fresh CI triggered.
+- **Status:** 🔄 PR #2455 open (fire-523) — CodeQL race; rebased onto current main (fire-525); fresh CI triggered.
 - **Why:** `InstanceAdminRest.java:210,271` — both `GET /v2/admin/permission-audit` and `GET /v2/admin/permission-audit/log` use `@Max(500)` on `pageSize` with descriptions "Page size 1–500". Admin-gated endpoints (`@RolesAllowed("instance-admin")`) still participate in the v2 standard.
 - **Fix:** Change both `@Max(500)` → `@Max(200)`; update the `@Parameter` description strings from "1–500" to "1–200".
 - **AC:** `grep -n '@Max(500)' backend/src/main/java/de/dlr/shepard/v2/admin/resources/InstanceAdminRest.java` returns empty; `mvn verify -pl backend` green.
@@ -4733,6 +4733,13 @@ picks these up. Terse by design.
 - **Fix:** Rename `{repoAppId}` → `{appId}` in both `@Path("/{repoAppId}/sparql")` declarations and the two `@PathParam("repoAppId") String repoAppId` bindings; update local variable usages and Javadoc/OpenAPI strings accordingly. Internal `executeSparql(String repoAppId, ...)` helper retains its parameter name (not part of the API surface).
 - **AC:** `grep -n '"repoAppId"' backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticSparqlRest.java | grep -E '@Path|@PathParam'` returns empty; `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticSparqlRest.java:169,207,230,258`.
+
+## APISIMP-LABJOURNAL-PATHPARAM — rename `{entryAppId}` → `{appId}` path-param in `LabJournalHistoryRest` (size: XS, fire-525)
+- **Status:** ✅ shipped (fire-525).
+- **Why:** `LabJournalHistoryRest.java` declared `@Path("/{entryAppId}/history")` and `@PathParam("entryAppId") String entryAppId` on `GET /v2/lab-journal/{entryAppId}/history`. The v2 convention is bare `{appId}` when the resource type is implied by the path prefix (`/v2/lab-journal/`). Identical pattern to the already-merged `{repoAppId}` (fire-524), `{collectionAppId}` (fire-523), `{snapshotAppId}` (fire-518), `{templateAppId}` (fire-507), `{bundleAppId}` (fire-506) normalizations. Zero wire-shape change — only the extraction variable name changes.
+- **Fix:** Rename `{entryAppId}` → `{appId}` in `@Path`, `@PathParam`, Javadoc `@param`, `@Operation` description string, and method body (`findByAppId(entryAppId)` → `findByAppId(appId)`, error message string). Internal service/DAO parameter names unchanged.
+- **AC:** `grep -n 'entryAppId' backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java` returns empty; `mvn -q -DnoPlugins compile` green.
+- **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java:38,76,85,91,118,129,130`.
 
 ## UIRULE-DROPDOWN-SEARCH-SORT — every dropdown searchable + naturally ordered (size: M, sweep)
 

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java
@@ -35,7 +35,7 @@ import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
- * J1d — {@code GET /v2/lab-journal/{entryAppId}/history}.
+ * J1d — {@code GET /v2/lab-journal/{appId}/history}.
  *
  * <p>Returns the append-only revision history of a lab journal entry —
  * one element per edit, ordered newest revision first. Each revision
@@ -73,7 +73,7 @@ public class LabJournalHistoryRest {
   /**
    * List the edit history of a lab journal entry.
    *
-   * @param entryAppId the application-level identifier of the {@code LabJournalEntry}.
+   * @param appId the application-level identifier of the {@code LabJournalEntry}.
    * @param page       0-based page index (default 0).
    * @param pageSize   items per page, 1–200 (default 50).
    * @param sc         the JAX-RS security context providing the caller identity.
@@ -82,13 +82,13 @@ public class LabJournalHistoryRest {
    *         entry is deleted.
    */
   @GET
-  @Path("/{entryAppId}/history")
+  @Path("/{appId}/history")
   @Produces(MediaType.APPLICATION_JSON)
   @Operation(
     operationId = "history",
     summary = "List the edit history of a lab journal entry.",
     description =
-      "Returns a paginated, append-only revision list for the entry identified by entryAppId. " +
+      "Returns a paginated, append-only revision list for the entry identified by appId. " +
       "Each element captures the entry's content as it existed immediately before " +
       "the corresponding update was applied. Revisions are ordered newest first " +
       "(highest revisionNumber first). An empty items array is returned when the entry " +
@@ -115,7 +115,7 @@ public class LabJournalHistoryRest {
     description = "No LabJournalEntry with that appId, or the entry is deleted."
   )
   public Response history(
-      @PathParam("entryAppId") String entryAppId,
+      @PathParam("appId") String appId,
       @Parameter(description = "Zero-based page index (default 0).")
       @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
       @Parameter(description = "Page size, 1–200 (default 50).")
@@ -126,8 +126,8 @@ public class LabJournalHistoryRest {
     if (caller == null) return problem(PT_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, "No authenticated principal.");
 
     // Resolve entry — null or deleted → 404
-    LabJournalEntry entry = labJournalEntryDAO.findByAppId(entryAppId);
-    if (entry == null || entry.isDeleted()) return problem(PT_NOT_FOUND, "Not found", Response.Status.NOT_FOUND, "No LabJournalEntry with appId: " + entryAppId);
+    LabJournalEntry entry = labJournalEntryDAO.findByAppId(appId);
+    if (entry == null || entry.isDeleted()) return problem(PT_NOT_FOUND, "Not found", Response.Status.NOT_FOUND, "No LabJournalEntry with appId: " + appId);
 
     // Permission check via parent DataObject
     var dataObject = entry.getDataObject();


### PR DESCRIPTION
## Summary

`LabJournalHistoryRest` declared `@Path("/{entryAppId}/history")` and `@PathParam("entryAppId") String entryAppId` on `GET /v2/lab-journal/{entryAppId}/history`. The v2 convention is bare `{appId}` when the resource type is already implied by the path prefix (`/v2/lab-journal/`).

**Change (1 file, 7 lines):**

```diff
-  * J1d — {@code GET /v2/lab-journal/{entryAppId}/history}.
+  * J1d — {@code GET /v2/lab-journal/{appId}/history}.
...
-   * @param entryAppId the application-level identifier of the {@code LabJournalEntry}.
+   * @param appId the application-level identifier of the {@code LabJournalEntry}.
...
-  @Path("/{entryAppId}/history")
+  @Path("/{appId}/history")
...
-      "Returns a paginated, append-only revision list for the entry identified by entryAppId. "
+      "Returns a paginated, append-only revision list for the entry identified by appId. "
...
-      @PathParam("entryAppId") String entryAppId,
+      @PathParam("appId") String appId,
...
-    LabJournalEntry entry = labJournalEntryDAO.findByAppId(entryAppId);
-    if (entry == null || entry.isDeleted()) return problem(..., "No LabJournalEntry with appId: " + entryAppId);
+    LabJournalEntry entry = labJournalEntryDAO.findByAppId(appId);
+    if (entry == null || entry.isDeleted()) return problem(..., "No LabJournalEntry with appId: " + appId);
```

Same pattern as the already-merged normalizations:
- `{repoAppId}` → `{appId}` (fire-524, PR #2458)
- `{collectionAppId}` → `{appId}` (fire-523, PR #2457)
- `{snapshotAppId}` → `{appId}` (fire-518)
- `{templateAppId}` → `{appId}` (fire-507, PR #2438)
- `{bundleAppId}` → `{appId}` (fire-506, PR #2431)

**Wire impact:** None. The JAX-RS path-parameter *name* is an extraction detail — only the URL path *structure* matters on the wire, and the structure (`/v2/lab-journal/{…}/history`) is unchanged. No migration needed.

**Backlog row:** `APISIMP-LABJOURNAL-PATHPARAM` (XS) in `aidocs/16-dispatcher-backlog.md` — marked ✅ shipped (fire-525).

## Test plan

- [x] `grep -n 'entryAppId' backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java` returns zero results ✅
- [x] `mvn -q -DnoPlugins compile` (from `backend/`) passes — clean ✅
- [x] Zero logic change — path structure and all runtime behaviour unchanged ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bpb3Z7Vfs6LGB3dy3wrJk4)_