### PR TITLE
fix(APISIMP-COLLWATCHES-PATHPARAM): rename {collectionAppId} → {appId} in CollectionWatchesRest

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4817,14 +4817,14 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java:164,228`.
 
 ## APISIMP-MEROLE-PATHPARAM — rename `{collectionAppId}` → `{appId}` path-param in `MeRoleInRest` (size: XS, fire-526)
-- **Status:** 🔄 in-flight (fire-531, branch `APISIMP-MEROLE-PATHPARAM-1`).
+- **Status:** ✅ done (fire-532, PR #2465, sha `4c1a26206fa1ab3efaf31e48c45298ec6d974204`).
 - **Why:** `MeRoleInRest.java` declares `@Path("/v2/users/me/role-in/{collectionAppId}")` at the class level with one method `@PathParam("collectionAppId")` binding at line 88. Single-ID context — rename to `{appId}` per v2 convention.
 - **Fix:** Rename `{collectionAppId}` → `{appId}` in the class-level `@Path`, `@PathParam` binding, and local variable usage.
 - **AC:** `grep -n 'collectionAppId' backend/src/main/java/de/dlr/shepard/v2/me/resources/MeRoleInRest.java` returns empty; `mvn -q test-compile -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/me/resources/MeRoleInRest.java:88`.
 
 ## APISIMP-COLLWATCHES-PATHPARAM — rename `{collectionAppId}` → `{appId}` class-level path-param in `CollectionWatchesRest` (size: XS, fire-526)
-- **Status:** 🔲 queued.
+- **Status:** 🔄 in-flight (fire-532, branch `APISIMP-COLLWATCHES-PATHPARAM-1`).
 - **Why:** `CollectionWatchesRest.java` declares `@Path("/v2/collections/{collectionAppId}/watched-containers")` at the class level with method bindings at lines 109 and 160. The DELETE method at line ~198 adds a second param `{watchAppId}` — renaming the class-level param to `{appId}` introduces no JAX-RS ambiguity since the two names remain distinct.
 - **Fix:** Rename `{collectionAppId}` → `{appId}` in the class-level `@Path` and method bindings at lines 109, 160 plus local variable usages. Leave `{watchAppId}` unchanged (distinct secondary ID in the DELETE sub-path).
 - **AC:** `grep -n 'collectionAppId' backend/src/main/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRest.java` returns empty; `mvn -q test-compile -pl backend` green.

--- a/backend/src/main/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRest.java
@@ -49,7 +49,7 @@ import static de.dlr.shepard.v2.common.ProblemResponse.problem;
  * adder — checked at create time and reflected in the
  * `containerAvailability` token at list time.
  */
-@Path("/v2/collections/{collectionAppId}/watched-containers")
+@Path("/v2/collections/{appId}/watched-containers")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @RequestScoped
@@ -66,7 +66,7 @@ public class CollectionWatchesRest {
     summary = "List containers this Collection is watching (WATCH1).",
     description =
       "Returns one `WatchIO` row per `:Watch` edge attached to the " +
-      "Collection identified by `collectionAppId`. A Watch is a link from " +
+      "Collection identified by `appId`. A Watch is a link from " +
       "a Collection to a Container the Collection does NOT own through any " +
       "DataObject reference — useful for live-data Collections that surface " +
       "containers shared from elsewhere (e.g. the home-showcase demo " +
@@ -89,7 +89,7 @@ public class CollectionWatchesRest {
       "Pagination (APISIMP-WATCHES-LIST-NO-PAGINATION): supply both `page` (0-based) and `pageSize` " +
       "(1–200) to receive a slice. Omit both to return all watches. " +
       "`X-Total-Count` header carries the total before paging.\n\n" +
-      "Next step: `POST /v2/collections/{collectionAppId}/watched-containers` " +
+      "Next step: `POST /v2/collections/{appId}/watched-containers` " +
       "to add a watch, or click the target container's appId in the UI."
   )
   @APIResponse(
@@ -106,14 +106,14 @@ public class CollectionWatchesRest {
   @APIResponse(responseCode = "403", description = "Caller lacks Read on the Collection.")
   @APIResponse(responseCode = "404", description = "No Collection with that appId.")
   public Response list(
-      @PathParam("collectionAppId") @NotBlank String collectionAppId,
+      @PathParam("appId") @NotBlank String appId,
       @Parameter(description = "Zero-based page index (default 0).")
       @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
       @Parameter(description = "Page size, 1–200 (default 50).")
       @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize) {
-    long total = service.count(collectionAppId);
+    long total = service.count(appId);
     int skip = page * pageSize;
-    List<WatchIO> items = service.list(collectionAppId, skip, pageSize);
+    List<WatchIO> items = service.list(appId, skip, pageSize);
     return Response.ok(new PagedResponseIO<>(items, total, page, pageSize))
         .header("X-Total-Count", total)  // kept during deprecation window (APISIMP-PAGINATION-ENVELOPE)
         .build();
@@ -125,7 +125,7 @@ public class CollectionWatchesRest {
     summary = "Add a Watch link from a Collection to a Container (WATCH1).",
     description =
       "Creates a `:Watch` edge from the Collection identified by " +
-      "`collectionAppId` to the Container identified by the body. The " +
+      "`appId` to the Container identified by the body. The " +
       "target container is NOT modified — only a new graph edge is added.\n\n" +
       "Body fields (all required):\n" +
       "  - `containerKind` (one of `TIMESERIES`, `FILE`, `STRUCTURED_DATA`).\n" +
@@ -143,7 +143,7 @@ public class CollectionWatchesRest {
       "noise).\n\n" +
       "Side effects: ProvenanceCaptureFilter records a `CREATE` Activity on " +
       "the new Watch's appId.\n\n" +
-      "Next step: `GET /v2/collections/{collectionAppId}/watched-containers` " +
+      "Next step: `GET /v2/collections/{appId}/watched-containers` " +
       "to confirm the list, or `DELETE ../watched-containers/{watchAppId}` " +
       "to remove."
   )
@@ -157,7 +157,7 @@ public class CollectionWatchesRest {
   @APIResponse(responseCode = "403", description = "Caller lacks Write on the Collection, or Read on the target Container.")
   @APIResponse(responseCode = "404", description = "No Collection with that appId.")
   public Response create(
-    @PathParam("collectionAppId") @NotBlank String collectionAppId,
+    @PathParam("appId") @NotBlank String appId,
     @RequestBody(
       required = true,
       content = @Content(schema = @Schema(implementation = CreateWatchIO.class))
@@ -168,7 +168,7 @@ public class CollectionWatchesRest {
       return problem("/problems/watches.bad-request", "Bad Request", Response.Status.BAD_REQUEST,
           "containerKind and containerAppId are required");
     }
-    WatchIO out = service.create(collectionAppId, body.containerKind(), body.containerAppId());
+    WatchIO out = service.create(appId, body.containerKind(), body.containerAppId());
     return Response.status(Response.Status.CREATED).entity(out).build();
   }
 
@@ -179,7 +179,7 @@ public class CollectionWatchesRest {
     summary = "Remove a Watch link by its appId (WATCH1).",
     description =
       "Deletes the `:Watch` edge identified by `watchAppId` from the " +
-      "Collection identified by `collectionAppId`. The target Container is " +
+      "Collection identified by `appId`. The target Container is " +
       "untouched — only the edge is removed.\n\n" +
       "Idempotency: deleting a non-existent or already-deleted Watch " +
       "returns 204 without error.\n\n" +
@@ -194,10 +194,10 @@ public class CollectionWatchesRest {
   @APIResponse(responseCode = "403", description = "Caller lacks Write on the Collection.")
   @APIResponse(responseCode = "404", description = "Watch exists but belongs to a different Collection.")
   public Response delete(
-    @PathParam("collectionAppId") @NotBlank String collectionAppId,
+    @PathParam("appId") @NotBlank String appId,
     @PathParam("watchAppId") @NotBlank String watchAppId
   ) {
-    service.delete(collectionAppId, watchAppId);
+    service.delete(appId, watchAppId);
     return Response.status(Response.Status.NO_CONTENT).build();
   }
 }

--- a/backend/src/test/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRestTest.java
@@ -152,4 +152,15 @@ class CollectionWatchesRestTest {
     org.junit.jupiter.api.Assertions.assertNotNull(ann, "pageSize must carry @Parameter annotation");
     assertTrue(ann.description() != null && !ann.description().isBlank());
   }
+
+  @Test
+  void classPath_usesAppId() {
+    // APISIMP-COLLWATCHES-PATHPARAM regression: class-level @Path must use {appId}, not {collectionAppId}.
+    var pathAnn = CollectionWatchesRest.class.getAnnotation(jakarta.ws.rs.Path.class);
+    org.junit.jupiter.api.Assertions.assertNotNull(pathAnn, "CollectionWatchesRest must carry @Path");
+    assertTrue(pathAnn.value().contains("{appId}"),
+        "class-level @Path must contain {appId}, got: " + pathAnn.value());
+    org.junit.jupiter.api.Assertions.assertFalse(pathAnn.value().contains("{collectionAppId}"),
+        "class-level @Path must NOT contain {collectionAppId}, got: " + pathAnn.value());
+  }
 }


### PR DESCRIPTION
## Summary

Normalise the class-level `@Path` param in `CollectionWatchesRest` to the bare `{appId}` convention per v2 API surface rules (`APISIMP-COLLWATCHES-PATHPARAM`).

**Changes in `CollectionWatchesRest.java`:**
- `@Path("/v2/collections/{collectionAppId}/watched-containers")` → `@Path("/v2/collections/{appId}/watched-containers")`
- `@PathParam("collectionAppId") … String collectionAppId` renamed to `@PathParam("appId") … String appId` in all three methods (`list`, `create`, `delete`)
- All local variable usages of `collectionAppId` within method bodies updated to `appId`
- OpenAPI `description` text updated accordingly (`{collectionAppId}` → `{appId}`)
- `{watchAppId}` in the DELETE sub-path left unchanged (distinct secondary ID — no ambiguity)

**Changes in `CollectionWatchesRestTest.java`:**
- Added `classPath_usesAppId()` — reflection-based regression test pinning that the class-level `@Path` contains `{appId}` and not `{collectionAppId}`

Zero wire-shape change. Same rename pattern as the 15+ prior normalisations (fires 506–532).

## Checklist
- [x] `aidocs/16` row `APISIMP-COLLWATCHES-PATHPARAM` marked in-flight (fire-532)
- [x] No v1 `/shepard/api/` surface touched
- [x] No numeric id leaks introduced
- [x] AC: `grep -n 'collectionAppId' backend/src/main/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRest.java` returns empty ✅
- [x] Regression test `classPath_usesAppId()` added
- [x] `aidocs/01-doc-stage-index.md` regenerated (no stage changes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZWHrARQHwSh8LxmBenNzE)_