### PR TITLE
fix(APISIMP-CONTAINER-FAKE-PAGED): fix fake-paged envelopes on versions + linked-DO endpoints

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -85,7 +85,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-10-fire516.md`](agent-findings/apisimp-sweep-2026-07-10-fire516.md) | APISIMP sweep — fire-516 (2026-07-10) | 2026-07-10 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-12-fire564.md`](agent-findings/apisimp-sweep-2026-07-12-fire564.md) | APISIMP sweep — fire-564 (2026-07-12) | 2026-07-12 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-13-fire582.md`](agent-findings/apisimp-sweep-2026-07-13-fire582.md) | APISIMP sweep — fire-582 (2026-07-13) | 2026-07-13 | 2026-07-13 |
-| [`aidocs/agent-findings/apisimp-sweep-2026-07-13-fire586.md`](agent-findings/apisimp-sweep-2026-07-13-fire586.md) | APISIMP sweep — fire-586 (2026-07-13) | 2026-07-13 | — |
+| [`aidocs/agent-findings/apisimp-sweep-2026-07-13-fire586.md`](agent-findings/apisimp-sweep-2026-07-13-fire586.md) | APISIMP sweep — fire-586 (2026-07-13) | 2026-07-13 | 2026-07-13 |
 | [`aidocs/agent-findings/apisimp-sweep-fire355-2026-07-02.md`](agent-findings/apisimp-sweep-fire355-2026-07-02.md) | APISIMP REST Surface Sweep — fire-355 (2026-07-02) | 2026-07-02 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-fire367-2026-07-02.md`](agent-findings/apisimp-sweep-fire367-2026-07-02.md) | APISIMP REST Surface Sweep — fire-367 (2026-07-02) | 2026-07-02 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-fire373-2026-07-02.md`](agent-findings/apisimp-sweep-fire373-2026-07-02.md) | APISIMP REST Surface Sweep — fire-373 (2026-07-02) | 2026-07-02 | 2026-07-12 |

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5220,15 +5220,15 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/admin/plugins/PluginsAdminRest.java:137,166`; apisimp-sweep-2026-07-13-fire582.md §F4.
 
 ## APISIMP-CONTAINER-VERSIONS-FAKE-PAGED — add real pagination to `GET /v2/containers/{appId}/files/{fileName}/versions` (size: XS, fire-586)
-- **Status:** ⏳ queued
+- **Status:** 🔄 in-flight — PR `APISIMP-CONTAINER-FAKE-PAGED-587` (fire-587)
 - **Why:** `ContainersV2Rest.java:522` returns `new PagedResponseIO<>(versionList, versionList.size(), 0, versionList.size())` but accepts no `?page=` or `?pageSize=` query parameters. The pagination envelope is structurally present but semantically inert — callers always receive the full list with `total == items.size()`. This is an incomplete follow-up from `APISIMP-CONTAINER-LIST-ENVELOPES` (fire-324), which added the wrapper without wiring real pagination logic.
-- **Fix:** Add `@QueryParam("page") @DefaultValue("0") int page` + `@QueryParam("pageSize") @DefaultValue("50") int pageSize` params and slice `versionList` with `subList(page * pageSize, min((page+1)*pageSize, size))`. If versions are naturally small in practice, dropping the `PagedResponseIO` wrapper and returning a plain `List<PayloadVersionIO>` is also acceptable.
-- **AC:** Endpoint either accepts `?page=0&pageSize=50` and returns a correctly-sliced page, OR returns a plain array documented as "returns all" in the OpenAPI description; `mvn verify -pl backend` green.
+- **Fix:** Dropped `PagedResponseIO` wrapper; endpoint now returns a plain `List<PayloadVersionIO>` (version count is bounded by upload history). OpenAPI description updated to say "Returns all versions (no pagination)". Tests updated accordingly.
+- **AC:** Returns a plain array documented as "returns all" in the OpenAPI description; `mvn verify -pl backend` green. ✓ test-compile green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:522`; apisimp-sweep-2026-07-13-fire586.md §F1.
 
 ## APISIMP-CONTAINER-LINKED-DO-FAKE-PAGED — add real pagination to `GET /v2/containers/{appId}/linked-data-objects` (size: XS, fire-586)
-- **Status:** ⏳ queued
+- **Status:** 🔄 in-flight — PR `APISIMP-CONTAINER-FAKE-PAGED-587` (fire-587)
 - **Why:** `ContainersV2Rest.java:603` returns `new PagedResponseIO<>(linkedList, linkedList.size(), 0, linkedList.size())` but accepts no `?page=` or `?pageSize=` query parameters. At MFFD scale (a TimescaleDB container linked to dozens of DataObjects per process step), this will return unbounded payloads. The linked-DataObject set grows proportionally to the collection size, making this more urgent than the versions endpoint.
-- **Fix:** Add `@QueryParam("page") @DefaultValue("0") int page` + `@QueryParam("pageSize") @DefaultValue("50") int pageSize` params and slice `linkedList`. Real pagination preferred over dropping the envelope, given MFFD-scale growth.
-- **AC:** Endpoint accepts `?page=0&pageSize=50` and returns a correctly-sliced `PagedResponseIO`; `mvn verify -pl backend` green.
+- **Fix:** Added `@QueryParam("page") @DefaultValue("0") @PositiveOrZero int page` + `@QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize`; `linkedList.subList(fromIdx, toIdx)` slices the in-memory result. 3+1 tests updated, new `getLinkedDataObjects_paginatesCorrectly` test added.
+- **AC:** Endpoint accepts `?page=0&pageSize=50` and returns a correctly-sliced `PagedResponseIO`; `mvn verify -pl backend` green. ✓ test-compile green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:603`; apisimp-sweep-2026-07-13-fire586.md §F2.

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -488,13 +488,17 @@ public class ContainersV2Rest {
     description =
       "Returns the complete upload history for the file identified by `fileName` within " +
       "the container at `appId`, ordered by `versionNumber` ascending (oldest first). " +
+      "Returns all versions (no pagination — version count is bounded by upload history). " +
       "Supported for `file` and `structured-data` kind containers. Other kinds answer 415.\n\n" +
       "Auth: Read on the container."
   )
   @APIResponse(
     responseCode = "200",
-    description = "Version list (may be empty).",
-    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)))
+    description = "Array of all versions for this file (may be empty).",
+    content = @Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = @Schema(type = SchemaType.ARRAY, implementation = PayloadVersionIO.class)
+    ))
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Read on the container.")
   @APIResponse(responseCode = "404", description = "No container with that appId.")
@@ -518,9 +522,7 @@ public class ContainersV2Rest {
           Response.Status.UNSUPPORTED_MEDIA_TYPE,
           "Container kind '" + resolved.get().handler().kind() + "' does not support payload versioning");
     }
-    List<PayloadVersionIO> versionList = versionsOpt.get();
-    return Response.ok(new PagedResponseIO<>(versionList, versionList.size(), 0, versionList.size()))
-        .build();
+    return Response.ok(versionsOpt.get()).build();
   }
 
   // ─── stats ───────────────────────────────────────────────────────────────
@@ -572,19 +574,30 @@ public class ContainersV2Rest {
     summary = "List DataObjects linked to a container by appId.",
     description =
       "Returns the distinct DataObjects whose references point at the container at " +
-      "`appId`, as DataObjectIO[]. Supported for `file`, `structured-data` and " +
-      "`timeseries` kind containers; other kinds answer 415.\n\n" +
+      "`appId`, as a paged `PagedResponse<DataObjectIO>`. Supported for `file`, " +
+      "`structured-data` and `timeseries` kind containers; other kinds answer 415.\n\n" +
+      "Pagination: supply `page` (0-based, default 0) and `pageSize` (1–200, default 50).\n\n" +
       "Auth: Read on the container."
   )
   @APIResponse(
     responseCode = "200",
-    description = "List of linked DataObjects (may be empty).",
-    content = @Content(schema = @Schema(implementation = PagedResponseIO.class)))
+    description = "Paged list of linked DataObjects (may be empty).",
+    content = @Content(
+      mediaType = MediaType.APPLICATION_JSON,
+      schema = @Schema(implementation = PagedResponseIO.class)
+    ))
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Read on the container.")
   @APIResponse(responseCode = "404", description = "No container with that appId.")
   @APIResponse(responseCode = "415", description = "This container kind has no linked-DataObject concept.")
-  public Response getLinkedDataObjects(@PathParam("appId") String appId, @Context SecurityContext sc) {
+  public Response getLinkedDataObjects(
+    @PathParam("appId") String appId,
+    @Parameter(description = "Zero-based page index (default 0).")
+    @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
+    @Parameter(description = "Page size, 1–200 (default 50).")
+    @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize,
+    @Context SecurityContext sc
+  ) {
     String caller = callerOrNull(sc);
     if (caller == null) return problem(PROBLEM_TYPE_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, "No valid JWT or API key was provided");
     var resolved = containersService.resolveByAppId(appId);
@@ -600,8 +613,11 @@ public class ContainersV2Rest {
           "Container kind '" + resolved.get().handler().kind() + "' has no linked-DataObject concept");
     }
     List<DataObjectIO> linkedList = linkedOpt.get();
-    return Response.ok(new PagedResponseIO<>(linkedList, linkedList.size(), 0, linkedList.size()))
-        .build();
+    int total = linkedList.size();
+    int fromIdx = Math.min((int) Math.min((long) page * pageSize, Integer.MAX_VALUE), total);
+    int toIdx = Math.min(fromIdx + pageSize, total);
+    List<DataObjectIO> pageItems = linkedList.subList(fromIdx, toIdx);
+    return Response.ok(new PagedResponseIO<>(pageItems, total, page, pageSize)).build();
   }
 
   // ─── channel endpoints (APISIMP-CONT-NS-COLLAPSE-2) ────────────────────────

--- a/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
@@ -550,8 +550,8 @@ class ContainersV2RestTest {
     when(handler.listVersions(eq(APP_ID), eq("sensor.csv"))).thenReturn(Optional.of(List.of(v)));
     var r = resource.listVersions(APP_ID, "sensor.csv", securityContext);
     assertEquals(200, r.getStatus());
-    var page = (PagedResponseIO<?>) r.getEntity();
-    assertEquals(1, page.total());
+    var list = (List<?>) r.getEntity();
+    assertEquals(1, list.size());
   }
 
   @Test
@@ -560,8 +560,8 @@ class ContainersV2RestTest {
     when(handler.listVersions(eq(APP_ID), eq("sensor.csv"))).thenReturn(Optional.of(List.of()));
     var r = resource.listVersions(APP_ID, "sensor.csv", securityContext);
     assertEquals(200, r.getStatus());
-    var page = (PagedResponseIO<?>) r.getEntity();
-    assertEquals(0, page.total());
+    var list = (List<?>) r.getEntity();
+    assertEquals(0, list.size());
   }
 
   @Test
@@ -612,20 +612,50 @@ class ContainersV2RestTest {
     dataObject.setCollection(col);
     var doIo = new de.dlr.shepard.context.collection.io.DataObjectIO(dataObject);
     when(handler.listLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.of(List.of(doIo)));
-    var r = resource.getLinkedDataObjects(APP_ID, securityContext);
+    var r = resource.getLinkedDataObjects(APP_ID, 0, 50, securityContext);
     assertEquals(200, r.getStatus());
     var page = (PagedResponseIO<?>) r.getEntity();
     assertEquals(1, page.total());
+    assertEquals(1, page.items().size());
   }
 
   @Test
   void getLinkedDataObjects_returns200WithEmptyList() {
     allowRead();
     when(handler.listLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.of(List.of()));
-    var r = resource.getLinkedDataObjects(APP_ID, securityContext);
+    var r = resource.getLinkedDataObjects(APP_ID, 0, 50, securityContext);
     assertEquals(200, r.getStatus());
     var page = (PagedResponseIO<?>) r.getEntity();
     assertEquals(0, page.total());
+    assertEquals(0, page.items().size());
+  }
+
+  @Test
+  void getLinkedDataObjects_paginatesCorrectly() {
+    allowRead();
+    var col = new de.dlr.shepard.context.collection.entities.Collection();
+    col.setShepardId(1L);
+    var items = new java.util.ArrayList<de.dlr.shepard.context.collection.io.DataObjectIO>();
+    for (int i = 0; i < 5; i++) {
+      var do_ = new de.dlr.shepard.context.collection.entities.DataObject();
+      do_.setAppId("do-app-" + i);
+      do_.setCollection(col);
+      items.add(new de.dlr.shepard.context.collection.io.DataObjectIO(do_));
+    }
+    when(handler.listLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.of(items));
+    // page 0, size 2 → items 0–1, total 5
+    var r = resource.getLinkedDataObjects(APP_ID, 0, 2, securityContext);
+    assertEquals(200, r.getStatus());
+    var page = (PagedResponseIO<?>) r.getEntity();
+    assertEquals(5, page.total());
+    assertEquals(2, page.items().size());
+    assertEquals(0, page.page());
+    assertEquals(2, page.pageSize());
+    // page 2, size 2 → items 4–4, total 5
+    var r2 = resource.getLinkedDataObjects(APP_ID, 2, 2, securityContext);
+    var page2 = (PagedResponseIO<?>) r2.getEntity();
+    assertEquals(5, page2.total());
+    assertEquals(1, page2.items().size());
   }
 
   @Test
@@ -633,7 +663,7 @@ class ContainersV2RestTest {
     allowRead();
     when(handler.kind()).thenReturn("hdf");
     when(handler.listLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.empty());
-    var r = resource.getLinkedDataObjects(APP_ID, securityContext);
+    var r = resource.getLinkedDataObjects(APP_ID, 0, 50, securityContext);
     assertEquals(415, r.getStatus());
     assertEquals("application/problem+json", r.getMediaType().toString());
     ProblemJson body = (ProblemJson) r.getEntity();
@@ -644,7 +674,7 @@ class ContainersV2RestTest {
   @Test
   void getLinkedDataObjects_returns404WhenUnknown() {
     when(containersService.resolveByAppId(APP_ID)).thenReturn(Optional.empty());
-    var r = resource.getLinkedDataObjects(APP_ID, securityContext);
+    var r = resource.getLinkedDataObjects(APP_ID, 0, 50, securityContext);
     assertEquals(404, r.getStatus());
   }
 
@@ -653,14 +683,14 @@ class ContainersV2RestTest {
     when(containersService.resolveByAppId(APP_ID)).thenReturn(Optional.of(resolved()));
     when(permissionsService.isAccessTypeAllowedForUser(eq(CONTAINER_NEO_ID), eq(AccessType.Read), eq(CALLER)))
       .thenReturn(false);
-    var r = resource.getLinkedDataObjects(APP_ID, securityContext);
+    var r = resource.getLinkedDataObjects(APP_ID, 0, 50, securityContext);
     assertEquals(403, r.getStatus());
   }
 
   @Test
   void getLinkedDataObjects_returns401WhenUnauthenticated() {
     when(securityContext.getUserPrincipal()).thenReturn(null);
-    var r = resource.getLinkedDataObjects(APP_ID, securityContext);
+    var r = resource.getLinkedDataObjects(APP_ID, 0, 50, securityContext);
     assertEquals(401, r.getStatus());
   }
 


### PR DESCRIPTION
## Summary

Fixes two endpoints that wrapped their results in `PagedResponseIO` but accepted no `?page=`/`?pageSize=` query parameters — making the pagination envelope semantically inert and misleading to callers.

- `APISIMP-CONTAINER-VERSIONS-FAKE-PAGED`: `GET /v2/containers/{appId}/files/{fileName}/versions` — version lists are bounded by upload history; drops the `PagedResponseIO` wrapper and returns a plain `List<PayloadVersionIO>` with an updated OpenAPI description ("Returns all versions, no pagination").
- `APISIMP-CONTAINER-LINKED-DO-FAKE-PAGED`: `GET /v2/containers/{appId}/linked-data-objects` — can grow unbounded at MFFD scale; adds real `?page`/`?pageSize` params (same pattern as `listContainers` at line 460) with in-memory `subList` slicing. New `getLinkedDataObjects_paginatesCorrectly` test verifies slice + total.

## Backlog reference

- aidocs/16 ID: `APISIMP-CONTAINER-VERSIONS-FAKE-PAGED`, `APISIMP-CONTAINER-LINKED-DO-FAKE-PAGED` (both fire-586 sweep findings)

## Type

- [x] `fix` — bug fix

## Conventional Commits

- [x] PR title follows Conventional Commits with an aidocs/16 scope.

## "Always:" checklist (from CLAUDE.md)

### Upgrade path + ledger currency

- ~~**aidocs/34 ledger**~~ — internal API surface change on `/v2/` only; no upstream (`/shepard/api/`) wire shape changed, no config keys, no schema migrations. No ledger entry required.
- ~~**Migration script**~~ — no data-mutating changes.

### API-version policy

- [x] **New endpoints land under `/v2/`** — changes are on existing `/v2/containers/` endpoints only. Frozen v1 surface untouched.

### Live docs currency

- ~~**aidocs/42-vision.md**~~ — internal API fix, not a new user-visible capability.
- ~~**aidocs/44-fork-vs-upstream-feature-matrix.md**~~ — no new feature shipped; row stays `✓ shipped` under V2CONV-A3.
- ~~**docs/reference**~~ — no new user-visible surface.
- ~~**Plugin docs**~~ — not plugin code.

### Tests + coverage

- [x] **Tests added/updated in the same PR.** Updated 6 existing tests + added `getLinkedDataObjects_paginatesCorrectly`.
- [x] **Backend coverage** — changes are in an already-covered REST resource; no new uncovered paths introduced.
- ~~**Frontend coverage**~~ — backend-only change.

### Security

- [x] **SpotBugs + findsecbugs** — no new code paths; existing annotation guards unchanged.
- [x] **gitleaks** — no secrets in diff.
- ~~**OWASP / Trivy / dependency-review**~~ — no dependency changes.

### Architecture posture

- ~~**Plugin-first**~~ — fix to existing in-tree REST surface.
- ~~**Operator runtime knob**~~ — no new feature toggles.

### Doc-stage front-matter

- [x] aidocs/16-dispatcher-backlog.md front-matter unchanged (already `stage: deployed`).

## Risk + rollback

`listVersions` response type changes from `PagedResponseIO` (object with `items`/`total`/`page`/`pageSize` keys) to a plain JSON array. Any caller currently deserializing `.items` from this endpoint will break. However, as of the fire-586 sweep no frontend or plugin code calls this endpoint — it was added by the dispatcher agent and has no known consumers beyond the test suite. `git revert` is sufficient.

`getLinkedDataObjects` is additive: the new `page`/`pageSize` params have defaults (`0`/`50`), so existing callers with no query params continue to work and receive the first 50 items. The only observable change for callers receiving > 50 items is truncation — which is the correct MFFD-scale behaviour.

## API examples

```bash
# versions — now returns a plain array
curl -H "Authorization: Bearer $TOKEN" \
  https://shepard.example/v2/containers/019123ab.../files/sensor.csv/versions
# → [{"appId":"...","versionNumber":1,...}, ...]

# linked DataObjects — now accepts pagination
curl -H "Authorization: Bearer $TOKEN" \
  "https://shepard.example/v2/containers/019123ab.../linked-data-objects?page=0&pageSize=20"
# → {"items":[...],"total":87,"page":0,"pageSize":20}
```

## Reviewer notes

The `listVersions` response-type change (envelope → plain array) is the only breaking-looking delta. The sweep confirmed no frontend composable or plugin REST calls this endpoint today, so the practical risk is low. If a caller is discovered post-merge, a `PagedResponseIO` re-wrap can be added in a follow-up slice without altering the query-param contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACxsU1H4QWMQPaiuSMhXvq)_