### PR TITLE
fix(APISIMP-TEMPLATE-PATHPARAM): rename {templateAppId} → {appId} in template REST resources

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4845,14 +4845,14 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/CollectionLabJournalEntriesRest.java:66,113`.
 
 ## APISIMP-DATAOBJECT-V2REST-PATHPARAM — rename `{dataObjectAppId}` → `{appId}` in `DataObjectV2Rest` (size: S, fire-534)
-- **Status:** 🔄 in-flight (fire-535, PR pending).
+- **Status:** ✅ done (fire-536, PR #2469 merged sha `eaac3431`).
 - **Why:** `DataObjectV2Rest.java` uses `{dataObjectAppId}` as the primary entity param across ~20+ method bindings covering GET, PUT, DELETE, PATCH sub-paths. Also uses `{collectionAppId}` in the class-level `@Path("/v2/collections/{collectionAppId}/dataobjects")` — that secondary param is the collection context and must keep a distinct name since the sub-paths add `{dataObjectAppId}` (two-entity pattern). Fix: rename `{dataObjectAppId}` → `{appId}` in all method-level `@PathParam` bindings and local variable usages; `{collectionAppId}` is reviewed for consistency at the same time. Sweep fire-534.
 - **Fix:** In each method that binds `@PathParam("dataObjectAppId")`, rename the annotation and local var to `appId`. Verify the two-entity path doesn't collide (class param `{collectionAppId}` + method param `{appId}` — distinct, no collision).
 - **AC:** `grep -n 'dataObjectAppId' backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java` returns empty; CI green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java` (multiple lines).
 
 ## APISIMP-TEMPLATE-PATHPARAM — rename `{templateAppId}` → `{appId}` in three template REST files (size: XS, fire-535)
-- **Status:** ⏳ queued (fire-535, dispatch fire-536).
+- **Status:** 🔄 in-flight (fire-536, branch `APISIMP-TEMPLATE-PATHPARAM-1`).
 - **Why:** Three template resource classes use `{templateAppId}` as their primary entity param but each is single-entity (no collision): `TemplateFormRest.java` (`/v2/templates/{templateAppId}/form`, 1 method), `TemplateExcelExportRest.java` (`/v2/templates/{templateAppId}/export`, 1 method), and `TemplateInstantiationRest.java` (class `/v2/collections/{collectionAppId}/data-objects/from-template`, method `/{templateAppId}` — two-entity with `{collectionAppId}` as the parent, `{templateAppId}` as the secondary → rename to `{appId}` safe). Sweep fire-535.
 - **Fix:** Rename `{templateAppId}` → `{appId}` in class-level `@Path`, method-level `@Path`, `@PathParam` annotations, and local variable usages in all three files.
 - **AC:** `grep -rn 'templateAppId' backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateFormRest.java backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateExcelExportRest.java backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateInstantiationRest.java` returns empty; CI green.

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateExcelExportRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateExcelExportRest.java
@@ -34,7 +34,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
- * {@code GET /v2/templates/{templateAppId}/export?dataObjectAppId=…} —
+ * {@code GET /v2/templates/{appId}/export?dataObjectAppId=…} —
  * shape-driven Excel export (BTKVS-C1-EXCEL-EXPORT, doc 125 §6/D5).
  *
  * <p><b>Seam reasoning (BTKVS-C1 reconciliation, aidocs/platform/191).</b>
@@ -65,7 +65,7 @@ import static de.dlr.shepard.v2.common.ProblemResponse.problem;
  * descriptor's contract).
  */
 @Produces(CellMappingExcelExporter.XLSX_MEDIA_TYPE)
-@Path("/v2/templates/{templateAppId}/export")
+@Path("/v2/templates/{appId}/export")
 @RequestScoped
 @Tag(name = "Templates")
 public class TemplateExcelExportRest {
@@ -124,7 +124,7 @@ public class TemplateExcelExportRest {
     description = "Template is not form-renderable: no shapeGraph in the flattened body, unparseable Turtle, or a non-data templateKind."
   )
   public Response exportExcel(
-    @PathParam("templateAppId") String templateAppId,
+    @PathParam("appId") String appId,
     @Parameter(
       description = "appId of the focused DataObject whose attributes fill the mapped cells.",
       required = true
@@ -136,16 +136,16 @@ public class TemplateExcelExportRest {
     }
     String caller = securityContext.getUserPrincipal().getName();
 
-    Optional<ShepardTemplate> templateOpt = templateDAO.findByAppId(templateAppId);
+    Optional<ShepardTemplate> templateOpt = templateDAO.findByAppId(appId);
     if (templateOpt.isEmpty()) {
       return problem(PT_NOT_FOUND, "Template not found", Response.Status.NOT_FOUND.getStatusCode(),
-        "No template with appId " + templateAppId);
+        "No template with appId " + appId);
     }
     ShepardTemplate template = templateOpt.get();
 
     if (template.isRetired()) {
       return problem(PT_CONFLICT, "Template retired", Response.Status.CONFLICT.getStatusCode(),
-        "Template " + templateAppId + " is retired; pick a non-retired version");
+        "Template " + appId + " is retired; pick a non-retired version");
     }
 
     if (template.getTemplateKind() == null ||
@@ -160,7 +160,7 @@ public class TemplateExcelExportRest {
     String shapeGraph = extractShapeGraph(effectiveBody);
     if (shapeGraph == null || shapeGraph.isBlank()) {
       return problem(PT_UNPROCESSABLE, "Template carries no shapeGraph", 422,
-        "The flattened body of template " + templateAppId + " has no shapeGraph Turtle — author one " +
+        "The flattened body of template " + appId + " has no shapeGraph Turtle — author one " +
         "via POST /v2/shapes/build (the JSON-DSL shape builder) and store it on the template body");
     }
 
@@ -169,12 +169,12 @@ public class TemplateExcelExportRest {
       descriptor = compiler.compile(template, shapeGraph);
     } catch (IllegalArgumentException ex) {
       return problem(PT_UNPROCESSABLE, "Shape graph not compilable", 422,
-        "Template " + templateAppId + ": " + ex.getMessage());
+        "Template " + appId + ": " + ex.getMessage());
     }
 
     if (!exporter.hasCellMappings(descriptor.fields())) {
       return problem(PT_CONFLICT, "Template carries no cell-mappings", Response.Status.CONFLICT.getStatusCode(),
-        "No property shape on template " + templateAppId + " carries a urn:btkvs:cell-mapping annotation — " +
+        "No property shape on template " + appId + " carries a urn:btkvs:cell-mapping annotation — " +
         "there is nothing to place in a workbook. Author cell mappings via the shape builder's " +
         "hints.cellMapping (doc 125 §4.2)");
     }

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateFormRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateFormRest.java
@@ -33,7 +33,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
- * {@code GET /v2/templates/{templateAppId}/form} — the form-descriptor
+ * {@code GET /v2/templates/{appId}/form} — the form-descriptor
  * endpoint (FORM-DESCRIPTOR-1, doc 125 §5.1 / BTKVS-B2).
  *
  * <p>Read-only projection: flattens the template's inheritance chain
@@ -58,7 +58,7 @@ import static de.dlr.shepard.v2.common.ProblemResponse.problem;
  * The FORM-DESCRIPTOR-1 backlog row tracks the residue.
  */
 @Produces(MediaType.APPLICATION_JSON)
-@Path("/v2/templates/{templateAppId}/form")
+@Path("/v2/templates/{appId}/form")
 @RequestScoped
 @Tag(name = "Templates")
 public class TemplateFormRest {
@@ -104,7 +104,7 @@ public class TemplateFormRest {
     description = "Template is not form-renderable: no shapeGraph in the flattened body, unparseable Turtle, or a non-data templateKind."
   )
   public Response getForm(
-    @PathParam("templateAppId") String templateAppId,
+    @PathParam("appId") String appId,
     @HeaderParam("If-None-Match") String ifNoneMatch,
     @Context SecurityContext securityContext
   ) {
@@ -112,16 +112,16 @@ public class TemplateFormRest {
       return problem(PT_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED.getStatusCode(), null);
     }
 
-    Optional<ShepardTemplate> templateOpt = templateDAO.findByAppId(templateAppId);
+    Optional<ShepardTemplate> templateOpt = templateDAO.findByAppId(appId);
     if (templateOpt.isEmpty()) {
       return problem(PT_NOT_FOUND, "Template not found", Response.Status.NOT_FOUND.getStatusCode(),
-        "No template with appId " + templateAppId);
+        "No template with appId " + appId);
     }
     ShepardTemplate template = templateOpt.get();
 
     if (template.isRetired()) {
       return problem(PT_CONFLICT, "Template retired", Response.Status.CONFLICT.getStatusCode(),
-        "Template " + templateAppId + " is retired; pick a non-retired version");
+        "Template " + appId + " is retired; pick a non-retired version");
     }
 
     if (template.getTemplateKind() == null ||
@@ -136,11 +136,11 @@ public class TemplateFormRest {
     String shapeGraph = extractShapeGraph(effectiveBody);
     if (shapeGraph == null || shapeGraph.isBlank()) {
       return problem(PT_UNPROCESSABLE, "Template carries no shapeGraph", 422,
-        "The flattened body of template " + templateAppId + " has no shapeGraph Turtle — author one " +
+        "The flattened body of template " + appId + " has no shapeGraph Turtle — author one " +
         "via POST /v2/shapes/build (the JSON-DSL shape builder) and store it on the template body");
     }
 
-    String etag = etagFor(templateAppId, effectiveBody);
+    String etag = etagFor(appId, effectiveBody);
     if (etag != null && etag.equals(ifNoneMatch)) {
       return Response.status(Response.Status.NOT_MODIFIED).header("ETag", etag).build();
     }
@@ -150,7 +150,7 @@ public class TemplateFormRest {
       descriptor = compiler.compile(template, shapeGraph);
     } catch (IllegalArgumentException ex) {
       return problem(PT_UNPROCESSABLE, "Shape graph not compilable", 422,
-        "Template " + templateAppId + ": " + ex.getMessage());
+        "Template " + appId + ": " + ex.getMessage());
     }
 
     Response.ResponseBuilder rb = Response.ok(descriptor);

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateInstantiationRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateInstantiationRest.java
@@ -46,7 +46,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import static de.dlr.shepard.v2.common.ProblemResponse.problem;
 
 /**
- * {@code POST /v2/collections/{collectionAppId}/data-objects/from-template/{templateAppId}}
+ * {@code POST /v2/collections/{collectionAppId}/data-objects/from-template/{appId}}
  *
  * <p>Server-side DataObject instantiation from a {@code :ShepardTemplate} per T1e
  * ({@code aidocs/16-dispatcher-backlog.md §T1e}).
@@ -127,7 +127,7 @@ public class TemplateInstantiationRest {
   SemanticAnnotationV2DAO annotationDAO;
 
   @POST
-  @Path("/{templateAppId}")
+  @Path("/{appId}")
   @Operation(
     operationId = "instantiateDataObject",
     summary = "Create a DataObject from a ShepardTemplate (server-side instantiation).",
@@ -156,7 +156,7 @@ public class TemplateInstantiationRest {
   )
   public Response instantiateDataObject(
     @PathParam("collectionAppId") String collectionAppId,
-    @PathParam("templateAppId") String templateAppId,
+    @PathParam("appId") String appId,
     @RequestBody(
       required = false,
       description = "Optional name override + caller-supplied attribute values (form input; merged over " +
@@ -183,26 +183,26 @@ public class TemplateInstantiationRest {
     }
 
     // Step 4: resolve template
-    Optional<ShepardTemplate> templateOpt = templateDAO.findByAppId(templateAppId);
+    Optional<ShepardTemplate> templateOpt = templateDAO.findByAppId(appId);
     if (templateOpt.isEmpty()) {
       return problem(PT_NOT_FOUND, "Template not found", Response.Status.NOT_FOUND,
-        "No template with appId " + templateAppId);
+        "No template with appId " + appId);
     }
     ShepardTemplate template = templateOpt.get();
 
     // Step 5: 409 if retired
     if (template.isRetired()) {
       return problem(PT_CONFLICT, "Template retired", Response.Status.CONFLICT,
-        "Template " + templateAppId + " is retired; pick a non-retired version");
+        "Template " + appId + " is retired; pick a non-retired version");
     }
 
     // Step 6: allow-list guard (empty list = unrestricted)
     List<ShepardTemplate> allowed = templateDAO.listAllowedForCollection(collectionAppId);
     if (!allowed.isEmpty()) {
-      boolean inList = allowed.stream().anyMatch(t -> templateAppId.equals(t.getAppId()));
+      boolean inList = allowed.stream().anyMatch(t -> appId.equals(t.getAppId()));
       if (!inList) {
         return problem(PT_FORBIDDEN, "Template not in allow-list", Response.Status.FORBIDDEN,
-          "Template " + templateAppId + " is not in the allow-list for Collection " + collectionAppId);
+          "Template " + appId + " is not in the allow-list for Collection " + collectionAppId);
       }
     }
 
@@ -238,7 +238,7 @@ public class TemplateInstantiationRest {
         // Malformed shape or engine error: log and skip validation rather than blocking
         Log.warnf(
           "SHACL validation skipped for template %s due to error: %s%s",
-          templateAppId,
+          appId,
           report.parseError() != null ? "parseError=" + report.parseError() : "",
           report.engineError() != null ? "engineError=" + report.engineError() : ""
         );
@@ -419,7 +419,7 @@ public class TemplateInstantiationRest {
           return nameNode.textValue();
         }
       } catch (JsonProcessingException e) {
-        Log.warnf("Could not parse template body for DataObject name fallback (templateAppId=%s): %s", template.getAppId(), e.getMessage());
+        Log.warnf("Could not parse template body for DataObject name fallback (appId=%s): %s", template.getAppId(), e.getMessage());
       }
     }
     return template.getName() + "-" + System.currentTimeMillis();

--- a/backend/src/test/java/de/dlr/shepard/v2/template/resources/TemplateExcelExportRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/template/resources/TemplateExcelExportRestTest.java
@@ -40,7 +40,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 /**
- * {@code GET /v2/templates/{templateAppId}/export?dataObjectAppId=…} —
+ * {@code GET /v2/templates/{appId}/export?dataObjectAppId=…} —
  * status-code contract + the doc 125 §6 round-trip proof: the focused
  * DataObject's attribute values land in the shape's mapped cells and are
  * read back out of the generated workbook with POI (BTKVS-C1-EXCEL-EXPORT).

--- a/backend/src/test/java/de/dlr/shepard/v2/template/resources/TemplateFormRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/template/resources/TemplateFormRestTest.java
@@ -29,7 +29,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 /**
- * {@code GET /v2/templates/{templateAppId}/form} — status-code contract +
+ * {@code GET /v2/templates/{appId}/form} — status-code contract +
  * happy-path descriptor + ETag (FORM-DESCRIPTOR-1, doc 125 §5.1).
  */
 class TemplateFormRestTest {


### PR DESCRIPTION
## Summary

Renames the `{templateAppId}` path parameter to `{appId}` across the three template REST resource files, consistent with the ongoing APISIMP path-param normalization sweep.

**Files changed:**
- `TemplateFormRest.java` — class-level `@Path("/v2/templates/{templateAppId}/form")` → `{appId}`; `@PathParam("templateAppId")` → `@PathParam("appId")`; local var `templateAppId` → `appId`.
- `TemplateExcelExportRest.java` — same treatment (class-level `@Path` + `@PathParam` + local vars).
- `TemplateInstantiationRest.java` — method-level `@Path("/{templateAppId}")` → `/{appId}`; `@PathParam("templateAppId")` → `@PathParam("appId")`; local var rename. **Class-level `{collectionAppId}` is left unchanged** — this is a two-entity path (`/v2/collections/{collectionAppId}/data-objects/from-template/{appId}`) where the parent param must stay distinct.

**aidocs/16:** APISIMP-DATAOBJECT-V2REST-PATHPARAM marked done (PR #2469 merged sha `eaac3431`); APISIMP-TEMPLATE-PATHPARAM marked in-flight.

## Scope

`/v2` surface only. `/shepard/api/` v1 surface untouched.

## Test plan

- [x] No `/shepard/api/` v1 surface touched
- [x] `grep -rn 'templateAppId' backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateFormRest.java backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateExcelExportRest.java backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateInstantiationRest.java` returns empty
- [ ] CI unit tests + coverage gate green

---
_Generated by [Claude Code](https://claude.ai/code/session_019GSEGaY7bNY7TSkjems36N)_