### PR TITLE
fix(APISIMP-BUNDLE-LISTGROUPS-PAGEPARAM): add @Parameter on listGroups page/pageSize in BundleGroupsV2Rest

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4873,7 +4873,7 @@ picks these up. Terse by design.
 - **First refs:** `plugins/wiki-writer/src/main/java/de/dlr/shepard/plugins/wikiwriter/resources/WikiWriterRest.java:49,95`.
 
 ## APISIMP-BUNDLE-LISTGROUPS-PAGEPARAM — add `@Parameter` on `listGroups` page/pageSize in `BundleGroupsV2Rest` (size: XS, fire-539)
-- **Status:** queued (fire-539).
+- **Status:** ✅ shipped (fire-540, PR #2473).
 - **Why:** `BundleGroupsV2Rest.java:141–142` exposes `@QueryParam("page")` and `@QueryParam("pageSize")` on the `listGroups` endpoint but lacks `@Parameter` OpenAPI annotations on both params. Other v2 list endpoints (e.g. `DataObjectV2Rest`, `CollectionV2Rest`) carry `@Parameter(description=..., schema=@Schema(...))` on their pagination params — missing here breaks API docs consistency. Pure annotation addition; no logic change. Sweep fire-539.
 - **Fix:** Add `@Parameter(description = "Page number (0-based)", schema = @Schema(defaultValue = "0"))` and `@Parameter(description = "Page size", schema = @Schema(defaultValue = "10", maximum = "200"))` on the two `@QueryParam` params in `listGroups`.
 - **AC:** OpenAPI spec for `GET /v2/bundle-groups` shows `page` and `pageSize` parameter descriptions; CI green.

--- a/backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/bundle/resources/BundleGroupsV2Rest.java
@@ -138,7 +138,15 @@ public class BundleGroupsV2Rest {
   @APIResponse(responseCode = "404", description = "No FileBundleReference with that appId.")
   public Response listGroups(
     @PathParam("appId") String appId,
+    @Parameter(
+      description = "Zero-based page index (default 0).",
+      schema = @Schema(minimum = "0", defaultValue = "0")
+    )
     @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
+    @Parameter(
+      description = "Page size, 1–200 (default 50).",
+      schema = @Schema(minimum = "1", maximum = "200", defaultValue = "50")
+    )
     @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize,
     @Context SecurityContext securityContext
   ) {


### PR DESCRIPTION
## Summary

`BundleGroupsV2Rest.listGroups()` exposed `@QueryParam("page")` and `@QueryParam("pageSize")` without `@Parameter` OpenAPI annotations, making the `GET /v2/references/{appId}/groups` pagination params undiscoverable in the generated API docs.

The sibling `listGroupFiles()` method on the same class already carries the correct `@Parameter` pattern; this applies it to `listGroups` consistently.

**Change (1 file, 8 lines — annotation metadata only):**

```diff
  public Response listGroups(
    @PathParam("appId") String appId,
+   @Parameter(
+     description = "Zero-based page index (default 0).",
+     schema = @Schema(minimum = "0", defaultValue = "0")
+   )
    @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
+   @Parameter(
+     description = "Page size, 1–200 (default 50).",
+     schema = @Schema(minimum = "1", maximum = "200", defaultValue = "50")
+   )
    @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize,
    @Context SecurityContext securityContext
  ) {
```

**No logic change.** Default (page=0, pageSize=50) and cap (@Max(200)) are unchanged. Existing callers unaffected.

**Backlog row:** `APISIMP-BUNDLE-LISTGROUPS-PAGEPARAM` (XS) in `aidocs/16-dispatcher-backlog.md` — marked ✅ shipped fire-540.

**Previous renames/fixes in this series:** #2428, #2451, #2455, #2472.

## Test plan

- [x] `mvn -q -DnoPlugins compile` passes — clean, exit 0 (verified)
- [x] No logic change — annotation metadata only; default and cap unchanged
- [x] `aidocs/01-doc-stage-index.md` regenerated (no stage change — no-op output)

---
_Generated by [Claude Code](https://claude.ai/code/session_011rDSfEDeFepQqTJBHEeEzS)_