### PR TITLE
feat(APISIMP-PROVENANCE-LIMIT-TO-PAGESIZE): rename ?limit= → ?pageSize= on cursor-paged provenance endpoints

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -87,6 +88,9 @@ public class ProvenanceRest {
   @Inject
   ProvenanceStatsService statsService;
 
+  @Context
+  UriInfo uriInfo;
+
   private static final String PROBLEM_TYPE_UNAUTHORIZED = "/problems/provenance.unauthorized";
   private static final String PROBLEM_TYPE_FORBIDDEN = "/problems/provenance.forbidden";
   private static final String PROBLEM_TYPE_BAD_REQUEST = "/problems/provenance.bad-request";
@@ -116,7 +120,7 @@ public class ProvenanceRest {
   @APIResponse(
     responseCode = "200",
     description = "Matching activities, sorted by startedAt DESC. " +
-    "Envelope: `pageSize` reflects the `?limit=` window; `total` reflects rows returned (not true DB total — cursor mode). " +
+    "Envelope: `pageSize` reflects the `?pageSize=` window; `total` reflects rows returned (not true DB total — cursor mode). " +
     "Response header `X-Has-More: true` when the window is full and more rows may exist; use the `X-Next-Cursor` epoch-ms value as `?until=` on the next call.",
     content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
   )
@@ -131,9 +135,13 @@ public class ProvenanceRest {
     @Parameter(description = "Filter to a specific target-entity appId.") @QueryParam("targetAppId") String targetAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=`/`?until=` for cursor navigation.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @Context SecurityContext securityContext
   ) {
+    if (uriInfo != null && uriInfo.getQueryParameters().containsKey("limit")) {
+      return problem(PROBLEM_TYPE_BAD_REQUEST, "Deprecated parameter", Response.Status.BAD_REQUEST,
+          "'?limit=' was renamed '?pageSize=' (APISIMP-PROVENANCE-LIMIT-TO-PAGESIZE). Update your client.");
+    }
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
     if (caller == null) return problem(PROBLEM_TYPE_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, "No authenticated principal.");
 
@@ -154,13 +162,13 @@ public class ProvenanceRest {
 
     OutputProfile prof = outputProfile.getProfile();
     List<ActivityIO> rows = provenance
-      .list(agent, targetKind, targetAppId, since, until, limit)
+      .list(agent, targetKind, targetAppId, since, until, pageSize)
       .stream()
       .map(ActivityIO::from)
       .map(io -> applyProfile(io, prof))
       .toList();
-    boolean hasMore = rows.size() >= limit;
-    var rb = Response.ok(new PagedResponseIO<>(rows, rows.size(), 0, limit))
+    boolean hasMore = rows.size() >= pageSize;
+    var rb = Response.ok(new PagedResponseIO<>(rows, rows.size(), 0, pageSize))
         .header("X-Has-More", hasMore);
     if (hasMore) {
       rb.header("X-Next-Cursor", Instant.parse(rows.get(rows.size() - 1).getStartedAt()).toEpochMilli());
@@ -199,9 +207,13 @@ public class ProvenanceRest {
     @Parameter(description = "Filter to a specific target-entity appId.") @QueryParam("targetAppId") String targetAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=`/`?until=` for cursor navigation.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @Context SecurityContext securityContext
   ) {
+    if (uriInfo != null && uriInfo.getQueryParameters().containsKey("limit")) {
+      return problem(PROBLEM_TYPE_BAD_REQUEST, "Deprecated parameter", Response.Status.BAD_REQUEST,
+          "'?limit=' was renamed '?pageSize=' (APISIMP-PROVENANCE-LIMIT-TO-PAGESIZE). Update your client.");
+    }
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
     if (caller == null) return problem(PROBLEM_TYPE_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, "No authenticated principal.");
 
@@ -216,7 +228,7 @@ public class ProvenanceRest {
     try { since = parseTimestamp(sinceRaw); until = parseTimestamp(untilRaw); }
     catch (IllegalArgumentException e) { return badTimestamp(e.getMessage()); }
 
-    List<Activity> rows = provenance.list(agent, targetKind, targetAppId, since, until, limit);
+    List<Activity> rows = provenance.list(agent, targetKind, targetAppId, since, until, pageSize);
     return Response.ok(provJsonRenderer.render(rows)).type(ProvJsonRenderer.MEDIA_TYPE).build();
   }
 
@@ -245,10 +257,14 @@ public class ProvenanceRest {
     @Parameter(description = "Filter to a specific target-entity appId.") @QueryParam("targetAppId") String targetAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=`/`?until=` for cursor navigation.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @HeaderParam(HttpHeaders.ACCEPT) String acceptHeader,
     @Context SecurityContext securityContext
   ) {
+    if (uriInfo != null && uriInfo.getQueryParameters().containsKey("limit")) {
+      return problem(PROBLEM_TYPE_BAD_REQUEST, "Deprecated parameter", Response.Status.BAD_REQUEST,
+          "'?limit=' was renamed '?pageSize=' (APISIMP-PROVENANCE-LIMIT-TO-PAGESIZE). Update your client.");
+    }
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
     if (caller == null) return problem(PROBLEM_TYPE_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, "No authenticated principal.");
 
@@ -267,7 +283,7 @@ public class ProvenanceRest {
     if (profileError != null) return profileError;
     ProvJsonLdRenderer.ProfileChoice profile = ProvJsonLdRenderer.resolveProfile(acceptHeader);
 
-    List<Activity> rows = provenance.list(agent, targetKind, targetAppId, since, until, limit);
+    List<Activity> rows = provenance.list(agent, targetKind, targetAppId, since, until, pageSize);
     return Response.ok(provJsonLdRenderer.render(rows, profile))
       .type(jsonLdMediaTypeFor(profile))
       .build();
@@ -288,7 +304,7 @@ public class ProvenanceRest {
   @APIResponse(
     responseCode = "200",
     description = "Activities targeting the entity, sorted by startedAt DESC. " +
-    "Envelope: `pageSize` reflects the `?limit=` window; `total` reflects rows returned (cursor mode, not true DB total). " +
+    "Envelope: `pageSize` reflects the `?pageSize=` window; `total` reflects rows returned (cursor mode, not true DB total). " +
     "Header `X-Has-More: true` when window is full; use `X-Next-Cursor` epoch-ms as `?until=` on the next call.",
     content = @Content(schema = @Schema(implementation = PagedResponseIO.class))
   )
@@ -298,9 +314,13 @@ public class ProvenanceRest {
     @Parameter(description = "Target entity's appId.", required = true) @PathParam("appId") String entityAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=`/`?until=` for cursor navigation.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @Context SecurityContext securityContext
   ) {
+    if (uriInfo != null && uriInfo.getQueryParameters().containsKey("limit")) {
+      return problem(PROBLEM_TYPE_BAD_REQUEST, "Deprecated parameter", Response.Status.BAD_REQUEST,
+          "'?limit=' was renamed '?pageSize=' (APISIMP-PROVENANCE-LIMIT-TO-PAGESIZE). Update your client.");
+    }
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
     if (caller == null) return problem(PROBLEM_TYPE_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, "No authenticated principal.");
 
@@ -314,13 +334,13 @@ public class ProvenanceRest {
 
     OutputProfile prof = outputProfile.getProfile();
     List<ActivityIO> rows = provenance
-      .list(agentFilter, null, entityAppId, since, until, limit)
+      .list(agentFilter, null, entityAppId, since, until, pageSize)
       .stream()
       .map(ActivityIO::from)
       .map(io -> applyProfile(io, prof))
       .toList();
-    boolean hasMore = rows.size() >= limit;
-    var rb = Response.ok(new PagedResponseIO<>(rows, rows.size(), 0, limit))
+    boolean hasMore = rows.size() >= pageSize;
+    var rb = Response.ok(new PagedResponseIO<>(rows, rows.size(), 0, pageSize))
         .header("X-Has-More", hasMore);
     if (hasMore) {
       rb.header("X-Next-Cursor", Instant.parse(rows.get(rows.size() - 1).getStartedAt()).toEpochMilli());
@@ -344,9 +364,13 @@ public class ProvenanceRest {
     @Parameter(description = "Target entity's appId.", required = true) @PathParam("appId") String entityAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=`/`?until=` for cursor navigation.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @Context SecurityContext securityContext
   ) {
+    if (uriInfo != null && uriInfo.getQueryParameters().containsKey("limit")) {
+      return problem(PROBLEM_TYPE_BAD_REQUEST, "Deprecated parameter", Response.Status.BAD_REQUEST,
+          "'?limit=' was renamed '?pageSize=' (APISIMP-PROVENANCE-LIMIT-TO-PAGESIZE). Update your client.");
+    }
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
     if (caller == null) return problem(PROBLEM_TYPE_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, "No authenticated principal.");
 
@@ -357,7 +381,7 @@ public class ProvenanceRest {
     try { since = parseTimestamp(sinceRaw); until = parseTimestamp(untilRaw); }
     catch (IllegalArgumentException e) { return badTimestamp(e.getMessage()); }
 
-    List<Activity> rows = provenance.list(agentFilter, null, entityAppId, since, until, limit);
+    List<Activity> rows = provenance.list(agentFilter, null, entityAppId, since, until, pageSize);
     return Response.ok(provJsonRenderer.render(rows)).type(ProvJsonRenderer.MEDIA_TYPE).build();
   }
 
@@ -379,10 +403,14 @@ public class ProvenanceRest {
     @Parameter(description = "Target entity's appId.", required = true) @PathParam("appId") String entityAppId,
     @Parameter(description = SINCE_DESC) @QueryParam("since") String sinceRaw,
     @Parameter(description = UNTIL_DESC) @QueryParam("until") String untilRaw,
-    @Parameter(description = "Cursor window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=` / `?until=` for navigation, not `?page=`.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("limit") int limit,
+    @Parameter(description = "Window size — max rows returned. Defaults to 100; capped at 1000. Use `?since=`/`?until=` for cursor navigation.") @DefaultValue("100") @Min(1) @Max(1000) @QueryParam("pageSize") int pageSize,
     @HeaderParam(HttpHeaders.ACCEPT) String acceptHeader,
     @Context SecurityContext securityContext
   ) {
+    if (uriInfo != null && uriInfo.getQueryParameters().containsKey("limit")) {
+      return problem(PROBLEM_TYPE_BAD_REQUEST, "Deprecated parameter", Response.Status.BAD_REQUEST,
+          "'?limit=' was renamed '?pageSize=' (APISIMP-PROVENANCE-LIMIT-TO-PAGESIZE). Update your client.");
+    }
     String caller = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
     if (caller == null) return problem(PROBLEM_TYPE_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, "No authenticated principal.");
 
@@ -397,7 +425,7 @@ public class ProvenanceRest {
     if (profileError != null) return profileError;
     ProvJsonLdRenderer.ProfileChoice profile = ProvJsonLdRenderer.resolveProfile(acceptHeader);
 
-    List<Activity> rows = provenance.list(agentFilter, null, entityAppId, since, until, limit);
+    List<Activity> rows = provenance.list(agentFilter, null, entityAppId, since, until, pageSize);
     return Response.ok(provJsonLdRenderer.render(rows, profile))
       .type(jsonLdMediaTypeFor(profile))
       .build();

--- a/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestCursorPagedTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestCursorPagedTest.java
@@ -13,8 +13,10 @@ import de.dlr.shepard.common.output.OutputProfileResolver;
 import de.dlr.shepard.provenance.entities.Activity;
 import de.dlr.shepard.provenance.services.ProvenanceService;
 import de.dlr.shepard.v2.common.io.PagedResponseIO;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
 import java.security.Principal;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +27,7 @@ import org.mockito.MockitoAnnotations;
 /**
  * APISIMP-PROV-CURSOR-PAGED-WRAP — regression guards ensuring that
  * {@link ProvenanceRest#listActivities} and
- * {@link ProvenanceRest#listEntityActivities} use the request {@code limit}
+ * {@link ProvenanceRest#listEntityActivities} use the request {@code pageSize}
  * as {@code pageSize} in the envelope (not {@code rows.size()}) and emit
  * correct {@code X-Has-More} / {@code X-Next-Cursor} response headers.
  */
@@ -34,6 +36,7 @@ class ProvenanceRestCursorPagedTest {
   @Mock ProvenanceService provenance;
   @Mock SecurityContext securityContext;
   @Mock Principal principal;
+  @Mock UriInfo uriInfo;
 
   ProvenanceRest resource;
 
@@ -42,6 +45,7 @@ class ProvenanceRestCursorPagedTest {
     MockitoAnnotations.openMocks(this);
     resource = new ProvenanceRest();
     resource.provenance = provenance;
+    resource.uriInfo = uriInfo;
     OutputProfileResolver outputProfile = new OutputProfileResolver();
     outputProfile.setProfile(OutputProfile.ALL);
     resource.outputProfile = outputProfile;
@@ -49,6 +53,7 @@ class ProvenanceRestCursorPagedTest {
     when(securityContext.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn("alice");
     when(securityContext.isUserInRole(any())).thenReturn(false);
+    when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
   }
 
   private static Activity stubActivity(long startedAtMillis) {
@@ -68,7 +73,7 @@ class ProvenanceRestCursorPagedTest {
     Response r = resource.listActivities(null, null, null, null, null, 50, securityContext);
     assertEquals(200, r.getStatus());
     PagedResponseIO<?> body = (PagedResponseIO<?>) r.getEntity();
-    assertEquals(50, body.pageSize(), "pageSize must equal the limit param (50), not rows.size() (0)");
+    assertEquals(50, body.pageSize(), "pageSize must equal the pageSize param (50), not rows.size() (0)");
   }
 
   @Test

--- a/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestParamAnnotationTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestParamAnnotationTest.java
@@ -38,21 +38,21 @@ class ProvenanceRestParamAnnotationTest {
   }
 
   @Test
-  void listActivitiesProvJson_limitParam_hasParameterAnnotation() throws NoSuchMethodException {
+  void listActivitiesProvJson_pageSizeParam_hasParameterAnnotation() throws NoSuchMethodException {
     Method m = ProvenanceRest.class.getMethod(
       "listActivitiesProvJson",
       String.class, String.class, String.class, String.class, String.class,
       int.class, jakarta.ws.rs.core.SecurityContext.class);
-    assertDocumented(queryParam(m, "limit"), "listActivitiesProvJson.limit");
+    assertDocumented(queryParam(m, "pageSize"), "listActivitiesProvJson.pageSize");
   }
 
   @Test
-  void listActivitiesJsonLd_limitParam_hasParameterAnnotation() throws NoSuchMethodException {
+  void listActivitiesJsonLd_pageSizeParam_hasParameterAnnotation() throws NoSuchMethodException {
     Method m = ProvenanceRest.class.getMethod(
       "listActivitiesJsonLd",
       String.class, String.class, String.class, String.class, String.class,
       int.class, String.class, jakarta.ws.rs.core.SecurityContext.class);
-    assertDocumented(queryParam(m, "limit"), "listActivitiesJsonLd.limit");
+    assertDocumented(queryParam(m, "pageSize"), "listActivitiesJsonLd.pageSize");
   }
 
   @Test
@@ -65,12 +65,12 @@ class ProvenanceRestParamAnnotationTest {
   }
 
   @Test
-  void listEntityActivitiesProvJson_limitParam_hasParameterAnnotation() throws NoSuchMethodException {
+  void listEntityActivitiesProvJson_pageSizeParam_hasParameterAnnotation() throws NoSuchMethodException {
     Method m = ProvenanceRest.class.getMethod(
       "listEntityActivitiesProvJson",
       String.class, String.class, String.class, int.class,
       jakarta.ws.rs.core.SecurityContext.class);
-    assertDocumented(queryParam(m, "limit"), "listEntityActivitiesProvJson.limit");
+    assertDocumented(queryParam(m, "pageSize"), "listEntityActivitiesProvJson.pageSize");
   }
 
   @Test
@@ -83,21 +83,21 @@ class ProvenanceRestParamAnnotationTest {
   }
 
   @Test
-  void listEntityActivitiesJsonLd_limitParam_hasParameterAnnotation() throws NoSuchMethodException {
+  void listEntityActivitiesJsonLd_pageSizeParam_hasParameterAnnotation() throws NoSuchMethodException {
     Method m = ProvenanceRest.class.getMethod(
       "listEntityActivitiesJsonLd",
       String.class, String.class, String.class, int.class, String.class,
       jakarta.ws.rs.core.SecurityContext.class);
-    assertDocumented(queryParam(m, "limit"), "listEntityActivitiesJsonLd.limit");
+    assertDocumented(queryParam(m, "pageSize"), "listEntityActivitiesJsonLd.pageSize");
   }
 
   @Test
-  void listEntityActivities_limitParam_hasParameterAnnotation() throws NoSuchMethodException {
+  void listEntityActivities_pageSizeParam_hasParameterAnnotation() throws NoSuchMethodException {
     Method m = ProvenanceRest.class.getMethod(
       "listEntityActivities",
       String.class, String.class, String.class, int.class,
       jakarta.ws.rs.core.SecurityContext.class);
-    assertDocumented(queryParam(m, "limit"), "listEntityActivities.limit");
+    assertDocumented(queryParam(m, "pageSize"), "listEntityActivities.pageSize");
   }
 
   @Test

--- a/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestTimestampTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRestTimestampTest.java
@@ -12,8 +12,10 @@ import static org.mockito.Mockito.when;
 import de.dlr.shepard.common.output.OutputProfile;
 import de.dlr.shepard.common.output.OutputProfileResolver;
 import de.dlr.shepard.provenance.services.ProvenanceService;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
 import java.security.Principal;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +42,9 @@ class ProvenanceRestTimestampTest {
   @Mock
   Principal principal;
 
+  @Mock
+  UriInfo uriInfo;
+
   ProvenanceRest resource;
 
   @BeforeEach
@@ -47,6 +52,7 @@ class ProvenanceRestTimestampTest {
     MockitoAnnotations.openMocks(this);
     resource = new ProvenanceRest();
     resource.provenance = provenance;
+    resource.uriInfo = uriInfo;
     OutputProfileResolver outputProfile = new OutputProfileResolver();
     outputProfile.setProfile(OutputProfile.ALL);
     resource.outputProfile = outputProfile;
@@ -54,6 +60,7 @@ class ProvenanceRestTimestampTest {
     when(securityContext.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn("alice");
     when(securityContext.isUserInRole(any())).thenReturn(false);
+    when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
   }
 
   // ── parseTimestamp unit tests ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Rename `@QueryParam("limit")` → `@QueryParam("pageSize")` on all six cursor-paged `ProvenanceRest` methods: `listActivities` (JSON, PROV-JSON, JSON-LD) and `listEntityActivities` (JSON, PROV-JSON, JSON-LD)
- Add a 10-fire tombstone via `@Context UriInfo` (class-level, null-guarded): requests carrying the old `?limit=` param receive HTTP 400 with a descriptive migration message
- Update `@Parameter(description=...)` annotations and `@APIResponse` Javadoc on all six methods
- Update three test classes to wire the `UriInfo` mock and rename `limit`→`pageSize` look-ups

## Motivation

`APISIMP-PROVENANCE-LIMIT-TO-PAGESIZE` (aidocs/16 line 5174). Every other paged endpoint on the `/v2/` shelf uses `?pageSize=`; the provenance cursor endpoints were the last outlier using `?limit=`. This makes the surface uniform.

The tombstone returns 400 (not 301/302) because `?limit=` is a query-param rename, not a path move — callers need to update their client code, not follow a redirect.

## Files changed

| File | Change |
|---|---|
| `ProvenanceRest.java` | 6× `@QueryParam` renamed; 6× tombstone added; `UriInfo` field injected; method-body `pageSize` variable renames |
| `ProvenanceRestCursorPagedTest.java` | `UriInfo` mock wired; assertion message updated |
| `ProvenanceRestTimestampTest.java` | `UriInfo` mock wired |
| `ProvenanceRestParamAnnotationTest.java` | 5 test methods renamed `limitParam` → `pageSizeParam`; reflection look-ups updated |

## Test plan

- [x] `ProvenanceRestCursorPagedTest` — 8 tests pass (cursor pagination envelope, X-Has-More / X-Next-Cursor headers)
- [x] `ProvenanceRestTimestampTest` — 11 tests pass (ISO 8601 / epoch-ms dual parsing, 200/400 responses)
- [x] `ProvenanceRestParamAnnotationTest` — 11 tests pass (reflection guards on @Parameter annotations)
- [ ] Full `mvn verify -pl backend` — expected green; CI will confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5soSvWLTyjHuBPBRXdTvT

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5soSvWLTyjHuBPBRXdTvT)_