### PR TITLE
feat(APISIMP-TYPED-PRED-NEO4J-ID-DROP): remove dead predecessorId from TypedPredecessorSummaryIO

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -4950,7 +4950,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:467`; `backend/src/main/java/de/dlr/shepard/v2/collection/resources/CollectionV2Rest.java:176`; `backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java:212`; apisimp-sweep-fire545-2026-07-11 §Finding3.
 
 ## APISIMP-TYPED-PRED-NEO4J-ID-DROP — remove `@JsonIgnore @Deprecated long predecessorId` from `TypedPredecessorSummaryIO` (size: XS, fire-547)
-- **Status:** ⏳ queued.
+- **Status:** 🚧 in-progress — PR #2485 (fire-548).
 - **Why:** `TypedPredecessorSummaryIO.java:28-38` carries `@Deprecated @JsonIgnore long predecessorId` that is never serialized to the wire (`@JsonIgnore`) and is `@Schema(hidden=true)`. It is pure dead code — noted in fire-545 sweep but not filed. Removes the last numeric Neo4j id from the `TypedPredecessorSummaryIO` record. Sweep fire-547.
 - **Fix:** Delete the four-line component (`@Deprecated @JsonIgnore @Schema(…) long predecessorId`) from the record declaration. No callers to update.
 - **AC:** `grep -n 'predecessorId' backend/src/main/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIO.java` returns empty; `mvn -q test-compile -pl backend` green.

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/io/DataObjectDetailV2IO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/io/DataObjectDetailV2IO.java
@@ -233,7 +233,6 @@ public class DataObjectDetailV2IO extends DataObjectIO {
         String rType = appIdToType.getOrDefault(p.getAppId(), TypedPredecessorIO.DEFAULT_TYPE);
         tpList.add(new TypedPredecessorSummaryIO(
           p.getAppId(),
-          p.getShepardId() != null ? p.getShepardId() : -1L,
           p.getName(),
           p.getStatus(),
           rType

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIO.java
@@ -1,13 +1,12 @@
 package de.dlr.shepard.v2.dataobject.io;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * PROV1k — read-side typed predecessor entry in
  * {@link DataObjectDetailV2IO#getTypedPredecessorSummaries()}.
  *
- * <p>Pairs the compact predecessor summary (appId, id, name, status) with
+ * <p>Pairs the compact predecessor summary (appId, name, status) with
  * the stored PROV-O / FAIR²R relationship type. Pre-PROV1k DataObjects
  * (whose {@code typedPredecessorsJson} is null) emit
  * {@code "prov:wasInformedBy"} as the default.
@@ -24,18 +23,6 @@ public record TypedPredecessorSummaryIO(
 
   @Schema(readOnly = true, description = "appId (UUID v7) of the predecessor DataObject.")
   String predecessorAppId,
-
-  @Deprecated
-  @JsonIgnore
-  @Schema(
-    readOnly = true,
-    deprecated = true,
-    hidden = true,
-    description =
-      "Deprecated — join on predecessorAppId (UUID v7) instead. " +
-      "Numeric Neo4j shepardId of the predecessor DataObject."
-  )
-  long predecessorId,
 
   @Schema(readOnly = true, description = "Display name of the predecessor DataObject.")
   String predecessorName,

--- a/backend/src/test/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIOTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/dataobject/io/TypedPredecessorSummaryIOTest.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 /**
- * APISIMP-TYPED-PRED-ID — regression guard: {@code predecessorId} must not appear
- * in the serialized JSON output. It is a numeric Neo4j internal ID that violates
- * the v2 "no numeric internal IDs on the wire" contract.
+ * Regression guard: {@code predecessorId} must not appear in the serialized
+ * JSON output. The field was removed in APISIMP-TYPED-PRED-NEO4J-ID-DROP;
+ * this test keeps the contract explicit.
  */
 public class TypedPredecessorSummaryIOTest {
 
@@ -19,7 +19,6 @@ public class TypedPredecessorSummaryIOTest {
   void predecessorId_isNotSerializedToWire() throws Exception {
     TypedPredecessorSummaryIO io = new TypedPredecessorSummaryIO(
       "01930a2b-fe4c-7e3c-9f1d-8a5b2c3d4e5f",
-      42L,
       "TR-004",
       "PUBLISHED",
       "prov:wasRevisionOf"


### PR DESCRIPTION
## Summary

Removes the dead `@Deprecated @JsonIgnore long predecessorId` component from `TypedPredecessorSummaryIO`.

- The field was a v2 no-numeric-internal-IDs-on-wire violation: Neo4j internal node IDs must not appear on the `/v2/` surface.
- It was already suppressed via `@JsonIgnore`, so **no wire-shape change** — clients have never received this field.
- Removing it eliminates the dead constructor argument and the misleading declaration that a numeric ID even exists in this type.
- Regression guard (`TypedPredecessorSummaryIOTest`) updated to assert `predecessorId` is absent from serialised JSON and that `predecessorAppId` + `predecessorName` are present.

## Changed files

| File | Change |
|------|--------|
| `TypedPredecessorSummaryIO.java` | Remove `predecessorId` component, `@JsonIgnore`/`@Deprecated` annotations, and unused `JsonIgnore` import |
| `DataObjectDetailV2IO.java` | Remove `p.getShepardId()` argument from `TypedPredecessorSummaryIO` constructor call |
| `TypedPredecessorSummaryIOTest.java` | Update to 4-arg constructor; assert field absent from JSON |

## Backlog row

`APISIMP-TYPED-PRED-NEO4J-ID-DROP` (XS) — no migration needed (wire-transparent removal).

## Test plan

- [x] `mvn -q test-compile` passes
- [ ] CI: `TypedPredecessorSummaryIOTest#predecessorId_isNotSerializedToWire` green
- [ ] CI: full backend unit suite green


---
_Generated by [Claude Code](https://claude.ai/code/session_01LfMaeaWuer9WpHsYT4796v)_