### PR TITLE
fix(APISIMP-DQR-PATHPARAM): rename {dqrAppId} → {appId} in CollectionDQRRest DELETE

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4852,7 +4852,14 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java` (multiple lines).
 
 ## APISIMP-TEMPLATE-PATHPARAM — rename `{templateAppId}` → `{appId}` in three template REST files (size: XS, fire-535)
-- **Status:** 🔄 in-flight (fire-536, branch `APISIMP-TEMPLATE-PATHPARAM-1`).
+- **Status:** 🔄 in-flight (fire-536, branch `APISIMP-TEMPLATE-PATHPARAM-1`). PR #2470 — awaiting CI.
+
+## APISIMP-DQR-PATHPARAM — rename `{dqrAppId}` → `{appId}` in `CollectionDQRRest` DELETE endpoint (size: XS, fire-537)
+- **Status:** 🔄 in-flight (fire-537, branch `APISIMP-DQR-PATHPARAM-1`).
+- **Why:** `CollectionDQRRest.java` serves `DELETE /v2/collections/{collectionAppId}/dqr/{dqrAppId}`. The secondary entity param `{dqrAppId}` uses a bespoke name deviating from the v2-standard `{appId}`. The parent `{collectionAppId}` stays (two-entity path; no collision since `collectionAppId` ≠ `appId`). This is the same normalization shape as APISIMP-DATAOBJECT-V2REST-PATHPARAM (fire-535) and APISIMP-TEMPLATE-PATHPARAM (fire-536).
+- **Fix:** `@Path("{dqrAppId}")` → `@Path("{appId}")` (line 153); `@PathParam("dqrAppId") String dqrAppId` → `@PathParam("appId") String appId` (line 168); `service.remove(collectionAppId, dqrAppId, caller)` → `service.remove(collectionAppId, appId, caller)` (line 173); javadoc line 48 updated.
+- **AC:** `grep -n 'dqrAppId' backend/src/main/java/de/dlr/shepard/v2/quality/resources/CollectionDQRRest.java` returns empty (excluding DTO field refs in tests); CI green.
+- **First refs:** `backend/src/main/java/de/dlr/shepard/v2/quality/resources/CollectionDQRRest.java:48,153,168,173`.
 - **Why:** Three template resource classes use `{templateAppId}` as their primary entity param but each is single-entity (no collision): `TemplateFormRest.java` (`/v2/templates/{templateAppId}/form`, 1 method), `TemplateExcelExportRest.java` (`/v2/templates/{templateAppId}/export`, 1 method), and `TemplateInstantiationRest.java` (class `/v2/collections/{collectionAppId}/data-objects/from-template`, method `/{templateAppId}` — two-entity with `{collectionAppId}` as the parent, `{templateAppId}` as the secondary → rename to `{appId}` safe). Sweep fire-535.
 - **Fix:** Rename `{templateAppId}` → `{appId}` in class-level `@Path`, method-level `@Path`, `@PathParam` annotations, and local variable usages in all three files.
 - **AC:** `grep -rn 'templateAppId' backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateFormRest.java backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateExcelExportRest.java backend/src/main/java/de/dlr/shepard/v2/template/resources/TemplateInstantiationRest.java` returns empty; CI green.

--- a/backend/src/main/java/de/dlr/shepard/v2/quality/resources/CollectionDQRRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/quality/resources/CollectionDQRRest.java
@@ -45,7 +45,7 @@ import static de.dlr.shepard.v2.common.ProblemResponse.problem;
  * <ul>
  *   <li>{@code GET    /v2/collections/{collectionAppId}/dqr}             — list DQRs (Read).</li>
  *   <li>{@code POST   /v2/collections/{collectionAppId}/dqr}             — assign DQR (Write).</li>
- *   <li>{@code DELETE /v2/collections/{collectionAppId}/dqr/{dqrAppId}}  — remove DQR (Write).</li>
+ *   <li>{@code DELETE /v2/collections/{collectionAppId}/dqr/{appId}}  — remove DQR (Write).</li>
  *   <li>{@code POST   /v2/collections/{collectionAppId}/dqr/evaluate}    — evaluate DQRs (Read).</li>
  * </ul>
  *
@@ -150,7 +150,7 @@ public class CollectionDQRRest {
   // ─── Remove ───────────────────────────────────────────────────────────────
 
   @DELETE
-  @Path("{dqrAppId}")
+  @Path("{appId}")
   @Operation(
     operationId = "remove",
     summary = "Remove a DQR from this Collection (TPL10).",
@@ -165,12 +165,12 @@ public class CollectionDQRRest {
   @APIResponse(responseCode = "404", description = "No such DQR or not assigned to this Collection.")
   public Response remove(
     @PathParam("collectionAppId") String collectionAppId,
-    @PathParam("dqrAppId") String dqrAppId,
+    @PathParam("appId") String appId,
     @Context SecurityContext securityContext
   ) {
     String caller = caller(securityContext);
     if (caller == null) return unauthorized();
-    service.remove(collectionAppId, dqrAppId, caller);
+    service.remove(collectionAppId, appId, caller);
     return Response.noContent().build();
   }
 


### PR DESCRIPTION
## Summary

Normalises the bespoke `{dqrAppId}` secondary-entity path param in `CollectionDQRRest` to the v2-standard `{appId}`, consistent with the ongoing APISIMP path-param normalization sweep (APISIMP-DATAOBJECT-V2REST-PATHPARAM fire-535, APISIMP-TEMPLATE-PATHPARAM fire-536).

**Endpoint affected:**
`DELETE /v2/collections/{collectionAppId}/dqr/{dqrAppId}` → `DELETE /v2/collections/{collectionAppId}/dqr/{appId}`

**Files changed (1 file, 4 lines):**

```diff
// CollectionDQRRest.java:48 — javadoc
- *   <li>{@code DELETE /v2/collections/{collectionAppId}/dqr/{dqrAppId}}  — remove DQR (Write).</li>
+ *   <li>{@code DELETE /v2/collections/{collectionAppId}/dqr/{appId}}  — remove DQR (Write).</li>

// CollectionDQRRest.java:153 — method-level @Path
- @Path("{dqrAppId}")
+ @Path("{appId}")

// CollectionDQRRest.java:168 — @PathParam + local var
- @PathParam("dqrAppId") String dqrAppId,
+ @PathParam("appId") String appId,

// CollectionDQRRest.java:173 — service call
- service.remove(collectionAppId, dqrAppId, caller);
+ service.remove(collectionAppId, appId, caller);
```

**Two-entity path rule applied correctly:** class-level `{collectionAppId}` stays (parent context param, distinct name avoids duplicate); only the secondary DQR param (`{dqrAppId}`) is renamed to `{appId}`. No JAX-RS collision.

**aidocs/16:** APISIMP-TEMPLATE-PATHPARAM status note updated (PR #2470 reference added); APISIMP-DQR-PATHPARAM row added as in-flight.

## Scope

`/v2` surface only. `/shepard/api/` v1 surface untouched. Response DTO field `DQRIO.dqrAppId()` is not a path param — unchanged.

## Test plan

- [x] `grep -n 'dqrAppId' backend/src/main/java/de/dlr/shepard/v2/quality/resources/CollectionDQRRest.java` returns empty ✅
- [x] Two-entity path collision check: `{collectionAppId}` ≠ `{appId}` — no JAX-RS duplicate ✅
- [x] `/shepard/api/` v1 surface untouched ✅
- [ ] CI unit tests + coverage gate green

---
_Generated by [Claude Code](https://claude.ai/code/session_019GSEGaY7bNY7TSkjems36N)_