### PR TITLE
fix(APISIMP-COLL-LABJOURNAL-PATHPARAM): rename {collectionAppId} → {appId} in CollectionLabJournalEntriesRest

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -37,10 +37,10 @@ section and the `upgrade-overlay` section.
 | `audited-by-personas` | 78 |
 | `feedback-implemented` | 4 |
 | `tests-implemented` | 9 |
-| `deployed` | 139 |
+| `deployed` | 140 |
 | `decommissioned` | 49 |
 | `upgrade-vX:vY` (overlay) | 0 |
-| **total docs** | **559** |
+| **total docs** | **560** |
 | **UNTAGGED** | **0** |
 
 ## fragment (89)
@@ -449,7 +449,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/integrations/123-template-inheritance.md`](integrations/123-template-inheritance.md) | 123 — ShepardTemplate inheritance | 2026-06-03 | 2026-07-09 |
 | [`aidocs/integrations/93-mffd-import-v15-requirements.md`](integrations/93-mffd-import-v15-requirements.md) | 93 — MFFD real-data import (v15) requirements | 2026-05-23 | 2026-07-09 |
 
-## deployed (139)
+## deployed (140)
 
 | doc | title | last-stage-change | last-touched |
 |---|---|---|---|
@@ -497,6 +497,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-08-fire481.md`](agent-findings/apisimp-sweep-2026-07-08-fire481.md) | APISIMP sweep — fire-481 (2026-07-08) | 2026-07-08 | 2026-07-09 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-09-fire494.md`](agent-findings/apisimp-sweep-2026-07-09-fire494.md) | APISIMP SWEEP — fire-494 (2026-07-09) | 2026-07-09 | 2026-07-09 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-09-fire496.md`](agent-findings/apisimp-sweep-2026-07-09-fire496.md) | APISIMP Sweep — fire-496 (2026-07-09) | 2026-07-09 | 2026-07-09 |
+| [`aidocs/agent-findings/apisimp-sweep-2026-07-10-fire534.md`](agent-findings/apisimp-sweep-2026-07-10-fire534.md) | APISIMP Sweep — Fire 534 (2026-07-10) | 2026-07-10 | — |
 | [`aidocs/agent-findings/apisimp-sweep-fire341-2026-07-01.md`](agent-findings/apisimp-sweep-fire341-2026-07-01.md) | API Simplification Sweep — fire-341 (2026-07-01) | 2026-07-01 | 2026-07-09 |
 | [`aidocs/agent-findings/apisimp-sweep-fire342-2026-07-01.md`](agent-findings/apisimp-sweep-fire342-2026-07-01.md) | APISIMP Sweep — 2026-07-01 (fire-342) | 2026-07-01 | 2026-07-09 |
 | [`aidocs/agent-findings/apisimp-sweep-fire353-2026-07-01.md`](agent-findings/apisimp-sweep-fire353-2026-07-01.md) | APISIMP Sweep — fire-353 (2026-07-01) | 2026-07-01 | 2026-07-09 |

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4796,21 +4796,21 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/collectionwatchers/resources/CollectionWatchersRest.java:89,128,157,178`.
 
 ## APISIMP-CONTAINERPUBSTATE-PATHPARAM — rename `{containerAppId}` → `{appId}` path-param in `ContainerPublicationStateRest` (size: XS, fire-526)
-- **Status:** ✅ in-flight (fire-528, PR pending).
+- **Status:** ✅ shipped (fire-531, PR #2462, sha `7cf839aa6`).
 - **Why:** `ContainerPublicationStateRest.java` declares `@Path("/v2/containers/{containerAppId}/publication-state")` with two method `@PathParam("containerAppId")` bindings at lines 99, 140. The resource type is expressed by `/v2/containers/`; only one path param per method.
 - **Fix:** Rename `{containerAppId}` → `{appId}` in the class-level `@Path` and both `@PathParam` bindings plus local variable usages.
 - **AC:** `grep -n 'containerAppId' backend/src/main/java/de/dlr/shepard/v2/container/resources/ContainerPublicationStateRest.java` returns empty; `mvn -q test-compile -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/container/resources/ContainerPublicationStateRest.java:99,140`.
 
 ## APISIMP-NOTEBOOK-PATHPARAM — rename `{dataObjectAppId}` → `{appId}` path-param in `NotebookRest` (size: XS, fire-526)
-- **Status:** 🔄 in-flight (fire-529, PR #2463).
+- **Status:** ✅ shipped (fire-530, PR #2463, sha `4b0bfe320`).
 - **Why:** `NotebookRest.java` (class `@Path("/v2/lab-journal")`) declares method-level `@Path("/{dataObjectAppId}/notebooks")`. Effective full path: `/v2/lab-journal/{dataObjectAppId}/notebooks`. Single-ID context — no JAX-RS collision. Rename per v2 convention.
 - **Fix:** Rename `{dataObjectAppId}` → `{appId}` in the method `@Path`, `@PathParam` binding (line 119), and local variable usages.
 - **AC:** `grep -n 'dataObjectAppId' backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/NotebookRest.java` returns empty; `mvn -q test-compile -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/NotebookRest.java:95,119`.
 
 ## APISIMP-VOCABBROWSE-PATHPARAM — rename `{entityAppId}` and `{vocabId}` → `{appId}` path-params in `VocabularyBrowseRest` (size: XS, fire-526)
-- **Status:** 🔄 in-flight (fire-530, branch `APISIMP-VOCABBROWSE-PATHPARAM-1`).
+- **Status:** ✅ shipped (fire-531, PR #2464, sha `3ecf8c100`).
 - **Why:** `VocabularyBrowseRest.java` (class `@Path("/v2/semantic/vocabularies")`) has two non-standard params: (1) `@PathParam("entityAppId")` at line 228, method `@Path("/{entityAppId}/vocabularies")` — full path `/v2/semantic/vocabularies/{entityAppId}/vocabularies`; (2) `@PathParam("vocabId")` at line 164, method `@Path("/{vocabId}/predicates")` — full path `/v2/semantic/vocabularies/{vocabId}/predicates`; internally calls `vocabularyDAO.findByAppId(vocabId)`, confirming it is an appId. Both are single-ID; both should be `{appId}`.
 - **Fix:** In each affected method, rename `@PathParam("entityAppId")` → `@PathParam("appId")` and `@PathParam("vocabId")` → `@PathParam("appId")`, update the method-level `@Path` segments, and update local variable usages.
 - **AC:** `grep -n 'entityAppId\|vocabId' backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java` returns empty; `mvn -q test-compile -pl backend` green.
@@ -4824,15 +4824,29 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/me/resources/MeRoleInRest.java:88`.
 
 ## APISIMP-COLLWATCHES-PATHPARAM — rename `{collectionAppId}` → `{appId}` class-level path-param in `CollectionWatchesRest` (size: XS, fire-526)
-- **Status:** 🔄 in-flight (fire-532, branch `APISIMP-COLLWATCHES-PATHPARAM-1`).
+- **Status:** ✅ shipped (fire-533, PR #2466, sha `3f99b930a`).
 - **Why:** `CollectionWatchesRest.java` declares `@Path("/v2/collections/{collectionAppId}/watched-containers")` at the class level with method bindings at lines 109 and 160. The DELETE method at line ~198 adds a second param `{watchAppId}` — renaming the class-level param to `{appId}` introduces no JAX-RS ambiguity since the two names remain distinct.
 - **Fix:** Rename `{collectionAppId}` → `{appId}` in the class-level `@Path` and method bindings at lines 109, 160 plus local variable usages. Leave `{watchAppId}` unchanged (distinct secondary ID in the DELETE sub-path).
 - **AC:** `grep -n 'collectionAppId' backend/src/main/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRest.java` returns empty; `mvn -q test-compile -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/watches/resources/CollectionWatchesRest.java:109,160`.
 
 ## APISIMP-BUNDLEGROUPS-PAGECAP — lower `BundleGroupsV2Rest` pageSize @Max 1000 → 200 (size: XS, fire-526)
-- **Status:** ✅ shipped (fire-533, PR #2467).
+- **Status:** ✅ shipped (fire-533, PR #2467, merged fire-534, sha `ec2366f21`).
 - **Why:** `BundleGroupsV2Rest.java:369` declared `@Max(1000)` on `pageSize` (default already 200). Standard v2 pagination cap is `@Max(200)`. The oversized cap let a caller request 5× the intended maximum. Identical pattern to `APISIMP-REFANNOT-PAGECAP` (fire-519) and `APISIMP-SNAPSHOT-PAGECAP` (fire-524, PR #2451).
 - **Fix:** `@Max(1000)` → `@Max(200)` at `listGroupFiles`; `MAX_FILES_PAGE_SIZE` constant corrected to 200; OpenAPI description updated; regression test `maxFilesPageSize_isAtMost200` added.
 - **AC:** `grep -n '@Max' backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java | grep 'pageSize'` shows `@Max(200)`. ✅
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java:369`.
+
+## APISIMP-COLL-LABJOURNAL-PATHPARAM — rename `{collectionAppId}` → `{appId}` in `CollectionLabJournalEntriesRest` (size: XS, fire-534)
+- **Status:** 🔄 in-flight (fire-534, PR pending).
+- **Why:** `CollectionLabJournalEntriesRest.java` declares class-level `@Path("/v2/collections/{collectionAppId}/lab-journal-entries")` with a single method `list()` using `@PathParam("collectionAppId")`. Single-entity path — no JAX-RS collision. Rename per v2 `{appId}` convention (sweep fire-534).
+- **Fix:** Rename `{collectionAppId}` → `{appId}` in the class-level `@Path`, the `@PathParam` binding, and all local variable usages in `list()`.
+- **AC:** `grep -n 'collectionAppId' backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java` returns empty; CI green.
+- **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java:66,113`.
+
+## APISIMP-DATAOBJECT-V2REST-PATHPARAM — rename `{dataObjectAppId}` → `{appId}` in `DataObjectV2Rest` (size: S, fire-534)
+- **Status:** 🔄 queued (fire-534, dispatch fire-535).
+- **Why:** `DataObjectV2Rest.java` uses `{dataObjectAppId}` as the primary entity param across ~20+ method bindings covering GET, PUT, DELETE, PATCH sub-paths. Also uses `{collectionAppId}` in the class-level `@Path("/v2/collections/{collectionAppId}/dataobjects")` — that secondary param is the collection context and must keep a distinct name since the sub-paths add `{dataObjectAppId}` (two-entity pattern). Fix: rename `{dataObjectAppId}` → `{appId}` in all method-level `@PathParam` bindings and local variable usages; `{collectionAppId}` is reviewed for consistency at the same time. Sweep fire-534.
+- **Fix:** In each method that binds `@PathParam("dataObjectAppId")`, rename the annotation and local var to `appId`. Verify the two-entity path doesn't collide (class param `{collectionAppId}` + method param `{appId}` — distinct, no collision).
+- **AC:** `grep -n 'dataObjectAppId' backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java` returns empty; CI green.
+- **First refs:** `backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java` (multiple lines).

--- a/aidocs/agent-findings/apisimp-sweep-2026-07-10-fire534.md
+++ b/aidocs/agent-findings/apisimp-sweep-2026-07-10-fire534.md
@@ -1,0 +1,59 @@
+---
+stage: deployed
+last-stage-change: 2026-07-10
+---
+
+# APISIMP Sweep — Fire 534 (2026-07-10)
+
+Triggered: 0 queued APISIMP rows remained after fire-533 merged
+`APISIMP-BUNDLEGROUPS-PAGECAP` (PR #2467). This sweep scanned the live
+`/v2` REST surface for residual path-param inconsistencies and pagination
+cap violations.
+
+## Scope
+
+All JAX-RS resource files under
+`backend/src/main/java/de/dlr/shepard/v2/` plus plugin REST resources
+under `plugins/*/src/main/java/de/dlr/shepard/v2/`.
+
+## Methodology
+
+1. Grepped all `@PathParam` annotations for non-`appId` names.
+2. Checked `@Max` annotations on `pageSize` / `limit`-style params against
+   the 200 cap standard.
+3. Verified multi-param endpoints for by-design exceptions (two-entity
+   paths where both params can't both be named `appId`).
+
+## Findings
+
+### Filed this fire
+
+| Row ID | File | Finding | Size |
+|--------|------|---------|------|
+| APISIMP-COLL-LABJOURNAL-PATHPARAM | `CollectionLabJournalEntriesRest.java` | `{collectionAppId}` → `{appId}` in class `@Path` and method param. Single-entity path. | XS |
+| APISIMP-DATAOBJECT-V2REST-PATHPARAM | `DataObjectV2Rest.java` | `{dataObjectAppId}` → `{appId}` across ~20+ occurrences in multiple methods; `{collectionAppId}` review. | S |
+
+### By-design exceptions (not filed)
+
+- **Two-entity endpoints** (`/v2/collections/{collectionId}/dataobjects/{dataObjectId}/...`):
+  when a path contains two entity segments both cannot be named `appId` (JAX-RS
+  collision). These are handled case-by-case in their respective APISIMP rows.
+- **Domain-semantic size params** (`maxPoints`, `maxItems`, `windowSeconds`):
+  exempt from the 200 cap standard per `aidocs/16` policy note.
+
+### Already clean
+
+All other `/v2` resources reviewed this fire carried either `{appId}` already
+or a by-design two-entity exception. No new pagination cap violations found
+beyond the two rows filed.
+
+## Rows Dispatched
+
+- `APISIMP-COLL-LABJOURNAL-PATHPARAM` — dispatched this fire (PR opened)
+- `APISIMP-DATAOBJECT-V2REST-PATHPARAM` — queued for fire-535
+
+## Next Sweep
+
+Trigger: when `APISIMP-DATAOBJECT-V2REST-PATHPARAM` and any subsequent rows
+are exhausted. The sweep should also revisit plugin REST surfaces (git,
+spatiotemporal, krl-interpreter) once their V2 resources stabilise.

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java
@@ -43,7 +43,7 @@ import static de.dlr.shepard.v2.common.ProblemResponse.problem;
  *
  * <p>Route:
  * <ul>
- *   <li>{@code GET /v2/collections/{collectionAppId}/lab-journal-entries}
+ *   <li>{@code GET /v2/collections/{appId}/lab-journal-entries}
  *       — returns every non-deleted {@link LabJournalEntry} attached to any
  *       non-deleted DataObject in the collection, sorted by {@code createdAt DESC}.
  *       Requires Read permission on the Collection.</li>
@@ -63,7 +63,7 @@ import static de.dlr.shepard.v2.common.ProblemResponse.problem;
  */
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-@Path("/v2/collections/{collectionAppId}/lab-journal-entries")
+@Path("/v2/collections/{appId}/lab-journal-entries")
 @RequestScoped
 @Tag(name = "Collections")
 public class CollectionLabJournalEntriesRest {
@@ -92,7 +92,7 @@ public class CollectionLabJournalEntriesRest {
       "round-trips. Returns an empty array when the collection has no data " +
       "objects or none of them carry lab journal entries.\n\n" +
       "Auth: Read permission on the Collection. 401 if unauthenticated, " +
-      "404 if the collectionAppId resolves to nothing, 403 if the caller lacks Read.\n\n" +
+      "404 if the appId resolves to nothing, 403 if the caller lacks Read.\n\n" +
       "Pagination: `page` (0-based, default 0) and `pageSize` (1–200, default 50). " +
       "`X-Total-Count` header carries the total entry count before paging."
   )
@@ -110,7 +110,7 @@ public class CollectionLabJournalEntriesRest {
   @APIResponse(responseCode = "403", description = "Caller lacks Read permission on the Collection.")
   @APIResponse(responseCode = "404", description = "No Collection with that appId.")
   public Response list(
-    @PathParam("collectionAppId") String collectionAppId,
+    @PathParam("appId") String appId,
     @Parameter(description = "Zero-based page index (default 0).")
     @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
     @Parameter(description = "Page size, 1–200 (default 50).")
@@ -122,18 +122,18 @@ public class CollectionLabJournalEntriesRest {
 
     long ogmId;
     try {
-      ogmId = entityIdResolver.resolveLong(collectionAppId);
+      ogmId = entityIdResolver.resolveLong(appId);
     } catch (NotFoundException nfe) {
-      return problem(PT_NOT_FOUND, "Not found", Response.Status.NOT_FOUND, "No Collection with appId: " + collectionAppId);
+      return problem(PT_NOT_FOUND, "Not found", Response.Status.NOT_FOUND, "No Collection with appId: " + appId);
     }
 
     if (!permissionsService.isAccessTypeAllowedForUser(ogmId, AccessType.Read, caller)) {
       return problem(PT_FORBIDDEN, "Forbidden", Response.Status.FORBIDDEN, "Caller lacks Read permission on the Collection.");
     }
 
-    long total = entriesDAO.countByCollectionAppId(collectionAppId);
+    long total = entriesDAO.countByCollectionAppId(appId);
     int skip = page * pageSize;
-    List<LabJournalEntry> entries = entriesDAO.findByCollectionAppId(collectionAppId, skip, pageSize);
+    List<LabJournalEntry> entries = entriesDAO.findByCollectionAppId(appId, skip, pageSize);
     List<LabJournalEntryIO> ios = new ArrayList<>();
     for (LabJournalEntry e : entries) {
       // Defensive: skip orphan entries whose owning DataObject didn't hydrate.
@@ -145,7 +145,7 @@ public class CollectionLabJournalEntriesRest {
         Log.warnf(
           "Skipping orphan LabJournalEntry (appId=%s) with null DataObject in collection %s",
           e.getAppId(),
-          collectionAppId
+          appId
         );
         continue;
       }


### PR DESCRIPTION
## Summary

- Renames `{collectionAppId}` → `{appId}` in `CollectionLabJournalEntriesRest`: class-level `@Path`, `@PathParam` annotation, and all local variable usages in `list()`. Single-entity path — no JAX-RS collision.
- Updates 5 stale APISIMP status entries in `aidocs/16` (fires 531–534 merges now reflected).
- Appends two new backlog rows: `APISIMP-COLL-LABJOURNAL-PATHPARAM` (this PR) and `APISIMP-DATAOBJECT-V2REST-PATHPARAM` (queued, fire-535).
- Adds sweep report `aidocs/agent-findings/apisimp-sweep-2026-07-10-fire534.md`.
- Regenerates `aidocs/01-doc-stage-index.md`.

## Scope

`/v2` surface only. `/shepard/api/` v1 surface untouched.

## Test plan

- [ ] CI `mvn verify` green (covers compile + unit tests via backend CI)
- [ ] `grep -n 'collectionAppId' backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java` returns empty
- [ ] `CollectionLabJournalEntriesRestTest` all tests pass (unit tests call `resource.list(...)` directly, unaffected by `@PathParam` rename)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ug3U1HXWDNidcoocLCH3st)_