### PR TITLE
refactor(APISIMP-ANNOTATION-EPOCH-MS-TO-ISO): convert validFromMillis/validUntilMillis to ISO 8601 in annotation IOs

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/annotations/io/AnnotationIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/annotations/io/AnnotationIO.java
@@ -1,6 +1,9 @@
 package de.dlr.shepard.v2.annotations.io;
 
 import de.dlr.shepard.context.semantic.entities.SemanticAnnotation;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -68,11 +71,11 @@ public class AnnotationIO {
 
   // ─── temporal validity ─────────────────────────────────────────────────────
 
-  @Schema(nullable = true, description = "Epoch-millis at which this annotation becomes valid. Null = valid from creation.")
-  private Long validFromMillis;
+  @Schema(nullable = true, description = "ISO 8601 UTC timestamp at which this annotation becomes valid. Null = valid from creation.")
+  private String validFrom;
 
-  @Schema(nullable = true, description = "Epoch-millis at which this annotation expires. Null = no expiry (currently asserted).")
-  private Long validUntilMillis;
+  @Schema(nullable = true, description = "ISO 8601 UTC timestamp at which this annotation expires. Null = no expiry (currently asserted).")
+  private String validUntil;
 
   // ─── confidence ────────────────────────────────────────────────────────────
 
@@ -105,10 +108,15 @@ public class AnnotationIO {
     this.sourceActivityAppId = a.getSourceActivityAppId();
 
     // temporal
-    this.validFromMillis = a.getValidFromMillis();
-    this.validUntilMillis = a.getValidUntilMillis();
+    this.validFrom = toIso(a.getValidFromMillis());
+    this.validUntil = toIso(a.getValidUntilMillis());
 
     // confidence
     this.confidence = a.getConfidence();
+  }
+
+  private static String toIso(Long epochMs) {
+    if (epochMs == null) return null;
+    return DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(epochMs).atZone(ZoneOffset.UTC));
   }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/annotations/io/CreateAnnotationIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/annotations/io/CreateAnnotationIO.java
@@ -61,11 +61,11 @@ public class CreateAnnotationIO {
 
   // ─── temporal validity (optional) ─────────────────────────────────────────
 
-  @Schema(nullable = true, description = "Epoch-millis start of temporal validity. Null = valid from creation.")
-  private Long validFromMillis;
+  @Schema(nullable = true, description = "ISO 8601 UTC timestamp start of temporal validity (e.g. '2024-06-01T12:00:00Z'). Null = valid from creation.")
+  private String validFrom;
 
-  @Schema(nullable = true, description = "Epoch-millis end of temporal validity. Null = currently asserted.")
-  private Long validUntilMillis;
+  @Schema(nullable = true, description = "ISO 8601 UTC timestamp end of temporal validity. Null = currently asserted.")
+  private String validUntil;
 
   // ─── confidence ───────────────────────────────────────────────────────────
 

--- a/backend/src/main/java/de/dlr/shepard/v2/annotations/io/UpdateAnnotationIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/annotations/io/UpdateAnnotationIO.java
@@ -34,12 +34,12 @@ public class UpdateAnnotationIO {
 
   // ─── temporal validity ─────────────────────────────────────────────────────
 
-  @Schema(nullable = true, description = "Epoch-millis close of the prior validity window. " +
+  @Schema(nullable = true, description = "ISO 8601 UTC timestamp closing the prior validity window (e.g. '2024-06-01T12:00:00Z'). " +
       "Setting this to a past time soft-deletes the annotation.")
-  private Long validUntilMillis;
+  private String validUntil;
 
-  @Schema(nullable = true, description = "Epoch-millis start of validity.")
-  private Long validFromMillis;
+  @Schema(nullable = true, description = "ISO 8601 UTC timestamp start of validity.")
+  private String validFrom;
 
   // ─── confidence ────────────────────────────────────────────────────────────
 

--- a/backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/annotations/resources/SemanticAnnotationV2Rest.java
@@ -43,6 +43,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -444,8 +445,8 @@ public class SemanticAnnotationV2Rest {
     // if ProvenanceService mints a new Activity for this create.
     annotation.setSourceActivityAppId(body.getSourceActivityAppId());
     annotation.setAgentUsername(caller);  // SEMA-V6-013: record the author username at creation
-    annotation.setValidFromMillis(body.getValidFromMillis());
-    annotation.setValidUntilMillis(body.getValidUntilMillis());
+    annotation.setValidFromMillis(parseIso(body.getValidFrom()));
+    annotation.setValidUntilMillis(parseIso(body.getValidUntil()));
     annotation.setConfidence(body.getConfidence() != null ? body.getConfidence() : 1.0);
 
     annotationDAO.createOrUpdate(annotation);
@@ -573,8 +574,8 @@ public class SemanticAnnotationV2Rest {
         annotation.setSourceMode(resolvedSourceMode);
         annotation.setSourceActivityAppId(body.getSourceActivityAppId());
         annotation.setAgentUsername(caller);
-        annotation.setValidFromMillis(body.getValidFromMillis());
-        annotation.setValidUntilMillis(body.getValidUntilMillis());
+        annotation.setValidFromMillis(parseIso(body.getValidFrom()));
+        annotation.setValidUntilMillis(parseIso(body.getValidUntil()));
         annotation.setConfidence(body.getConfidence() != null ? body.getConfidence() : 1.0);
 
         annotationDAO.createOrUpdate(annotation);
@@ -623,8 +624,8 @@ public class SemanticAnnotationV2Rest {
     description =
       "RFC 7396 merge-patch: only non-null fields in the request body are applied. " +
       "The subject and predicate of an annotation are immutable. Patchable fields: " +
-      "`objectLiteral`, `objectIri`, `numericValue`, `unitIri`, `validFromMillis`, " +
-      "`validUntilMillis`, `confidence`, `sourceMode`.\n\n" +
+      "`objectLiteral`, `objectIri`, `numericValue`, `unitIri`, `validFrom`, " +
+      "`validUntil`, `confidence`, `sourceMode`.\n\n" +
       "Auth: caller must be able to Write the subject entity (inherited from its Collection). " +
       "Returns `200 OK` with the updated AnnotationV2."
   )
@@ -694,8 +695,8 @@ public class SemanticAnnotationV2Rest {
     }
     if (body.getNumericValue() != null) annotation.setNumericValue(body.getNumericValue());
     if (body.getUnitIri() != null) annotation.setUnitIRI(body.getUnitIri());
-    if (body.getValidFromMillis() != null) annotation.setValidFromMillis(body.getValidFromMillis());
-    if (body.getValidUntilMillis() != null) annotation.setValidUntilMillis(body.getValidUntilMillis());
+    if (body.getValidFrom() != null) annotation.setValidFromMillis(parseIso(body.getValidFrom()));
+    if (body.getValidUntil() != null) annotation.setValidUntilMillis(parseIso(body.getValidUntil()));
     if (body.getConfidence() != null) annotation.setConfidence(body.getConfidence());
     if (body.getSourceMode() != null) annotation.setSourceMode(body.getSourceMode());
 
@@ -728,8 +729,8 @@ public class SemanticAnnotationV2Rest {
       "- `'author-only'` — only the annotation author may delete.\n" +
       "- `'manager-only'` — only collection managers may delete.\n\n" +
       "Returns `204 No Content` on success.\n\n" +
-      "Note: this is a hard delete. For soft-delete (set `validUntilMillis`), use " +
-      "`PATCH /v2/annotations/{appId}` with `{\"validUntilMillis\": <now>}`."
+      "Note: this is a hard delete. For soft-delete, use " +
+      "`PATCH /v2/annotations/{appId}` with `{\"validUntil\": \"<iso-timestamp>\"}`."
   )
   @APIResponse(responseCode = "204", description = "Annotation deleted.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
@@ -1096,5 +1097,10 @@ public class SemanticAnnotationV2Rest {
 
   private static String nvl(String s, String fallback) {
     return s == null || s.isBlank() ? fallback : s;
+  }
+
+  private static Long parseIso(String iso) {
+    if (iso == null || iso.isBlank()) return null;
+    return Instant.parse(iso).toEpochMilli();
   }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/mcp/AnnotationMcpTools.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/mcp/AnnotationMcpTools.java
@@ -16,6 +16,9 @@ import io.vertx.ext.web.RoutingContext;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -697,8 +700,8 @@ public class AnnotationMcpTools {
     row.put("sourceMode", a.getSourceMode());
     row.put("confidence", a.getConfidence());
     row.put("sourceActivityAppId", a.getSourceActivityAppId());
-    row.put("validFromMillis", a.getValidFromMillis());
-    row.put("validUntilMillis", a.getValidUntilMillis());
+    row.put("validFrom", toIso(a.getValidFromMillis()));
+    row.put("validUntil", toIso(a.getValidUntilMillis()));
     row.put("source", a.getSource());
     return row;
   }
@@ -719,5 +722,10 @@ public class AnnotationMcpTools {
     } catch (RuntimeException e) {
       return false;
     }
+  }
+
+  private static String toIso(Long epochMs) {
+    if (epochMs == null) return null;
+    return DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(epochMs).atZone(ZoneOffset.UTC));
   }
 }

--- a/backend/src/test/java/de/dlr/shepard/v2/mcp/AnnotationMcpToolsTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/mcp/AnnotationMcpToolsTest.java
@@ -137,9 +137,9 @@ class AnnotationMcpToolsTest {
     assertEquals(VOC_APP_ID, row.get("vocabularyId").asText());
     assertEquals("ai", row.get("sourceMode").asText());
     assertEquals(0.87, row.get("confidence").asDouble(), 0.001);
-    // temporal bounds
-    assertEquals(1000L, row.get("validFromMillis").asLong());
-    assertEquals(9999L, row.get("validUntilMillis").asLong());
+    // temporal bounds — now ISO 8601 strings
+    assertEquals("1970-01-01T00:00:01Z", row.get("validFrom").asText());
+    assertEquals("1970-01-01T00:00:09.999Z", row.get("validUntil").asText());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- **`AnnotationIO`** (output): `Long validFromMillis` → `String validFrom`, `Long validUntilMillis` → `String validUntil`; adds private `toIso()` helper using `DateTimeFormatter.ISO_INSTANT`
- **`CreateAnnotationIO`** (POST input): same field rename; callers now send ISO 8601 strings instead of epoch-ms longs
- **`UpdateAnnotationIO`** (PATCH input): same field rename
- **`SemanticAnnotationV2Rest`**: adds `parseIso()` helper (`Instant.parse(s).toEpochMilli()`) used at all three call sites (single create, bulk create, PATCH); updates `@Operation` docstrings referencing the old field names
- **`AnnotationMcpTools`**: `toDetailMap()` now emits `validFrom`/`validUntil` as ISO strings (consistent with REST output); adds `toIso()` private helper
- **`AnnotationMcpToolsTest`**: updates temporal-bounds assertions to match ISO string output

Part of the `APISIMP-*` series (row `APISIMP-ANNOTATION-EPOCH-MS-TO-ISO`). Follows the same `toIso()` / `parseIso()` pattern established in #2534.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDE65EyBdsxiNrNXZhoHKr)_