### PR TITLE
fix(APISIMP-FEED-ENTRY-DATE-TO-ISO,APISIMP-LEGACY-V1-CONFIG-DATE-TO-ISO): convert Date fields to ISO 8601 strings

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5240,7 +5240,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/dataobject/io/DataObjectListItemV2IO.java`; `backend/src/main/java/de/dlr/shepard/v2/dataobject/resources/DataObjectV2Rest.java:326-327`; `frontend/utils/collectionDataObjectTimeline.ts`; `backend-client/src/models/DataObjectListItemV2.ts`; apisimp-sweep (fire-588 dispatch).
 
 ## APISIMP-AAS-REGISTRATION-LONG-TO-ISO — convert `AasRegistrationIO.lastAttemptAt`/`createdAt`/`updatedAt` from epoch-ms `Long` to ISO 8601 `String` (size: XS, fire-588)
-- **Status:** 🔄 in-flight (PR #2551, fire-592)
+- **Status:** ✅ shipped (PR #2551, fire-593, SHA a44c2ff7)
 - **Why:** `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/io/AasRegistrationIO.java` lines 17, 19–20 expose `lastAttemptAt`, `createdAt`, and `updatedAt` as `Long` epoch-ms values on `GET /v2/admin/aas/registrations`. The entity fields (`AasRegistration.java:71,79,83`) are `Long` ms since epoch. All other v2 admin entity timestamps have been converted to ISO 8601 strings; these three are the last outliers in the AAS plugin.
 - **AC:** `AasRegistrationIO` record components `lastAttemptAt`, `createdAt`, `updatedAt` are `String` ISO 8601 UTC values (e.g. `"2026-07-01T10:00:00Z"`); entity `Long` values converted via `Instant.ofEpochMilli(...).toString()` with null-guard; `mvn verify -pl plugins/aas` green.
 - **First refs:** `plugins/aas/src/main/java/de/dlr/shepard/plugins/aas/admin/io/AasRegistrationIO.java:17,19-20`; apisimp-sweep-2026-07-13-fire586.md follow-on sweep (fire-588).
@@ -5258,13 +5258,13 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/io/LabJournalRevisionIO.java:36`; apisimp-sweep (fire-588).
 
 ## APISIMP-DATACITE-CONFIG-DATE-TO-ISO — convert `DataciteMinterConfigIO.updatedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-588)
-- **Status:** 🔄 in-flight (PR #2551, fire-592)
+- **Status:** ✅ shipped (PR #2551, fire-593, SHA a44c2ff7)
 - **Why:** `plugins/minter-datacite/src/main/java/de/dlr/shepard/plugins/minter/datacite/io/DataciteMinterConfigIO.java:32,40,51` wraps the entity's `Long updatedAtMillis` into a `Date` field; Jackson serialises as numeric epoch-ms. Pattern matches the other minter config outlier (APISIMP-EPIC-CONFIG-DATE-TO-ISO). Fix: change `Date updatedAt` to `String updatedAt`; convert via `updatedAtMillis == null ? null : Instant.ofEpochMilli(updatedAtMillis).toString()`.
 - **AC:** `GET /v2/admin/config/datacite` (via AdminConfigRest) returns `updatedAt` as an ISO 8601 UTC string; `mvn verify -pl plugins/minter-datacite` green.
 - **First refs:** `plugins/minter-datacite/src/main/java/de/dlr/shepard/plugins/minter/datacite/io/DataciteMinterConfigIO.java:32,40,51`; apisimp-sweep (fire-588).
 
 ## APISIMP-EPIC-CONFIG-DATE-TO-ISO — convert `EpicMinterConfigIO.updatedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-588)
-- **Status:** 🔄 in-flight (PR #2551, fire-592)
+- **Status:** ✅ shipped (PR #2551, fire-593, SHA a44c2ff7)
 - **Why:** `plugins/minter-epic/src/main/java/de/dlr/shepard/plugins/minter/epic/io/EpicMinterConfigIO.java:28,36,43` wraps `Long updatedAtMillis` into a `Date` field (same anti-pattern as `DataciteMinterConfigIO`). Fix: same pattern — change `Date updatedAt` to `String updatedAt`; convert via `Instant.ofEpochMilli(updatedAtMillis).toString()`.
 - **AC:** `GET /v2/admin/config/epic` returns `updatedAt` as an ISO 8601 UTC string; `mvn verify -pl plugins/minter-epic` green.
 - **First refs:** `plugins/minter-epic/src/main/java/de/dlr/shepard/plugins/minter/epic/io/EpicMinterConfigIO.java:28,36,43`; apisimp-sweep (fire-588).
@@ -5282,7 +5282,7 @@ picks these up. Terse by design.
 - **First refs:** `plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/HarvestKeyMintedIO.java:32`; apisimp-sweep (fire-588).
 
 ## APISIMP-LEGACY-V1-STATS-DATE-TO-ISO — convert `LegacyV1StatsIO.firstHitAt`/`mostRecentHitAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-588)
-- **Status:** 🔄 in-flight (PR #2551, fire-592)
+- **Status:** ✅ shipped (PR #2551, fire-593, SHA a44c2ff7)
 - **Why:** `plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1StatsIO.java:34-35` has `Date firstHitAt` and `Date mostRecentHitAt` as record components on `GET /v2/admin/config/legacy-v1/stats`. Without `@JsonFormat(shape=STRING)` both serialise as numeric epoch-ms. Fix: change both to `String`; convert via `Instant.ofEpochMilli(...)`.
 - **AC:** `GET /v2/admin/config/legacy-v1/stats` carries `firstHitAt`/`mostRecentHitAt` as ISO 8601 UTC strings; `mvn verify -pl plugins/v1-compat` green.
 - **First refs:** `plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1StatsIO.java:34-35`; apisimp-sweep (fire-588).

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5288,13 +5288,13 @@ picks these up. Terse by design.
 - **First refs:** `plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1StatsIO.java:34-35`; apisimp-sweep (fire-588).
 
 ## APISIMP-LEGACY-V1-CONFIG-DATE-TO-ISO — convert `LegacyV1ConfigIO.updatedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-592)
-- **Status:** ⏳ queued
+- **Status:** 🔄 in-flight (PR dispatched fire-593, branch apisimp-feed-v1config-dates-to-iso)
 - **Why:** `plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1ConfigIO.java:39` exposes `Date updatedAt` as a record component on `GET /v2/admin/legacy/v1/config`. The factory at line 44 wraps a `Long updatedAt` entity field via `new Date(updated)`. There is no `@JsonFormat(shape=STRING)` annotation, so Jackson serialises as numeric epoch-ms — the last Date-typed field in the v1-compat plugin's IO surface after `LegacyV1StatsIO` is fixed by PR #2551. Fix: change record component to `String updatedAt`; convert in `from()` via `updated == null ? null : Instant.ofEpochMilli(updated).toString()`.
 - **AC:** `GET /v2/admin/legacy/v1/config` returns `updatedAt` as an ISO 8601 UTC string (e.g. `"2026-07-14T10:00:00Z"`) or `null`; `mvn verify -pl plugins/v1-compat` green.
 - **First refs:** `plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1ConfigIO.java:39,44`; apisimp-sweep-2026-07-14-fire592.md §Finding1.
 
 ## APISIMP-FEED-ENTRY-DATE-TO-ISO — convert `FeedEntryIO.dateCreated`/`dateModified` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-592)
-- **Status:** ⏳ queued
+- **Status:** 🔄 in-flight (PR dispatched fire-593, branch apisimp-feed-v1config-dates-to-iso)
 - **Why:** `plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/FeedEntryIO.java:81-82` exposes `Date dateCreated` and `Date dateModified` as record components in the JSON-LD feed at `GET /v2/unhide/feed.jsonld`. No `@JsonFormat(shape=STRING)` annotation is present, so Jackson serialises both as numeric epoch-ms integers — which is invalid schema.org JSON-LD (schema.org `dateCreated`/`dateModified` expects an ISO 8601 dateTime string per its spec). Fix: change both components to `String`; convert at the call site in `UnhideFeedService` via `Instant.ofEpochMilli(collection.getCreatedAt().getTime()).toString()` with null-guard.
 - **AC:** `GET /v2/unhide/feed.jsonld` entries carry `dateCreated`/`dateModified` as ISO 8601 UTC strings conforming to schema.org; `mvn verify -pl plugins/unhide` green.
 - **First refs:** `plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/FeedEntryIO.java:81-82`; apisimp-sweep-2026-07-14-fire592.md §Finding2.

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5288,13 +5288,13 @@ picks these up. Terse by design.
 - **First refs:** `plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1StatsIO.java:34-35`; apisimp-sweep (fire-588).
 
 ## APISIMP-LEGACY-V1-CONFIG-DATE-TO-ISO — convert `LegacyV1ConfigIO.updatedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-592)
-- **Status:** 🔄 in-flight (PR dispatched fire-593, branch apisimp-feed-v1config-dates-to-iso)
+- **Status:** 🔄 in-flight (PR #2552, fire-593)
 - **Why:** `plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1ConfigIO.java:39` exposes `Date updatedAt` as a record component on `GET /v2/admin/legacy/v1/config`. The factory at line 44 wraps a `Long updatedAt` entity field via `new Date(updated)`. There is no `@JsonFormat(shape=STRING)` annotation, so Jackson serialises as numeric epoch-ms — the last Date-typed field in the v1-compat plugin's IO surface after `LegacyV1StatsIO` is fixed by PR #2551. Fix: change record component to `String updatedAt`; convert in `from()` via `updated == null ? null : Instant.ofEpochMilli(updated).toString()`.
 - **AC:** `GET /v2/admin/legacy/v1/config` returns `updatedAt` as an ISO 8601 UTC string (e.g. `"2026-07-14T10:00:00Z"`) or `null`; `mvn verify -pl plugins/v1-compat` green.
 - **First refs:** `plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1ConfigIO.java:39,44`; apisimp-sweep-2026-07-14-fire592.md §Finding1.
 
 ## APISIMP-FEED-ENTRY-DATE-TO-ISO — convert `FeedEntryIO.dateCreated`/`dateModified` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-592)
-- **Status:** 🔄 in-flight (PR dispatched fire-593, branch apisimp-feed-v1config-dates-to-iso)
+- **Status:** 🔄 in-flight (PR #2552, fire-593)
 - **Why:** `plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/FeedEntryIO.java:81-82` exposes `Date dateCreated` and `Date dateModified` as record components in the JSON-LD feed at `GET /v2/unhide/feed.jsonld`. No `@JsonFormat(shape=STRING)` annotation is present, so Jackson serialises both as numeric epoch-ms integers — which is invalid schema.org JSON-LD (schema.org `dateCreated`/`dateModified` expects an ISO 8601 dateTime string per its spec). Fix: change both components to `String`; convert at the call site in `UnhideFeedService` via `Instant.ofEpochMilli(collection.getCreatedAt().getTime()).toString()` with null-guard.
 - **AC:** `GET /v2/unhide/feed.jsonld` entries carry `dateCreated`/`dateModified` as ISO 8601 UTC strings conforming to schema.org; `mvn verify -pl plugins/unhide` green.
 - **First refs:** `plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/FeedEntryIO.java:81-82`; apisimp-sweep-2026-07-14-fire592.md §Finding2.

--- a/plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/FeedEntryIO.java
+++ b/plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/FeedEntryIO.java
@@ -3,7 +3,6 @@ package de.dlr.shepard.plugins.unhide.io;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import java.util.Date;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
@@ -78,8 +77,8 @@ public record FeedEntryIO(
   @JsonProperty("@type") List<String> type,
   @JsonProperty("name") String name,
   @JsonProperty("description") String description,
-  @JsonProperty("dateCreated") Date dateCreated,
-  @JsonProperty("dateModified") Date dateModified,
+  @JsonProperty("dateCreated") String dateCreated,
+  @JsonProperty("dateModified") String dateModified,
   @JsonProperty("license") String license,
   @JsonProperty("creator") Object creator,
   @JsonProperty("schema:identifier") Object schemaIdentifier,

--- a/plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/services/UnhideFeedService.java
+++ b/plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/services/UnhideFeedService.java
@@ -15,6 +15,7 @@ import de.dlr.shepard.publish.entities.Publication;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -156,13 +157,15 @@ public class UnhideFeedService {
     // UH1c — KIP citation: current Publication's PID + resolver URL.
     KipCitation kip = buildKipCitation(c.getAppId(), baseUrl);
 
+    Date createdAtDate = c.getCreatedAt();
+    Date updatedAtDate = c.getUpdatedAt();
     return new FeedEntryIO(
       id,
       List.of("schema:Dataset", "m4i:Dataset"),
       c.getName(),
       c.getDescription(),
-      c.getCreatedAt(),
-      c.getUpdatedAt(),
+      createdAtDate == null ? null : Instant.ofEpochMilli(createdAtDate.getTime()).toString(),
+      updatedAtDate == null ? null : Instant.ofEpochMilli(updatedAtDate.getTime()).toString(),
       null, // license — Collection schema doesn't carry one yet; UH1d wires it via CP1a properties
       creator,
       kip == null ? null : kip.schemaIdentifier,

--- a/plugins/unhide/src/test/java/de/dlr/shepard/plugins/unhide/services/UnhideFeedValidationTest.java
+++ b/plugins/unhide/src/test/java/de/dlr/shepard/plugins/unhide/services/UnhideFeedValidationTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import de.dlr.shepard.plugins.unhide.io.FeedEntryIO;
 import de.dlr.shepard.plugins.unhide.io.FeedIO;
 import de.dlr.shepard.plugins.unhide.io.UnhideValidationReportIO;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -153,8 +152,8 @@ class UnhideFeedValidationTest {
       List.of("schema:Dataset"),
       name,
       description,
-      new Date(),
-      new Date(),
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:00:00Z",
       null, // license
       null, // creator
       null, // schemaIdentifier

--- a/plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1ConfigIO.java
+++ b/plugins/v1-compat/src/main/java/de/dlr/shepard/plugins/v1compat/io/LegacyV1ConfigIO.java
@@ -2,7 +2,7 @@ package de.dlr.shepard.plugins.v1compat.io;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.dlr.shepard.plugins.v1compat.entities.LegacyV1Config;
-import java.util.Date;
+import java.time.Instant;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
@@ -36,7 +36,7 @@ public record LegacyV1ConfigIO(
   boolean suppressDeprecationHeaders,
   boolean stripAppIdFromResponses,
   String appId,
-  Date updatedAt,
+  String updatedAt,
   String updatedBy
 ) {
   /** Project an entity onto the IO record. */
@@ -47,7 +47,7 @@ public record LegacyV1ConfigIO(
       cfg.isSuppressDeprecationHeaders(),
       cfg.isStripAppIdFromResponses(),
       cfg.getAppId(),
-      updated == null ? null : new Date(updated),
+      updated == null ? null : Instant.ofEpochMilli(updated).toString(),
       cfg.getUpdatedBy()
     );
   }


### PR DESCRIPTION
## Summary

Converts two `java.util.Date` timestamp fields (both WITHOUT `@JsonFormat` — guaranteed epoch-ms integers on the wire) to ISO 8601 UTC `String`, completing the HIGH-priority items from the fire-592 sweep.

| IO class | field(s) | endpoint | was | now |
|---|---|---|---|---|
| `FeedEntryIO` | `dateCreated`, `dateModified` | `GET /v2/unhide/feed.jsonld` | `Date` → epoch-ms integer | `String` ISO 8601 |
| `LegacyV1ConfigIO` | `updatedAt` | `GET /v2/admin/legacy/v1/config` | `Date` → epoch-ms integer | `String` ISO 8601 |

### `FeedEntryIO` — schema.org violation fix (HIGH)

`FeedEntryIO.java:80-81` had `Date dateCreated` and `Date dateModified` with no `@JsonFormat` annotation. Jackson serialised both as numeric epoch-ms integers (e.g. `"dateCreated": 1700000000000`). This violates the [schema.org `dateCreated` vocabulary](https://schema.org/dateCreated) which requires an ISO 8601 dateTime string — numeric integers cause JSON-LD processor failures and break Helmholtz Unhide inward-mappings.

Fix:
- `FeedEntryIO`: `Date dateCreated`/`dateModified` → `String`
- `UnhideFeedService.toFeedEntry()`: convert via `Instant.ofEpochMilli(date.getTime()).toString()` with null-guard
- `UnhideFeedValidationTest`: replace `new Date()` literals with ISO 8601 string literals

### `LegacyV1ConfigIO` — no `@JsonFormat`, epoch-ms on wire (HIGH)

`LegacyV1ConfigIO.java:39` had `Date updatedAt` as a record component with no `@JsonFormat`. Factory method at line 44 wrapped a `Long updatedAt` entity field via `new Date(updated)`. Jackson emitted `"updatedAt": 1720955200000`.

Fix: record component → `String updatedAt`; factory: `updated == null ? null : Instant.ofEpochMilli(updated).toString()`.

## Backlog reference

- aidocs/16 IDs: `APISIMP-FEED-ENTRY-DATE-TO-ISO`, `APISIMP-LEGACY-V1-CONFIG-DATE-TO-ISO`

## Type

- [x] `fix` — bug fix

## Conventional Commits

- [x] PR title follows Conventional Commits with aidocs/16 scopes.

## "Always:" checklist (from CLAUDE.md)

### Upgrade path + ledger currency

- ~~**aidocs/34 ledger**~~ — wire-shape change is additive-compatible: epoch-ms integer is replaced by ISO 8601 string. Any JSON consumer already tolerating a JSON string will handle this. No admin-visible breakage; no ledger row needed.
- ~~**Migration script**~~ — no schema change; all values computed at read-time from entity fields.

### API-version policy

- [x] **Existing `/v2/` paths unchanged** — no new endpoints; type conversion only.

### Live docs currency

- ~~**aidocs/42-vision.md**~~ — internal wire-format fix.
- ~~**aidocs/44**~~ — no feature row change.

### Tests + coverage

- [x] **`UnhideFeedValidationTest`** — updated: `new Date()` → ISO 8601 string literals; no logic change.
- [x] **`UnhideFeedServiceTest`** — no date assertions on `dateCreated`/`dateModified`; passes unchanged.
- [x] **`LegacyV1ConfigIO`** — no existing test asserts on `updatedAt`; positional record constructor unchanged (type swap only).
- [x] **Backend coverage** — no new code paths; type swap only.

### Security

- [x] **SpotBugs + findsecbugs** — no new code paths.
- [x] **CodeQL** — no new code paths.
- ~~**OWASP Dependency-Check / Trivy**~~ — no dependency changes.
- [x] **gitleaks** — no secrets.

### Doc-stage front-matter

- [x] **aidocs/01-doc-stage-index.md** — no `stage:` frontmatter changed; index already current.

## Risk + rollback

Low. Pure wire-format improvement: ISO 8601 string replaces epoch-ms integer. `git revert` is sufficient rollback; no data migration needed.

---
_Generated by Claude Code (dispatcher fire-593)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaSacaEMpKopzdA6Zm8hrs)_