### PR TITLE
fix(APISIMP-PUBLICATION-GONE-PARAMS): remove dead pagination params from PublicationsListRest tombstone (XS)

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/publish/resources/PublicationsListRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/publish/resources/PublicationsListRest.java
@@ -2,12 +2,10 @@ package de.dlr.shepard.v2.publish.resources;
 
 import de.dlr.shepard.v2.common.ProblemResponse;
 import jakarta.enterprise.context.RequestScoped;
-import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
@@ -55,9 +53,7 @@ public class PublicationsListRest {
   @APIResponse(responseCode = "410", description = "Endpoint removed. Use GET /v2/publications?entityAppId={appId}.")
   public Response list(
     @PathParam("kind") String kind,
-    @PathParam("appId") String appId,
-    @QueryParam("page") @DefaultValue("0") int page,
-    @QueryParam("pageSize") @DefaultValue("50") int pageSize
+    @PathParam("appId") String appId
   ) {
     return gone();
   }

--- a/backend/src/test/java/de/dlr/shepard/v2/publish/resources/PublicationsListRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/publish/resources/PublicationsListRestTest.java
@@ -25,19 +25,19 @@ class PublicationsListRestTest {
 
   @Test
   void anyCallReturns410Gone() {
-    Response r = rest.list("data-objects", "01HF-A", 0, 50);
+    Response r = rest.list("data-objects", "01HF-A");
     assertEquals(410, r.getStatus());
   }
 
   @Test
   void responseHasLocationHeader() {
-    Response r = rest.list("data-objects", "01HF-A", 0, 50);
+    Response r = rest.list("data-objects", "01HF-A");
     assertEquals("/v2/publications", r.getHeaderString("Location"));
   }
 
   @Test
   void responseIsApplicationProblemJson() {
-    Response r = rest.list("data-objects", "01HF-A", 0, 50);
+    Response r = rest.list("data-objects", "01HF-A");
     assertNotNull(r.getMediaType());
     assertTrue(r.getMediaType().toString().contains("problem+json"),
       "Response media type should be application/problem+json");
@@ -45,14 +45,14 @@ class PublicationsListRestTest {
 
   @Test
   void differentKindAndAppIdStillReturns410() {
-    Response r = rest.list("collections", "01COLL-A", 0, 50);
+    Response r = rest.list("collections", "01COLL-A");
     assertEquals(410, r.getStatus());
     assertEquals("/v2/publications", r.getHeaderString("Location"));
   }
 
   @Test
   void problemBodyContainsGoneType() {
-    Response r = rest.list("data-objects", "01HF-A", 0, 50);
+    Response r = rest.list("data-objects", "01HF-A");
     String body = r.getEntity().toString();
     assertTrue(body.contains("urn:shepard:error:gone"), "Problem body should contain gone type");
   }


### PR DESCRIPTION
## Summary

`PublicationsListRest.list()` is a GONE/tombstone endpoint (`GET /v2/{kind}/{appId}/publications`) that always returns HTTP 410 immediately. Its method signature carried two vestigial pagination params (`page`, `pageSize`) that were never read — the body is a single `return gone()`.

**Problems with the dead params:**
- Appeared in the OpenAPI spec as documented query params on a 410-only endpoint (confusing to API consumers)
- Imported `@DefaultValue` and `@QueryParam` for no purpose
- Missing standard validators (`@PositiveOrZero`, `@Min(1)`, `@Max(200)`) that every live paginated endpoint carries

**Fix:** Remove the two unused param declarations and the now-unused `@DefaultValue` / `@QueryParam` imports. Update the 5 unit tests that previously passed `0, 50` as vestigial args.

## Changes

| File | Change |
|------|--------|
| `PublicationsListRest.java` | Remove `page`/`pageSize` params + unused imports |
| `PublicationsListRestTest.java` | Update 5 test call sites from 4 args → 2 args |

## Acceptance criteria

- `grep -n 'QueryParam\|DefaultValue' backend/src/main/java/de/dlr/shepard/v2/publish/resources/PublicationsListRest.java` returns empty ✓
- All 5 unit tests still pass (`anyCallReturns410Gone`, `responseHasLocationHeader`, `responseIsApplicationProblemJson`, `differentKindAndAppIdStillReturns410`, `problemBodyContainsGoneType`)
- CI green

Backlog row: `APISIMP-PUBLICATION-GONE-PARAMS` (XS) — sweep fire-545.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWFgpGuYKJYim1pb3kdG54)_