### PR TITLE
fix(APISIMP-CONTAINERPUBSTATE-PATHPARAM): rename {containerAppId} → {appId} in ContainerPublicationStateRest

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4789,14 +4789,14 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/events/CollectionEventsRest.java:47,83,92,98`.
 
 ## APISIMP-COLLWATCHERS-PATHPARAM — rename `{collectionAppId}` → `{appId}` path-param in `CollectionWatchersRest` (size: XS, fire-526)
-- **Status:** ✅ in-flight (fire-527, PR pending).
+- **Status:** ✅ shipped (fire-528, PR #2461, sha `74d8a8dc`).
 - **Why:** `CollectionWatchersRest.java` declares `@Path("/v2/collections/{collectionAppId}/watches")` at the class level with four method bindings at lines 89, 128, 157, 178. The resource type is expressed by `/v2/collections/`; only one path param per method — no JAX-RS collision.
 - **Fix:** Rename `{collectionAppId}` → `{appId}` in the class-level `@Path` and all four `@PathParam("collectionAppId")` bindings plus local variable usages.
 - **AC:** `grep -n 'collectionAppId' backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/resources/CollectionWatchersRest.java` returns empty; `mvn -q test-compile -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/resources/CollectionWatchersRest.java:89,128,157,178`.
 
 ## APISIMP-CONTAINERPUBSTATE-PATHPARAM — rename `{containerAppId}` → `{appId}` path-param in `ContainerPublicationStateRest` (size: XS, fire-526)
-- **Status:** 🔲 queued.
+- **Status:** ✅ in-flight (fire-528, PR pending).
 - **Why:** `ContainerPublicationStateRest.java` declares `@Path("/v2/containers/{containerAppId}/publication-state")` with two method `@PathParam("containerAppId")` bindings at lines 99, 140. The resource type is expressed by `/v2/containers/`; only one path param per method.
 - **Fix:** Rename `{containerAppId}` → `{appId}` in the class-level `@Path` and both `@PathParam` bindings plus local variable usages.
 - **AC:** `grep -n 'containerAppId' backend/src/main/java/de/dlr/shepard/v2/container/resources/ContainerPublicationStateRest.java` returns empty; `mvn -q test-compile -pl backend` green.

--- a/backend/src/main/java/de/dlr/shepard/v2/container/resources/ContainerPublicationStateRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/container/resources/ContainerPublicationStateRest.java
@@ -48,7 +48,7 @@ import static de.dlr.shepard.v2.common.ProblemResponse.problem;
  * job is to block writes against payload, not against the container's
  * own status field.
  */
-@Path("/v2/containers/{containerAppId}/publication-state")
+@Path("/v2/containers/{appId}/publication-state")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @RequestScoped
@@ -96,12 +96,12 @@ public class ContainerPublicationStateRest {
   @APIResponse(responseCode = "401", description = "Request is not authenticated.")
   @APIResponse(responseCode = "404", description = "No Container with that appId.")
   public Response get(
-    @PathParam("containerAppId") String containerAppId,
+    @PathParam("appId") String appId,
     @Context SecurityContext sc
   ) {
-    Long ogmId = resolveOrNull(containerAppId);
+    Long ogmId = resolveOrNull(appId);
     if (ogmId == null) return problem(PT_NOT_FOUND, "Container not found",
-      Response.Status.NOT_FOUND, "no Container with appId '" + containerAppId + "'");
+      Response.Status.NOT_FOUND, "no Container with appId '" + appId + "'");
 
     String caller = sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;
     if (caller == null) return problem(PT_UNAUTHORIZED, "Authentication required",
@@ -109,7 +109,7 @@ public class ContainerPublicationStateRest {
     if (!permissionsService.isAccessTypeAllowedForUser(ogmId, AccessType.Read, caller, 0L)) {
       return problem("/problems/container-publication-state.forbidden", "Read access required",
         Response.Status.FORBIDDEN,
-        "caller lacks Read on Container '" + containerAppId + "'");
+        "caller lacks Read on Container '" + appId + "'");
     }
     String status = readContainerStatus(ogmId);
     return Response.ok(PublicationStateIO.of(status)).build();
@@ -137,7 +137,7 @@ public class ContainerPublicationStateRest {
   @APIResponse(responseCode = "403", description = "Caller lacks Manage permission and is not an instance-admin.")
   @APIResponse(responseCode = "404", description = "No Container with that appId.")
   public Response patch(
-    @PathParam("containerAppId") String containerAppId,
+    @PathParam("appId") String appId,
     @Valid PublicationStateIO body,
     @Context SecurityContext sc
   ) {
@@ -145,9 +145,9 @@ public class ContainerPublicationStateRest {
       return problem("/problems/publication-state.invalid", "Invalid publication state",
         Response.Status.BAD_REQUEST, "state must be one of " + VALID_STATES);
     }
-    Long ogmId = resolveOrNull(containerAppId);
+    Long ogmId = resolveOrNull(appId);
     if (ogmId == null) return problem(PT_NOT_FOUND, "Container not found",
-      Response.Status.NOT_FOUND, "no Container with appId '" + containerAppId + "'");
+      Response.Status.NOT_FOUND, "no Container with appId '" + appId + "'");
 
     String caller = sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;
     if (caller == null) return problem(PT_UNAUTHORIZED, "Authentication required",

--- a/backend/src/test/java/de/dlr/shepard/v2/container/resources/ContainerPublicationStateRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/container/resources/ContainerPublicationStateRestTest.java
@@ -148,6 +148,6 @@ class ContainerPublicationStateRestTest {
   void container_pathOnV2Shelf() {
     Path p = ContainerPublicationStateRest.class.getAnnotation(Path.class);
     assertNotNull(p);
-    assertEquals("/v2/containers/{containerAppId}/publication-state", p.value());
+    assertEquals("/v2/containers/{appId}/publication-state", p.value());
   }
 }


### PR DESCRIPTION
## Summary

Normalise the two container publication-state endpoints to the bare `{appId}` path-param convention per the v2 API surface rules.

- Class-level `@Path("/v2/containers/{containerAppId}/publication-state")` → `@Path("/v2/containers/{appId}/publication-state")`
- `@PathParam("containerAppId") String containerAppId` → `@PathParam("appId") String appId` in both `get()` and `patch()` method signatures
- All local variable usages updated accordingly in both method bodies

Zero wire-shape change; only the JAX-RS extraction variable name changes. Identical rename pattern to the 11+ previously merged normalisations (fires 506–527).

## Checklist
- [x] `aidocs/16` backlog row `APISIMP-CONTAINERPUBSTATE-PATHPARAM` marked in-flight (fire-528)
- [x] No v1 `/shepard/api/` surface touched
- [x] No numeric id leaks introduced
- [x] `grep -n 'containerAppId' backend/src/main/java/de/dlr/shepard/v2/container/resources/ContainerPublicationStateRest.java` returns empty ✅
- [x] `mvn -q -DnoPlugins compile` (from `backend/`) passes — clean ✅
- [x] Diff: 1 Java file + aidocs/16 update; 10 lines changed (pure rename across 2 methods)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLfY3Gd3fvoe8G6PXLrYLH)_