### PR TITLE
fix(APISIMP-COLLEVENTS-PATHPARAM): rename {collectionAppId} → {appId} in CollectionEventsRest

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/events/CollectionEventsRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/events/CollectionEventsRest.java
@@ -44,7 +44,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
  * @see CollectionEventBus
  * @see CollectionEventProducer
  */
-@Path("/v2/collections/{collectionAppId}/events")
+@Path("/v2/collections/{appId}/events")
 @RequestScoped
 @Authenticated
 @Tag(name = "Collections")
@@ -80,7 +80,7 @@ public class CollectionEventsRest {
   @APIResponse(responseCode = "403", description = "Caller lacks Read on the Collection.")
   @APIResponse(responseCode = "404", description = "No Collection with that appId.")
   public void subscribe(
-    @PathParam("collectionAppId") String collectionAppId,
+    @PathParam("appId") String appId,
     @Context SseEventSink sink,
     @Context Sse sse,
     @Context SecurityContext securityContext
@@ -89,13 +89,13 @@ public class CollectionEventsRest {
     String caller = securityContext.getUserPrincipal().getName();
 
     // Throws NotFoundException (→ HTTP 404) if no Collection with this appId.
-    Long ogmId = entityIdResolver.resolveLong(collectionAppId);
+    Long ogmId = entityIdResolver.resolveLong(appId);
 
     if (!permissionsService.isAccessTypeAllowedForUser(ogmId, AccessType.Read, caller, 0L)) {
       throw new ForbiddenException();
     }
 
-    eventBus.subscribe(collectionAppId, sink, sse);
+    eventBus.subscribe(appId, sink, sse);
     // The sink stays open; the JAX-RS runtime holds the HTTP connection open
     // for the lifetime of the sink. The bus prunes closed sinks on next emit.
   }


### PR DESCRIPTION
## Summary

Normalise the SSE change-feed endpoint (`GET /v2/collections/{appId}/events`) path-param to the bare `{appId}` convention per the v2 API surface rules.

- Class-level `@Path("/v2/collections/{collectionAppId}/events")` → `@Path("/v2/collections/{appId}/events")`
- `@PathParam("collectionAppId") String collectionAppId` → `@PathParam("appId") String appId`
- Local variable usages at lines 92, 98 updated accordingly
- **Line 73 intentionally unchanged** — it references `collectionAppId` as a field name in the SSE event payload description (`@Operation`), documenting the wire shape of the data stream, not the path parameter

Zero wire-shape change; only the JAX-RS extraction variable name changes. Identical pattern to the 10+ previously merged normalizations (fire-506 → fire-525).

## Checklist
- [x] `aidocs/16` backlog row `APISIMP-COLLEVENTS-PATHPARAM` marked in-progress (committed to main in fire-526 sweep)
- [x] No v1 `/shepard/api/` surface touched
- [x] No numeric id leaks introduced
- [x] Diff: 1 file, 4 lines changed (pure rename)

---
_Generated by [Claude Code](https://claude.ai/code/session_013u4QqPt3o2qBUwGRgsDNbY)_