### PR TITLE
fix(APISIMP-IMPORT-RUNID-LOCKID-ALIAS): document runId/lockId alias across import resources

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4894,7 +4894,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/SnapshotRest.java:155–156`.
 
 ## APISIMP-IMPORT-RUNID-LOCKID-ALIAS — document `{runId}` vs `{lockId}` param naming across import resources (size: S, fire-539)
-- **Status:** queued (fire-539).
+- **Status:** ✅ shipped fire-542 (PR #2475).
 - **Why:** The import sub-surface uses two different param names across two resources: `ImportV2Rest` uses `{runId}` for import diagnostics/status paths, while `ImportLockV2Rest` uses `{lockId}` for lock-lifecycle operations. Both refer to the same import-run entity but use different names — callers must know which resource uses which name. `{lockId}` is intentional (it refers specifically to the lock, not the run entity) but the distinction is undocumented. Fix: add explicit `@Parameter(description = ...)` on both params noting the distinction, and ensure javadoc on each resource cross-references the other. No path rename required.
 - **Fix:** `@Parameter` annotations on `{runId}` in `ImportV2Rest` and `{lockId}` in `ImportLockV2Rest`; cross-reference comments in both class-level Javadocs.
 - **AC:** OpenAPI spec clearly distinguishes `runId` (diagnostics) from `lockId` (lock lifecycle); CI green.

--- a/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportDiagnosticsV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportDiagnosticsV2Rest.java
@@ -58,6 +58,9 @@ import static de.dlr.shepard.v2.common.ProblemResponse.problem;
  * push DO_CREATE / REF_ATTACH / FILE_UPLOAD phase events that are out of reach of
  * the Java service.
  *
+ * <p>Cross-resource alias: {@link ImportLockV2Rest} uses the name {@code lockId} for
+ * the same value on its heartbeat/release/abandon/cancel paths.
+ *
  * <h2>Auth</h2>
  * <p>All endpoints require authentication.  There is no Write-on-collection
  * check because diagnostic data is considered operational metadata, readable by
@@ -123,6 +126,13 @@ public class ImportDiagnosticsV2Rest {
   @APIResponse(responseCode = "400", description = "Invalid level or phase filter value, or limit out of range")
   @APIResponse(responseCode = "401", description = "Authentication required")
   public Response getEvents(
+    @Parameter(
+      description =
+        "Import run identifier — the lockId value returned by POST /v2/import/lock. " +
+        "This resource uses the name 'runId' to emphasise its diagnostic role; " +
+        "ImportLockV2Rest uses the name 'lockId' for the same value on its " +
+        "heartbeat/release/abandon/cancel paths."
+    )
     @PathParam("runId") String runId,
     @Parameter(description = "Filter to a single severity level. One of: INFO, WARN, ERROR.",
                schema = @Schema(enumeration = {"INFO", "WARN", "ERROR"}))
@@ -159,7 +169,7 @@ public class ImportDiagnosticsV2Rest {
     return builder.build();
   }
 
-  // ─── GET /v2/import/runs ──────────────────────────────────────────────────
+  // ─── GET /v2/import/runs ──────────────────────────────────────────
 
   @GET
   @Path("/runs")
@@ -214,6 +224,13 @@ public class ImportDiagnosticsV2Rest {
   @APIResponse(responseCode = "400", description = "Missing required fields or invalid level/phase")
   @APIResponse(responseCode = "401", description = "Authentication required")
   public Response ingestEvent(
+    @Parameter(
+      description =
+        "Import run identifier — the lockId value returned by POST /v2/import/lock. " +
+        "This resource uses the name 'runId' to emphasise its diagnostic role; " +
+        "ImportLockV2Rest uses the name 'lockId' for the same value on its " +
+        "heartbeat/release/abandon/cancel paths."
+    )
     @PathParam("runId") String runId,
     IngestEventIO body,
     @Context SecurityContext sc
@@ -234,7 +251,7 @@ public class ImportDiagnosticsV2Rest {
     return Response.noContent().build();
   }
 
-  // ─── POST /v2/import/diagnostics/{runId}/events/batch ────────────────────
+  // ─── POST /v2/import/diagnostics/{runId}/events/batch ────────────────────────
 
   @POST
   @Path("/diagnostics/{runId}/events/batch")
@@ -253,6 +270,13 @@ public class ImportDiagnosticsV2Rest {
   @APIResponse(responseCode = "400", description = "Empty batch or invalid event field")
   @APIResponse(responseCode = "401", description = "Authentication required")
   public Response ingestBatch(
+    @Parameter(
+      description =
+        "Import run identifier — the lockId value returned by POST /v2/import/lock. " +
+        "This resource uses the name 'runId' to emphasise its diagnostic role; " +
+        "ImportLockV2Rest uses the name 'lockId' for the same value on its " +
+        "heartbeat/release/abandon/cancel paths."
+    )
     @PathParam("runId") String runId,
     BatchIngestIO body,
     @Context SecurityContext sc
@@ -282,7 +306,7 @@ public class ImportDiagnosticsV2Rest {
     return Response.noContent().build();
   }
 
-  // ─── Helpers ──────────────────────────────────────────────────────────────
+  // ─── Helpers ──────────────────────────────────────────────────────────────────────────────
 
   /**
    * Validate an ingest event body.

--- a/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportLockV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/importer/resources/ImportLockV2Rest.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import static de.dlr.shepard.v2.common.ProblemResponse.problem;
@@ -47,6 +48,10 @@ import static de.dlr.shepard.v2.common.ProblemResponse.problem;
  * The lock persists across server restarts so a restarted backend can surface
  * "an import was in progress" rather than silently losing state.
  *
+ * <p>The {@code lockId} returned on acquire is also the {@code runId} accepted by
+ * {@link ImportDiagnosticsV2Rest} on its {@code /v2/import/diagnostics/{runId}} paths.
+ * Use it throughout the import run to push and query structured diagnostic events.
+ *
  * <p>Auth: all endpoints require authentication.  Only {@code DELETE} requires the
  * {@code instance-admin} role.
  */
@@ -66,7 +71,7 @@ public class ImportLockV2Rest {
   @Inject
   ImportLockService lockService;
 
-  // ─── GET /v2/import/lock ──────────────────────────────────────────────────
+  // ─── GET /v2/import/lock ────────────────────────────────────────────────────
 
   @GET
   @Operation(
@@ -92,7 +97,7 @@ public class ImportLockV2Rest {
     return Response.ok(LockStatusIO.from(lock)).build();
   }
 
-  // ─── POST /v2/import/lock ─────────────────────────────────────────────────
+  // ─── POST /v2/import/lock ───────────────────────────────────────────────────
 
   @POST
   @Operation(
@@ -132,7 +137,7 @@ public class ImportLockV2Rest {
       .build();
   }
 
-  // ─── POST /v2/import/lock/{lockId}/heartbeat ──────────────────────────────
+  // ─── POST /v2/import/lock/{lockId}/heartbeat ───────────────────────────────
 
   @POST
   @Path("/{lockId}/heartbeat")
@@ -153,6 +158,12 @@ public class ImportLockV2Rest {
   @APIResponse(responseCode = "404", description = "Lock not found")
   @APIResponse(responseCode = "409", description = "Lock is not in RUNNING status")
   public Response heartbeat(
+    @Parameter(
+      description =
+        "Lock identifier returned by POST /v2/import/lock (the 'lockId' field in LockStatusIO). " +
+        "Cross-resource alias: ImportDiagnosticsV2Rest uses this same value under the " +
+        "name 'runId' on its /v2/import/diagnostics/{runId} paths."
+    )
     @PathParam("lockId") String lockId,
     @Context SecurityContext sc
   ) {
@@ -186,6 +197,12 @@ public class ImportLockV2Rest {
   @APIResponse(responseCode = "401", description = "Authentication required")
   @APIResponse(responseCode = "404", description = "Lock not found or not in RUNNING status")
   public Response release(
+    @Parameter(
+      description =
+        "Lock identifier returned by POST /v2/import/lock (the 'lockId' field in LockStatusIO). " +
+        "Cross-resource alias: ImportDiagnosticsV2Rest uses this same value under the " +
+        "name 'runId' on its /v2/import/diagnostics/{runId} paths."
+    )
     @PathParam("lockId") String lockId,
     @Context SecurityContext sc
   ) {
@@ -220,6 +237,12 @@ public class ImportLockV2Rest {
   @APIResponse(responseCode = "401", description = "Authentication required")
   @APIResponse(responseCode = "404", description = "Lock not found or not in RUNNING status")
   public Response abandon(
+    @Parameter(
+      description =
+        "Lock identifier returned by POST /v2/import/lock (the 'lockId' field in LockStatusIO). " +
+        "Cross-resource alias: ImportDiagnosticsV2Rest uses this same value under the " +
+        "name 'runId' on its /v2/import/diagnostics/{runId} paths."
+    )
     @PathParam("lockId") String lockId,
     AbandonRequestIO body,
     @Context SecurityContext sc
@@ -239,7 +262,7 @@ public class ImportLockV2Rest {
     return Response.ok(LockStatusIO.from(lock)).build();
   }
 
-  // ─── DELETE /v2/import/lock/{lockId} ─────────────────────────────────────
+  // ─── DELETE /v2/import/lock/{lockId} ───────────────────────────────────────────
 
   @DELETE
   @Path("/{lockId}")
@@ -262,6 +285,12 @@ public class ImportLockV2Rest {
   @APIResponse(responseCode = "403", description = "Requires instance-admin role")
   @APIResponse(responseCode = "404", description = "Lock not found")
   public Response cancel(
+    @Parameter(
+      description =
+        "Lock identifier returned by POST /v2/import/lock (the 'lockId' field in LockStatusIO). " +
+        "Cross-resource alias: ImportDiagnosticsV2Rest uses this same value under the " +
+        "name 'runId' on its /v2/import/diagnostics/{runId} paths."
+    )
     @PathParam("lockId") String lockId,
     @Context SecurityContext sc
   ) {
@@ -275,7 +304,7 @@ public class ImportLockV2Rest {
     return Response.ok(LockStatusIO.from(lock)).build();
   }
 
-  // ─── Helpers ──────────────────────────────────────────────────────────────
+  // ─── Helpers ──────────────────────────────────────────────────────────────────────────────
 
   private static String caller(SecurityContext sc) {
     return sc.getUserPrincipal() != null ? sc.getUserPrincipal().getName() : null;


### PR DESCRIPTION
## Summary

The import sub-surface exposes two resource-local path-param names for the same underlying value — `ImportLock.lockId`:

| Resource | Path param | Paths |
|---|---|---|
| `ImportDiagnosticsV2Rest` | `{runId}` | `GET /v2/import/diagnostics/{runId}`, `POST …/events`, `POST …/events/batch` |
| `ImportLockV2Rest` | `{lockId}` | `POST /v2/import/lock/{lockId}/heartbeat`, `/release`, `/abandon`, `DELETE /v2/import/lock/{lockId}` |

Both names refer to the same `ImportLock.lockId` UUID. The distinction is intentional — `runId` emphasises the diagnostic/observability role, `lockId` emphasises the lock-lifecycle role — but was entirely undocumented in the OpenAPI spec, forcing callers to read the source to understand they must use the `lockId` returned by `POST /v2/import/lock` as the `runId` for diagnostics calls.

**Changes (annotation + javadoc only — no logic change):**

1. `ImportDiagnosticsV2Rest.java` — add `@Parameter(description = "Import run identifier — the lockId value returned by POST /v2/import/lock …")` on all three `@PathParam("runId")` occurrences; add cross-reference note in class Javadoc.

2. `ImportLockV2Rest.java` — add `import org.eclipse.microprofile.openapi.annotations.parameters.Parameter`; add `@Parameter(description = "Lock identifier returned by POST /v2/import/lock … Cross-resource alias: ImportDiagnosticsV2Rest uses this same value under the name 'runId' …")` on all four `@PathParam("lockId")` occurrences; add cross-reference note in class Javadoc.

3. `aidocs/16-dispatcher-backlog.md` — mark `APISIMP-IMPORT-RUNID-LOCKID-ALIAS` ✅ shipped fire-542.

**Backlog row:** `APISIMP-IMPORT-RUNID-LOCKID-ALIAS` (S) in `aidocs/16-dispatcher-backlog.md` — marked ✅ shipped fire-542.

**Previous fixes in this series:** #2428, #2451, #2455, #2472, #2473, #2474.

## Test plan

- [x] `mvn -q -DnoPlugins compile --no-transfer-progress` (from `backend/`) passes — clean, exit 0 (verified)
- [x] No logic change — annotation + javadoc metadata only; path resolution and lockId semantics unchanged
- [x] `aidocs/01-doc-stage-index.md` regenerated (`python3 scripts/regenerate-doc-stage-index.py`) — no stage change (no-op output)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNboCXd5U3Myk1CKvDnfZD)_