### PR TITLE
feat(APISIMP-DO-TIME-BOUNDS-NS-TO-ISO): convert timeBoundsStart/End from ns Long to ISO 8601 String

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5232,3 +5232,57 @@ picks these up. Terse by design.
 - **Fix:** Added `@QueryParam("page") @DefaultValue("0") @PositiveOrZero int page` + `@QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize`; `linkedList.subList(fromIdx, toIdx)` slices the in-memory result. 3+1 tests updated, new `getLinkedDataObjects_paginatesCorrectly` test added.
 - **AC:** Endpoint accepts `?page=0&pageSize=50` and returns a correctly-sliced `PagedResponseIO`; `mvn verify -pl backend` green. ✓ test-compile green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:603`; apisimp-sweep-2026-07-13-fire586.md §F2.
+
+## APISIMP-DO-TIME-BOUNDS-NS-TO-ISO — convert `DataObjectListItemV2IO.timeBoundsStart`/`timeBoundsEnd` from nanosecond `Long` to ISO 8601 `String` (size: S, fire-588)
+- **Status:** 🔄 in-flight (fire-588, PR open)
+- **Why:** `DataObjectListItemV2IO.timeBoundsStart`/`timeBoundsEnd` were typed `Long` (nanoseconds since Unix epoch) on the `GET /v2/collections/{appId}/data-objects?include=time-bounds` response. Inconsistent with the ISO 8601 conversion wave applied to all other v2 timestamp fields. Additionally, nanosecond epoch values for current dates (~1.7×10^18) exceed JavaScript's `Number.MAX_SAFE_INTEGER` (~9×10^15), causing silent precision loss in frontend arithmetic. Fix: change field types to `String`; add `toIsoNs(long epochNs)` static helper using `Instant.ofEpochSecond(epochNs / 1_000_000_000L, epochNs % 1_000_000_000L).toString()`; update setter calls in `DataObjectV2Rest`; update generated TypeScript client type; update frontend timeline utils and components to parse ISO strings to ms.
+- **AC:** `timeBoundsStart`/`timeBoundsEnd` are ISO 8601 UTC strings with nanosecond precision (e.g. `"2024-06-01T12:00:00.000000001Z"`); `DataObjectV2RestTest.listIncludesTimeBoundsWhenRequested` asserts ISO shape; frontend timeline renders correctly; `mvn verify -pl backend` green; `npm run test` 2678 passed; `npm run typecheck` exit 0.
+- **First refs:** `backend/src/main/java/de/dlr/shepard/v2/dataobject/io/DataObjectListItemV2IO.java`; `backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java:326-327`; `frontend/utils/collectionDataObjectTimeline.ts`; `backend-client/src/models/DataObjectListItemV2.ts`; apisimp-sweep (fire-588 dispatch).
+
+## APISIMP-AAS-REGISTRATION-LONG-TO-ISO — convert `AasRegistrationIO.lastAttemptAt`/`createdAt`/`updatedAt` from epoch-ms `Long` to ISO 8601 `String` (size: XS, fire-588)
+- **Status:** ⏳ queued
+- **Why:** `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/io/AasRegistrationIO.java` lines 17, 19–20 expose `lastAttemptAt`, `createdAt`, and `updatedAt` as `Long` epoch-ms values on `GET /v2/admin/aas/registrations`. The entity fields (`AasRegistration.java:71,79,83`) are `Long` ms since epoch. All other v2 admin entity timestamps have been converted to ISO 8601 strings; these three are the last outliers in the AAS plugin.
+- **AC:** `AasRegistrationIO` record components `lastAttemptAt`, `createdAt`, `updatedAt` are `String` ISO 8601 UTC values (e.g. `"2026-07-01T10:00:00Z"`); entity `Long` values converted via `Instant.ofEpochMilli(...).toString()` with null-guard; `mvn verify -pl plugins/aas` green.
+- **First refs:** `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/io/AasRegistrationIO.java:17,19-20`; apisimp-sweep-2026-07-13-fire586.md follow-on sweep (fire-588).
+
+## APISIMP-PLUGIN-ENTRY-DATE-TO-ISO — convert `PluginEntryIO.registeredAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-588)
+- **Status:** ⏳ queued
+- **Why:** `backend/src/main/java/de/dlr/shepard/v2/admin/plugins/io/PluginEntryIO.java:54` has `Date registeredAt` as a record component; line 80 sets it via `Date.from(entry.registeredAt())`. Jackson serialises `java.util.Date` as a numeric epoch-ms by default (without `@JsonFormat(shape=STRING)`), diverging from the ISO 8601 convention applied everywhere else on the v2 surface. Fix: change type to `String`; convert via `entry.registeredAt() == null ? null : entry.registeredAt().toString()` (Instant → ISO 8601 string).
+- **AC:** `GET /v2/admin/plugins` response carries `registeredAt` as an ISO 8601 UTC string; `PluginsAdminRestTest` asserts string shape; `mvn verify -pl backend` green.
+- **First refs:** `backend/src/main/java/de/dlr/shepard/v2/admin/plugins/io/PluginEntryIO.java:54,80`; apisimp-sweep (fire-588).
+
+## APISIMP-LAB-JOURNAL-REVISION-DATE-TO-ISO — convert `LabJournalRevisionIO.revisedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-588)
+- **Status:** ⏳ queued
+- **Why:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/io/LabJournalRevisionIO.java:36` has `private Date revisedAt`. Without `@JsonFormat(shape=STRING)` Jackson serialises as numeric epoch-ms. Every other timestamp on the lab-journal surface uses ISO 8601 strings. Fix: change type to `String`; convert in the static `from()` factory via `Instant.ofEpochMilli(entity.getRevisedAt().getTime()).toString()` with null-guard.
+- **AC:** `GET /v2/lab-journal/{entryAppId}/history` response carries `revisedAt` as an ISO 8601 UTC string; `mvn verify -pl backend` green.
+- **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/io/LabJournalRevisionIO.java:36`; apisimp-sweep (fire-588).
+
+## APISIMP-DATACITE-CONFIG-DATE-TO-ISO — convert `DataciteMinterConfigIO.updatedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-588)
+- **Status:** ⏳ queued
+- **Why:** `plugins/minter-datacite/src/main/java/de/dlr/shepard/plugins/minter/datacite/io/DataciteMinterConfigIO.java:32,40,51` wraps the entity's `Long updatedAtMillis` into a `Date` field; Jackson serialises as numeric epoch-ms. Pattern matches the other minter config outlier (APISIMP-EPIC-CONFIG-DATE-TO-ISO). Fix: change `Date updatedAt` to `String updatedAt`; convert via `updatedAtMillis == null ? null : Instant.ofEpochMilli(updatedAtMillis).toString()`.
+- **AC:** `GET /v2/admin/config/datacite` (via AdminConfigRest) returns `updatedAt` as an ISO 8601 UTC string; `mvn verify -pl plugins/minter-datacite` green.
+- **First refs:** `plugins/minter-datacite/src/main/java/de/dlr/shepard/plugins/minter/datacite/io/DataciteMinterConfigIO.java:32,40,51`; apisimp-sweep (fire-588).
+
+## APISIMP-EPIC-CONFIG-DATE-TO-ISO — convert `EpicMinterConfigIO.updatedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-588)
+- **Status:** ⏳ queued
+- **Why:** `plugins/minter-epic/src/main/java/de/dlr/shepard/plugins/minter/epic/io/EpicMinterConfigIO.java:28,36,43` wraps `Long updatedAtMillis` into a `Date` field (same anti-pattern as `DataciteMinterConfigIO`). Fix: same pattern — change `Date updatedAt` to `String updatedAt`; convert via `Instant.ofEpochMilli(updatedAtMillis).toString()`.
+- **AC:** `GET /v2/admin/config/epic` returns `updatedAt` as an ISO 8601 UTC string; `mvn verify -pl plugins/minter-epic` green.
+- **First refs:** `plugins/minter-epic/src/main/java/de/dlr/shepard/plugins/minter/epic/io/EpicMinterConfigIO.java:28,36,43`; apisimp-sweep (fire-588).
+
+## APISIMP-UNHIDE-CONFIG-DATE-TO-ISO — convert `UnhideConfigIO.harvestApiKeyMintedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-588)
+- **Status:** ⏳ queued
+- **Why:** `plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/UnhideConfigIO.java:30` has `Date harvestApiKeyMintedAt` as a record component. Without `@JsonFormat(shape=STRING)` this serialises as numeric epoch-ms on `GET /v2/admin/config/unhide`. Fix: change type to `String`; convert in the `from()` factory via `entity.getHarvestApiKeyMintedAt() == null ? null : Instant.ofEpochMilli(entity.getHarvestApiKeyMintedAt()).toString()`.
+- **AC:** `GET /v2/admin/config/unhide` carries `harvestApiKeyMintedAt` as an ISO 8601 UTC string; `mvn verify -pl plugins/unhide` green.
+- **First refs:** `plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/UnhideConfigIO.java:30`; apisimp-sweep (fire-588).
+
+## APISIMP-HARVEST-KEY-MINTED-DATE-TO-ISO — convert `HarvestKeyMintedIO.mintedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-588)
+- **Status:** ⏳ queued
+- **Why:** `plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/HarvestKeyMintedIO.java:32` has `Date mintedAt` as a record component on the `POST /v2/admin/unhide/harvest-key` (key-mint) response. Same Date serialisation issue as `UnhideConfigIO.harvestApiKeyMintedAt`. Fix: change type to `String`; convert via `Instant.ofEpochMilli(...)`.
+- **AC:** Mint response carries `mintedAt` as an ISO 8601 UTC string; `mvn verify -pl plugins/unhide` green.
+- **First refs:** `plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/HarvestKeyMintedIO.java:32`; apisimp-sweep (fire-588).
+
+## APISIMP-LEGACY-V1-STATS-DATE-TO-ISO — convert `LegacyV1StatsIO.firstHitAt`/`mostRecentHitAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-588)
+- **Status:** ⏳ queued
+- **Why:** `plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1StatsIO.java:34-35` has `Date firstHitAt` and `Date mostRecentHitAt` as record components on `GET /v2/admin/config/legacy-v1/stats`. Without `@JsonFormat(shape=STRING)` both serialise as numeric epoch-ms. Fix: change both to `String`; convert via `Instant.ofEpochMilli(...)`.
+- **AC:** `GET /v2/admin/config/legacy-v1/stats` carries `firstHitAt`/`mostRecentHitAt` as ISO 8601 UTC strings; `mvn verify -pl plugins/v1-compat` green.
+- **First refs:** `plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1StatsIO.java:34-35`; apisimp-sweep (fire-588).

--- a/backend-client/src/models/DataObjectListItemV2.ts
+++ b/backend-client/src/models/DataObjectListItemV2.ts
@@ -209,17 +209,17 @@ export interface DataObjectListItemV2 {
      */
     readonly structuredDataCount?: number;
     /**
-     * Earliest data-point timestamp across all timeseries channels of this DataObject, in nanoseconds since Unix epoch. Null when no timeseries data exists or `?include=time-bounds` was not requested.
-     * @type {number}
+     * Earliest data-point timestamp across all timeseries channels of this DataObject, as ISO 8601 UTC with nanosecond precision (e.g. '2024-06-01T12:00:00.000000001Z'). Null when no timeseries data exists or `?include=time-bounds` was not requested.
+     * @type {string}
      * @memberof DataObjectListItemV2
      */
-    readonly timeBoundsStart?: number | null;
+    readonly timeBoundsStart?: string | null;
     /**
-     * Latest data-point timestamp across all timeseries channels of this DataObject, in nanoseconds since Unix epoch. Null when no timeseries data exists or `?include=time-bounds` was not requested.
-     * @type {number}
+     * Latest data-point timestamp across all timeseries channels of this DataObject, as ISO 8601 UTC with nanosecond precision (e.g. '2024-06-01T12:00:00.000000001Z'). Null when no timeseries data exists or `?include=time-bounds` was not requested.
+     * @type {string}
      * @memberof DataObjectListItemV2
      */
-    readonly timeBoundsEnd?: number | null;
+    readonly timeBoundsEnd?: string | null;
     /**
      * EU AI Act Art. 50 provenance mode: 'human', 'ai', 'collaborative', or null (default, equivalent to human-authored). Set from the X-AI-Agent request header on create.
      * @type {string}

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/io/DataObjectListItemV2IO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/io/DataObjectListItemV2IO.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.dlr.shepard.context.collection.entities.DataObject;
 import de.dlr.shepard.context.collection.io.DataObjectIO;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
@@ -74,22 +76,22 @@ public class DataObjectListItemV2IO extends DataObjectIO {
     nullable = true,
     description =
       "Earliest data-point timestamp across all timeseries channels of this DataObject, " +
-      "in nanoseconds since Unix epoch. Null when no timeseries data exists or " +
-      "`?include=time-bounds` was not requested."
+      "as ISO 8601 UTC with nanosecond precision (e.g. '2024-06-01T12:00:00.000000001Z'). " +
+      "Null when no timeseries data exists or `?include=time-bounds` was not requested."
   )
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private Long timeBoundsStart;
+  private String timeBoundsStart;
 
   @Schema(
     readOnly = true,
     nullable = true,
     description =
       "Latest data-point timestamp across all timeseries channels of this DataObject, " +
-      "in nanoseconds since Unix epoch. Null when no timeseries data exists or " +
-      "`?include=time-bounds` was not requested."
+      "as ISO 8601 UTC with nanosecond precision (e.g. '2024-06-01T12:00:00.000000001Z'). " +
+      "Null when no timeseries data exists or `?include=time-bounds` was not requested."
   )
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private Long timeBoundsEnd;
+  private String timeBoundsEnd;
 
   /**
    * PROV1j — EU AI Act Art. 50 per-artefact visibility field.
@@ -173,5 +175,11 @@ public class DataObjectListItemV2IO extends DataObjectIO {
       }
     }
     this.childrenAppIds = kids;
+  }
+
+  /** Converts a nanosecond-precision epoch timestamp to ISO 8601 UTC (e.g. "2024-06-01T12:00:00.000000001Z"). */
+  public static String toIsoNs(long epochNs) {
+    return DateTimeFormatter.ISO_INSTANT.format(
+      Instant.ofEpochSecond(epochNs / 1_000_000_000L, epochNs % 1_000_000_000L));
   }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java
@@ -163,7 +163,7 @@ public class DataObjectV2Rest {
       "`APISIMP-DO-LIST-CONTENT-RANGE` in the backlog (a coordinated backend + " +
       "frontend two-commit change).\n\n" +
       "Optional enrichment via `?include=time-bounds`: adds `timeBoundsStart` and " +
-      "`timeBoundsEnd` (epoch nanoseconds) to each item, reflecting the earliest and " +
+      "`timeBoundsEnd` (ISO 8601 UTC with nanosecond precision) to each item, reflecting the earliest and " +
       "latest data-point timestamps across all timeseries channels. Null on items " +
       "with no timeseries data. Omitted from the response entirely when " +
       "`?include=time-bounds` is not requested.\n\n" +
@@ -323,8 +323,8 @@ public class DataObjectV2Rest {
             if (maxNs == null || bounds[1] > maxNs) maxNs = bounds[1];
           }
         }
-        item.setTimeBoundsStart(minNs);
-        item.setTimeBoundsEnd(maxNs);
+        item.setTimeBoundsStart(minNs != null ? DataObjectListItemV2IO.toIsoNs(minNs) : null);
+        item.setTimeBoundsEnd(maxNs != null ? DataObjectListItemV2IO.toIsoNs(maxNs) : null);
       }
       result.add(item);
     }

--- a/backend/src/test/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2RestTest.java
@@ -229,8 +229,8 @@ class DataObjectV2RestTest {
     List<DataObjectListItemV2IO> body = parseListBody(r);
     assertEquals(1, body.size());
     DataObjectListItemV2IO item = body.get(0);
-    assertEquals(1_000_000L, item.getTimeBoundsStart());
-    assertEquals(9_000_000L, item.getTimeBoundsEnd());
+    assertEquals("1970-01-01T00:00:00.001Z", item.getTimeBoundsStart());
+    assertEquals("1970-01-01T00:00:00.009Z", item.getTimeBoundsEnd());
   }
 
   @Test

--- a/frontend/components/context/collection/CollectionDataObjectTimelinePane.vue
+++ b/frontend/components/context/collection/CollectionDataObjectTimelinePane.vue
@@ -87,8 +87,8 @@ const lanes = computed<Lane[]>(() => {
       startMs: start,
       // A bin is active when the DataObject's time range overlaps it.
       active:
-        d.timeBoundsStart! / 1_000_000 < start + bms &&
-        d.timeBoundsEnd! / 1_000_000 >= start,
+        new Date(d.timeBoundsStart!).getTime() < start + bms &&
+        new Date(d.timeBoundsEnd!).getTime() >= start,
     })),
   }));
 });

--- a/frontend/components/context/collection/CollectionDataObjectsPanel.vue
+++ b/frontend/components/context/collection/CollectionDataObjectsPanel.vue
@@ -420,8 +420,8 @@ interface Row {
   childCount: number;
   incomingCount: number;
   createdAt: Date;
-  timeBoundsStart: number | null;
-  timeBoundsEnd: number | null;
+  timeBoundsStart: number | null; // milliseconds
+  timeBoundsEnd: number | null;   // milliseconds
   /** TEMPLATE-ICONS-2-FE-RENDER-POINTS-EXPAND: appId of the template this DO was created from. */
   attachedTemplateAppId: string | null;
 }
@@ -440,8 +440,8 @@ const rows = computed<Row[]>(() =>
     childCount: (d.childrenIds ?? []).length,
     incomingCount: (d.incomingIds ?? []).length,
     createdAt: d.createdAt instanceof Date ? d.createdAt : new Date(d.createdAt as unknown as string),
-    timeBoundsStart: d.timeBoundsStart ?? null,
-    timeBoundsEnd: d.timeBoundsEnd ?? null,
+    timeBoundsStart: d.timeBoundsStart != null ? new Date(d.timeBoundsStart).getTime() : null,
+    timeBoundsEnd: d.timeBoundsEnd != null ? new Date(d.timeBoundsEnd).getTime() : null,
     attachedTemplateAppId: d.attachedTemplateAppId ?? null,
   })),
 );
@@ -479,10 +479,7 @@ function timeBoundsBarWidth(start: number, end: number): number {
   return (end - start) / (gMax - gMin);
 }
 
-function timeBoundsTooltip(startNs: number, endNs: number): string {
-  // nanoseconds → milliseconds for Date
-  const startMs = startNs / 1_000_000;
-  const endMs   = endNs   / 1_000_000;
+function timeBoundsTooltip(startMs: number, endMs: number): string {
   return `${new Date(startMs).toLocaleString()} → ${new Date(endMs).toLocaleString()}`;
 }
 

--- a/frontend/tests/unit/collectionDataObjectTimeline.test.ts
+++ b/frontend/tests/unit/collectionDataObjectTimeline.test.ts
@@ -32,16 +32,16 @@ describe("computeGlobalMinMs", () => {
     expect(computeGlobalMinMs([])).toBe(0);
   });
 
-  it("converts nanoseconds to milliseconds", () => {
-    // 1 000 000 000 ns → 1 000 ms
-    expect(computeGlobalMinMs([{ timeBoundsStart: 1_000_000_000 }])).toBe(1_000);
+  it("parses ISO 8601 string to milliseconds", () => {
+    // "1970-01-01T00:00:01Z" = 1 000 ms
+    expect(computeGlobalMinMs([{ timeBoundsStart: "1970-01-01T00:00:01Z" }])).toBe(1_000);
   });
 
   it("returns the minimum across multiple rows", () => {
     const rows = [
-      { timeBoundsStart: 10_000_000_000 }, // 10 000 ms
-      { timeBoundsStart:  5_000_000_000 }, //  5 000 ms
-      { timeBoundsStart: 20_000_000_000 }, // 20 000 ms
+      { timeBoundsStart: "1970-01-01T00:00:10Z" }, // 10 000 ms
+      { timeBoundsStart: "1970-01-01T00:00:05Z" }, //  5 000 ms
+      { timeBoundsStart: "1970-01-01T00:00:20Z" }, // 20 000 ms
     ];
     expect(computeGlobalMinMs(rows)).toBe(5_000);
   });
@@ -58,15 +58,16 @@ describe("computeGlobalMaxMs", () => {
     expect(computeGlobalMaxMs([])).toBe(0);
   });
 
-  it("converts nanoseconds to milliseconds", () => {
-    expect(computeGlobalMaxMs([{ timeBoundsEnd: 2_000_000_000 }])).toBe(2_000);
+  it("parses ISO 8601 string to milliseconds", () => {
+    // "1970-01-01T00:00:02Z" = 2 000 ms
+    expect(computeGlobalMaxMs([{ timeBoundsEnd: "1970-01-01T00:00:02Z" }])).toBe(2_000);
   });
 
   it("returns the maximum across multiple rows", () => {
     const rows = [
-      { timeBoundsEnd: 10_000_000_000 }, // 10 000 ms
-      { timeBoundsEnd:  5_000_000_000 }, //  5 000 ms
-      { timeBoundsEnd: 20_000_000_000 }, // 20 000 ms
+      { timeBoundsEnd: "1970-01-01T00:00:10Z" }, // 10 000 ms
+      { timeBoundsEnd: "1970-01-01T00:00:05Z" }, //  5 000 ms
+      { timeBoundsEnd: "1970-01-01T00:00:20Z" }, // 20 000 ms
     ];
     expect(computeGlobalMaxMs(rows)).toBe(20_000);
   });

--- a/frontend/tests/unit/usePagedDataObjects.dbopt5.test.ts
+++ b/frontend/tests/unit/usePagedDataObjects.dbopt5.test.ts
@@ -133,8 +133,8 @@ describe("DB-OPT5 — usePagedDataObjects sends panel-shaped ?fields=", () => {
       timeseriesCount: 3,
       fileCount: 1,
       structuredDataCount: 0,
-      timeBoundsStart: 1_000_000_000,
-      timeBoundsEnd: 9_000_000_000,
+      timeBoundsStart: "1970-01-01T00:00:01Z",
+      timeBoundsEnd: "1970-01-01T00:00:09Z",
     };
     mockListDataObjectsRaw.mockReturnValue(rawResponse([trimmedItem], 1));
 

--- a/frontend/utils/collectionDataObjectTimeline.ts
+++ b/frontend/utils/collectionDataObjectTimeline.ts
@@ -15,21 +15,21 @@ export const BIN_SIZE_MS: Record<"hour" | "day" | "week", number> = {
 export const MAX_BINS = 200;
 
 /** Global start of the swimlane grid, in milliseconds.
- *  timeBoundsStart values are nanoseconds from the backend. */
+ *  timeBoundsStart values are ISO 8601 UTC strings from the backend. */
 export function computeGlobalMinMs(
-  rows: { timeBoundsStart?: number | null }[],
+  rows: { timeBoundsStart?: string | null }[],
 ): number {
   if (!rows.length) return 0;
-  return Math.min(...rows.map(d => (d.timeBoundsStart ?? 0) / 1_000_000));
+  return Math.min(...rows.map(d => d.timeBoundsStart != null ? new Date(d.timeBoundsStart).getTime() : 0));
 }
 
 /** Global end of the swimlane grid, in milliseconds.
- *  timeBoundsEnd values are nanoseconds from the backend. */
+ *  timeBoundsEnd values are ISO 8601 UTC strings from the backend. */
 export function computeGlobalMaxMs(
-  rows: { timeBoundsEnd?: number | null }[],
+  rows: { timeBoundsEnd?: string | null }[],
 ): number {
   if (!rows.length) return 0;
-  return Math.max(...rows.map(d => (d.timeBoundsEnd ?? 0) / 1_000_000));
+  return Math.max(...rows.map(d => d.timeBoundsEnd != null ? new Date(d.timeBoundsEnd).getTime() : 0));
 }
 
 /** Compute bin start timestamps (ms) for the grid, capped at MAX_BINS. */


### PR DESCRIPTION
## Summary

Converts `DataObjectListItemV2IO.timeBoundsStart` and `timeBoundsEnd` from `Long` (nanoseconds since Unix epoch) to `String` (ISO 8601 UTC with nanosecond precision). Part of the APISIMP epoch→ISO 8601 conversion wave; also fixes a silent JS precision-loss bug (nanosecond epoch values for current dates ≈ 1.7×10¹⁸ exceed `Number.MAX_SAFE_INTEGER` ≈ 9×10¹⁵). Backlog row: `APISIMP-DO-TIME-BOUNDS-NS-TO-ISO` (size S, fire-588).

## Backlog reference

- aidocs/16 ID: `APISIMP-DO-TIME-BOUNDS-NS-TO-ISO`

## Type

- [x] `refactor` — internal refactor, no behaviour change (wire-type change from numeric to ISO string — callers must update to parse string, but the semantic value is identical)

## Conventional Commits

- [x] PR title follows Conventional Commits with an aidocs/16 scope.

## Changes

**Backend:**
- `DataObjectListItemV2IO.java` — `Long timeBoundsStart/End` → `String`; added `toIsoNs(long epochNs)` static helper using `Instant.ofEpochSecond(epochNs / 1_000_000_000L, epochNs % 1_000_000_000L)`
- `DataObjectV2Rest.java:326-327` — setter calls wrap with `toIsoNs()` + null-guard
- `DataObjectV2RestTest.java` — `listIncludesTimeBoundsWhenRequested` updated to assert ISO string values (`"1970-01-01T00:00:00.001Z"`, `"1970-01-01T00:00:00.009Z"`)

**Generated client:**
- `backend-client/src/models/DataObjectListItemV2.ts` — `number | null` → `string | null`; JSDoc updated

**Frontend:**
- `collectionDataObjectTimeline.ts` — `computeGlobalMinMs`/`computeGlobalMaxMs` now accept `string | null` and parse via `new Date(iso).getTime()`; removed `/ 1_000_000` division
- `CollectionDataObjectTimelinePane.vue` — bin-overlap arithmetic uses `new Date(d.timeBoundsStart!).getTime()` instead of `d.timeBoundsStart! / 1_000_000`
- `CollectionDataObjectsPanel.vue` — `Row` type keeps `timeBoundsStart: number` (ms) internally; mapping converts ISO string at the boundary via `new Date(d.timeBoundsStart).getTime()`

**Tests:**
- `collectionDataObjectTimeline.test.ts` — mock data switched from nanosecond numbers to ISO 8601 strings
- `usePagedDataObjects.dbopt5.test.ts` — `trimmedItem` mock updated to ISO string fields

**Backlog:**
- `aidocs/16` — `APISIMP-DO-TIME-BOUNDS-NS-TO-ISO` row added (in-flight); 8 new XS sweep-findings rows queued (AasRegistrationIO, PluginEntryIO, LabJournalRevisionIO, DataciteMinterConfigIO, EpicMinterConfigIO, UnhideConfigIO, HarvestKeyMintedIO, LegacyV1StatsIO)

## "Always:" checklist (from CLAUDE.md)

### Upgrade path + ledger currency
- ~~**aidocs/34 ledger**~~ — wire-type change on a v2 response field; no upstream-compat surface touched. Clients consuming `timeBoundsStart/End` as numeric must update to parse ISO string — all callers are this fork's own frontend (updated in this PR). No third-party upstream client reads this field (it's a fork-only `?include=time-bounds` extension).
- ~~**Migration script**~~ — no DB schema change; conversion is at the IO layer only.

### API-version policy
- [x] Change is on `/v2/collections/{appId}/data-objects` — fork's development surface. Upstream `/shepard/api/` untouched.

### Live docs currency
- ~~**aidocs/42-vision.md**~~ — not user-visible (wire-type normalisation, not a new capability).
- ~~**aidocs/44**~~ — not a feature status change; APISIMP rows are internal refactors.
- ~~**docs/reference**~~ — no new user-visible surface.
- ~~**Plugin docs**~~ — in-tree change only.

### Tests + coverage
- [x] Tests updated in the same PR (`DataObjectV2RestTest` + 2 frontend unit tests).
- [x] Frontend: `npm run test` — 2678 passed, 0 failed; `npm run typecheck` exit 0.
- [x] Backend: `DataObjectV2RestTest.listIncludesTimeBoundsWhenRequested` updated; CI will validate `mvn verify`.

### Security
- [x] No new network surface, no secret handling, no dependency changes. SpotBugs/CodeQL/gitleaks/OWASP N/A for this diff.

### Architecture posture
- ~~**Plugin-first**~~ — IO layer normalisation in an existing in-tree resource.
- ~~**Operator runtime knob**~~ — no new feature toggle; this changes the wire type of an existing field.

### Doc-stage front-matter
- ~~**aidocs/* doc-stage**~~ — new `aidocs/16` rows are tracked fragments; front-matter not required for backlog entries.

## Risk + rollback

**Wire-type break for any caller reading `timeBoundsStart/End` as a number.** All callers are this fork's own frontend (updated in this PR) and the generated `backend-client` TypeScript (also updated). Rollback is a `git revert` of this commit — no DB migration needed.

## API examples

```
GET /v2/collections/{appId}/data-objects?include=time-bounds
```

Before:
```json
{ "timeBoundsStart": 1717243200000000000, "timeBoundsEnd": 1717329600000000000 }
```

After:
```json
{ "timeBoundsStart": "2024-06-01T12:00:00Z", "timeBoundsEnd": "2024-06-02T12:00:00Z" }
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbZ6W5JWjSuMBXpzH5Zz9z)_