### PR TITLE
fix(APISIMP-CROSS-BULK-KIND-PARAM): add @Parameter on kind QueryParam in CrossDoBulkDataRest

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4880,7 +4880,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/bundles/resources/BundleGroupsV2Rest.java:141–142`.
 
 ## APISIMP-CROSS-BULK-KIND-PARAM — add `@Parameter` on `kind` QueryParam in `CrossDoBulkDataRest` (size: XS, fire-539)
-- **Status:** queued (fire-539).
+- **Status:** ✅ shipped (fire-541, PR #2474).
 - **Why:** `CrossDoBulkDataRest.java:119` exposes `@QueryParam("kind")` on the bulk-data endpoint without an `@Parameter` annotation. The `kind` enum values are undiscoverable from the OpenAPI spec without it. Annotation-only addition; no logic change. Sweep fire-539.
 - **Fix:** Add `@Parameter(description = "Payload kind filter", schema = @Schema(enumeration = {...}))` on the `kind` `@QueryParam` in the relevant method.
 - **AC:** OpenAPI spec for the bulk-data endpoint shows `kind` as a documented param with enum values; CI green.

--- a/backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRest.java
@@ -34,6 +34,7 @@ import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import static de.dlr.shepard.v2.common.ProblemResponse.problem;
@@ -116,6 +117,11 @@ public class CrossDoBulkDataRest {
   @APIResponse(responseCode = "400", description = "Validation error on request body, or unsupported/missing `kind`.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
   public Response getCrossDoBulkData(
+    @Parameter(
+      description = "Payload-family discriminator. Currently only `timeseries` is accepted; "
+        + "future kinds (`file`, `structured`) will extend this endpoint without a new path.",
+      schema = @Schema(enumeration = {"timeseries"}, defaultValue = "timeseries")
+    )
     @QueryParam("kind") String kind,
     @NotNull @Valid CrossDoBulkDataRequestIO body,
     @Context SecurityContext sc


### PR DESCRIPTION
## Summary

`CrossDoBulkDataRest.getCrossDoBulkData()` at `POST /v2/data-objects/cross-bulk` exposes `@QueryParam("kind")` without an `@Parameter` OpenAPI annotation. The accepted enum value (`timeseries`) and the extension contract (`file`, `structured` will be added here, not at a new path) are invisible in the generated API spec.

**Change (1 file, 6 lines — annotation + import only):**

```diff
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;

  public Response getCrossDoBulkData(
+   @Parameter(
+     description = "Payload-family discriminator. Currently only `timeseries` is accepted; "
+       + "future kinds (`file`, `structured`) will extend this endpoint without a new path.",
+     schema = @Schema(enumeration = {"timeseries"}, defaultValue = "timeseries")
+   )
    @QueryParam("kind") String kind,
```

**No logic change.** The validation (`if (!kind.equals("timeseries"))`) and 400 response are untouched. Existing callers are unaffected.

**Backlog row:** `APISIMP-CROSS-BULK-KIND-PARAM` (XS) in `aidocs/16-dispatcher-backlog.md` — marked ✅ shipped fire-541.

**Previous fixes in this series:** #2428, #2451, #2455, #2472, #2473.

## Test plan

- [x] `mvn -q -DnoPlugins compile --no-transfer-progress` (from `backend/`) passes — clean, exit 0 (verified)
- [x] No logic change — annotation + import metadata only; validation unchanged
- [x] `aidocs/01-doc-stage-index.md` regenerated (`python3 scripts/regenerate-doc-stage-index.py`) — no stage change (no-op output)

---
_Generated by [Claude Code](https://claude.ai/code/session_011rDSfEDeFepQqTJBHEeEzS)_