### PR TITLE
fix(APISIMP-VOCABBROWSE-PATHPARAM): rename {entityAppId},{vocabId} → {appId} in VocabularyBrowseRest

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4810,7 +4810,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/NotebookRest.java:95,119`.
 
 ## APISIMP-VOCABBROWSE-PATHPARAM — rename `{entityAppId}` and `{vocabId}` → `{appId}` path-params in `VocabularyBrowseRest` (size: XS, fire-526)
-- **Status:** 🔲 queued.
+- **Status:** 🔄 in-flight (fire-530, branch `APISIMP-VOCABBROWSE-PATHPARAM-1`).
 - **Why:** `VocabularyBrowseRest.java` (class `@Path("/v2/semantic/vocabularies")`) has two non-standard params: (1) `@PathParam("entityAppId")` at line 228, method `@Path("/{entityAppId}/vocabularies")` — full path `/v2/semantic/vocabularies/{entityAppId}/vocabularies`; (2) `@PathParam("vocabId")` at line 164, method `@Path("/{vocabId}/predicates")` — full path `/v2/semantic/vocabularies/{vocabId}/predicates`; internally calls `vocabularyDAO.findByAppId(vocabId)`, confirming it is an appId. Both are single-ID; both should be `{appId}`.
 - **Fix:** In each affected method, rename `@PathParam("entityAppId")` → `@PathParam("appId")` and `@PathParam("vocabId")` → `@PathParam("appId")`, update the method-level `@Path` segments, and update local variable usages.
 - **AC:** `grep -n 'entityAppId\|vocabId' backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java` returns empty; `mvn -q test-compile -pl backend` green.

--- a/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java
@@ -43,9 +43,9 @@ import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
  *   <li>{@code GET /v2/semantic/vocabularies} — list all vocabularies
  *       (ordered by label ASC; includes both enabled and disabled rows so
  *       the operator can see what's hidden from autocomplete).</li>
- *   <li>{@code GET /v2/semantic/vocabularies/{vocabId}/predicates} — list
+ *   <li>{@code GET /v2/semantic/vocabularies/{appId}/predicates} — list
  *       the predicates declared by a given vocabulary, scoped by
- *       {@code :Predicate.vocabularyAppId = vocabId}.</li>
+ *       {@code :Predicate.vocabularyAppId = appId}.</li>
  * </ul>
  *
  * <p>This is the non-admin counterpart to
@@ -125,18 +125,18 @@ public class VocabularyBrowseRest {
         .build();
   }
 
-  // ─── GET /v2/semantic/vocabularies/{vocabId}/predicates ───────────────────
+  // ─── GET /v2/semantic/vocabularies/{appId}/predicates ────────────────────
 
   /**
-   * {@code GET /v2/semantic/vocabularies/{vocabId}/predicates}
+   * {@code GET /v2/semantic/vocabularies/{appId}/predicates}
    *
    * <p>Returns the predicates declared by the given vocabulary, scoped by
-   * {@code :Predicate.vocabularyAppId = vocabId}. Returns 404 when no
+   * {@code :Predicate.vocabularyAppId = appId}. Returns 404 when no
    * vocabulary with that appId exists. Returns a 200 with an empty list
    * when the vocabulary exists but has no predicates yet.
    */
   @GET
-  @Path("/{vocabId}/predicates")
+  @Path("/{appId}/predicates")
   @Operation(
     operationId = "listPredicatesForVocabulary",
     summary = "List predicates declared by one vocabulary.",
@@ -161,29 +161,29 @@ public class VocabularyBrowseRest {
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "404", description = "No vocabulary with this appId.")
   public Response listPredicatesForVocabulary(
-    @PathParam("vocabId") String vocabId,
+    @PathParam("appId") String appId,
     @Parameter(description = "Zero-based page index (default 0).")
     @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
     @Parameter(description = "Page size (default 50, max 200).")
     @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize
   ) {
-    if (vocabId == null || vocabId.isBlank()) {
-      return notFound(vocabId);
+    if (appId == null || appId.isBlank()) {
+      return notFound(appId);
     }
-    Vocabulary vocab = vocabularyDAO.findByAppId(vocabId);
+    Vocabulary vocab = vocabularyDAO.findByAppId(appId);
     if (vocab == null) {
-      return notFound(vocabId);
+      return notFound(appId);
     }
-    long total = predicateDAO.countByVocabulary(vocabId);
+    long total = predicateDAO.countByVocabulary(appId);
     long skip = Math.min((long) page * pageSize, total);
-    List<Predicate> rows = predicateDAO.listByVocabularyPaged(vocabId, skip, pageSize);
+    List<Predicate> rows = predicateDAO.listByVocabularyPaged(appId, skip, pageSize);
     List<PredicateIO> page_ = rows.stream().map(PredicateIO::from).toList();
     return Response.ok(new PagedResponseIO<>(page_, total, page, pageSize))
         .header("X-Total-Count", total)
         .build();
   }
 
-  // ─── GET /v2/semantic/vocabularies/used-by/{entityAppId} ──────────────────
+  // ─── GET /v2/semantic/vocabularies/used-by/{appId} ───────────────────────
 
   /**
    * TOOLS-CONTEXT-VOCAB-BACKEND-1 — list the vocabularies whose terms are
@@ -201,7 +201,7 @@ public class VocabularyBrowseRest {
    * <p>Source: TOOLS-CONTEXT-VOCAB-BACKEND-1 (aidocs/16).
    */
   @GET
-  @Path("/used-by/{entityAppId}")
+  @Path("/used-by/{appId}")
   @Operation(
     operationId = "listVocabulariesUsedBy",
     summary = "List vocabularies referenced by an entity's annotations.",
@@ -225,7 +225,7 @@ public class VocabularyBrowseRest {
   )
   @APIResponse(responseCode = "401", description = "Authentication required.")
   public Response listVocabulariesUsedBy(
-    @PathParam("entityAppId") String entityAppId,
+    @PathParam("appId") String appId,
     @Parameter(
       description =
         "Annotation walk scope. 'data-object' (default): only the entity's own " +
@@ -238,12 +238,12 @@ public class VocabularyBrowseRest {
     @Parameter(description = "Page size, 1–200 (default 50).")
     @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize
   ) {
-    if (entityAppId == null || entityAppId.isBlank()) {
+    if (appId == null || appId.isBlank()) {
       return Response.ok(new PagedResponseIO<>(List.<VocabularyIO>of(), 0L, page, pageSize))
           .header("X-Total-Count", 0L)
           .build();
     }
-    List<Vocabulary> used = vocabularyDAO.findVocabulariesUsedByEntity(entityAppId, scope);
+    List<Vocabulary> used = vocabularyDAO.findVocabulariesUsedByEntity(appId, scope);
     long total = used.size();
     int skip = (int) Math.min((long) page * pageSize, total);
     List<Vocabulary> slice = used.subList(skip, (int) Math.min((long) skip + pageSize, total));
@@ -255,8 +255,8 @@ public class VocabularyBrowseRest {
 
   // ─── helpers ──────────────────────────────────────────────────────────────
 
-  private static Response notFound(String vocabId) {
+  private static Response notFound(String id) {
     return ProblemResponse.problem(PROBLEM_TYPE_NOT_FOUND, "Vocabulary not found",
-        Status.NOT_FOUND, "No :Vocabulary node with appId='" + (vocabId == null ? "" : vocabId) + "'.");
+        Status.NOT_FOUND, "No :Vocabulary node with appId='" + (id == null ? "" : id) + "'.");
   }
 }

--- a/backend/src/test/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRestTest.java
@@ -20,6 +20,7 @@ import de.dlr.shepard.context.semantic.entities.Predicate;
 import de.dlr.shepard.context.semantic.entities.Vocabulary;
 import de.dlr.shepard.v2.semantic.io.PredicateIO;
 import de.dlr.shepard.v2.vocabularies.io.VocabularyIO;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -340,6 +341,28 @@ class VocabularyBrowseRestTest {
     assertEquals(3L, body1.total());
     assertEquals(1, body1.items().size());
     assertEquals("v-c", body1.items().get(0).getAppId());
+  }
+
+  // ─── APISIMP-VOCABBROWSE-PATHPARAM: path-annotation regressions ──────────
+
+  @Test
+  void predicates_pathUsesAppId() throws NoSuchMethodException {
+    // {vocabId} → {appId} per APISIMP-VOCABBROWSE-PATHPARAM
+    java.lang.reflect.Method m = VocabularyBrowseRest.class.getMethod(
+        "listPredicatesForVocabulary", String.class, int.class, int.class);
+    Path p = m.getAnnotation(Path.class);
+    assertNotNull(p, "listPredicatesForVocabulary must carry @Path");
+    assertEquals("/{appId}/predicates", p.value());
+  }
+
+  @Test
+  void usedBy_pathUsesAppId() throws NoSuchMethodException {
+    // {entityAppId} → {appId} per APISIMP-VOCABBROWSE-PATHPARAM
+    java.lang.reflect.Method m = VocabularyBrowseRest.class.getMethod(
+        "listVocabulariesUsedBy", String.class, String.class, int.class, int.class);
+    Path p = m.getAnnotation(Path.class);
+    assertNotNull(p, "listVocabulariesUsedBy must carry @Path");
+    assertEquals("/used-by/{appId}", p.value());
   }
 
   // ─── APISIMP-VOCAB-BROWSE-SCOPE-UNDOCUMENTED: @Parameter regression ───────


### PR DESCRIPTION
## Summary

Normalise the two sub-resource path params in `VocabularyBrowseRest` to the bare `{appId}` convention per the v2 API surface rules (APISIMP-VOCABBROWSE-PATHPARAM).

**Changes in `VocabularyBrowseRest.java`:**
- `@Path("/{vocabId}/predicates")` → `@Path("/{appId}/predicates")`
- `@PathParam("vocabId") String vocabId` → `@PathParam("appId") String appId` + local variable usages
- `@Path("/used-by/{entityAppId}")` → `@Path("/used-by/{appId}")`
- `@PathParam("entityAppId") String entityAppId` → `@PathParam("appId") String appId` + local variable usages
- Javadoc comments + section headers updated to match new path templates
- Private `notFound(String vocabId)` helper parameter renamed to `id`

**Changes in `VocabularyBrowseRestTest.java`:**
- Added `predicates_pathUsesAppId()` — pins `/{appId}/predicates` via reflection
- Added `usedBy_pathUsesAppId()` — pins `/used-by/{appId}` via reflection
- Added `import jakarta.ws.rs.Path`

Zero wire-shape change. Identical rename pattern to the 13+ prior normalisations (fires 506–529).

## Checklist
- [x] `aidocs/16` row `APISIMP-VOCABBROWSE-PATHPARAM` marked in-flight (fire-530)
- [x] No v1 `/shepard/api/` surface touched
- [x] No numeric id leaks introduced
- [x] AC: `grep -n 'entityAppId\|vocabId' backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java` returns empty ✅
- [x] Two path-annotation regression tests added
- [x] `aidocs/01-doc-stage-index.md` regenerated


---
_Generated by [Claude Code](https://claude.ai/code/session_01XvUaYQcyRfwFoM5hfWv48q)_