### PR TITLE
fix(APISIMP-*-DATE-TO-ISO ×5): convert @JsonFormat(STRING) Date fields to explicit ISO 8601 strings

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -154,7 +154,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/agent-findings/apisimp-sweep-2026-06-30-fire330.md`](agent-findings/apisimp-sweep-2026-06-30-fire330.md) | APISIMP Sweep — fire-330 (2026-06-30) | 2026-06-30 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-04.md`](agent-findings/apisimp-sweep-2026-07-04.md) | APISIMP Sweep — 2026-07-04 (fire-399) | 2026-07-04 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-10.md`](agent-findings/apisimp-sweep-2026-07-10.md) | APISIMP — v2 surface simplification sweep (2026-07-10, fire-526) | 2026-07-10 | 2026-07-12 |
-| [`aidocs/agent-findings/apisimp-sweep-2026-07-14-fire592.md`](agent-findings/apisimp-sweep-2026-07-14-fire592.md) | APISIMP Sweep — fire-592 (2026-07-14) | 2026-07-14 | — |
+| [`aidocs/agent-findings/apisimp-sweep-2026-07-14-fire592.md`](agent-findings/apisimp-sweep-2026-07-14-fire592.md) | APISIMP Sweep — fire-592 (2026-07-14) | 2026-07-14 | 2026-07-14 |
 | [`aidocs/agent-findings/apisimp-sweep-fire346-2026-07-01.md`](agent-findings/apisimp-sweep-fire346-2026-07-01.md) | APISIMP Sweep — 2026-07-01 (fire-346) | 2026-07-01 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-fire351-2026-07-01.md`](agent-findings/apisimp-sweep-fire351-2026-07-01.md) | APISIMP Sweep — 2026-07-01 (fire-351) | 2026-07-01 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-fire387-2026-07-03.md`](agent-findings/apisimp-sweep-fire387-2026-07-03.md) | APISIMP Sweep — 2026-07-03 (fire-387) | 2026-07-03 | 2026-07-12 |

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5300,31 +5300,31 @@ picks these up. Terse by design.
 - **First refs:** `plugins/unhide/src/main/java/de/dlr/shepard/plugins/unhide/io/FeedEntryIO.java:81-82`; apisimp-sweep-2026-07-14-fire592.md §Finding2.
 
 ## APISIMP-NOTEBOOK-REF-DATE-TO-ISO — convert `NotebookReferenceIO.createdAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-592)
-- **Status:** ⏳ queued
+- **Status:** 🔄 in-progress (branch: apisimp-medium-dates-to-iso, fire-593)
 - **Why:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/io/NotebookReferenceIO.java:83` has `private Date createdAt`. A `@JsonFormat(shape=STRING)` annotation is present (line 75), which causes Jackson to emit a date string — but the exact format depends on the ObjectMapper's configured `DateFormat` and timezone. Converting to `String` via `Instant.ofEpochMilli(...).toString()` in the factory method makes the ISO 8601 UTC format explicit and removes the `java.util.Date` type from the wire shape entirely. The `@Schema(example = "2024-08-15T11:18:44.632+00:00")` confirms the intended format.
 - **AC:** `GET /v2/lab-journal/{dataObjectAppId}/notebooks` response carries `createdAt` as an ISO 8601 UTC string; `NotebookRestTest` asserts string shape; `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/io/NotebookReferenceIO.java:83`; apisimp-sweep-2026-07-14-fire592.md §Finding3.
 
 ## APISIMP-INSTANCE-ADMIN-GRANT-DATE-TO-ISO — convert `InstanceAdminGrantIO.grantedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-592)
-- **Status:** ⏳ queued
+- **Status:** 🔄 in-progress (branch: apisimp-medium-dates-to-iso, fire-593)
 - **Why:** `backend/src/main/java/de/dlr/shepard/v2/admin/io/InstanceAdminGrantIO.java:55` has `private Date grantedAt`. A `@JsonFormat(shape=STRING)` annotation is present (line 48). Same implicit-format concern as `NotebookReferenceIO.createdAt`; converting to `String` makes the ISO 8601 UTC format explicit. The corresponding `InstanceAdminService` builds the IO from a `Date` entity field — that site must also be updated. Fix: change type to `String`; convert via `Instant.ofEpochMilli(entity.getGrantedAt().getTime()).toString()` with null-guard.
 - **AC:** `GET /v2/admin/instance-admins` returns `grantedAt` as an ISO 8601 UTC string or `null`; `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/admin/io/InstanceAdminGrantIO.java:55`; apisimp-sweep-2026-07-14-fire592.md §Finding4.
 
 ## APISIMP-USER-GROUP-DATE-TO-ISO — convert `UserGroupV2IO.createdAt`/`updatedAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-592)
-- **Status:** ⏳ queued
+- **Status:** 🔄 in-progress (branch: apisimp-medium-dates-to-iso, fire-593)
 - **Why:** `backend/src/main/java/de/dlr/shepard/v2/users/io/UserGroupV2IO.java:40,47` has `private Date createdAt` and `private Date updatedAt`. Both carry `@JsonFormat(shape=STRING)` annotations (lines 38, 45). The constructor at lines 52–64 assigns via `group.getCreatedAt()` / `group.getUpdatedAt()`. Converting to `String` makes the ISO 8601 UTC format explicit. Fix: change both fields to `String`; convert in the constructor via `Instant.ofEpochMilli(group.getCreatedAt().getTime()).toString()` with null-guards.
 - **AC:** `GET /v2/user-groups` and `POST /v2/user-groups` responses carry `createdAt`/`updatedAt` as ISO 8601 UTC strings; `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/users/io/UserGroupV2IO.java:40,47`; apisimp-sweep-2026-07-14-fire592.md §Finding5.
 
 ## APISIMP-DO-SUMMARY-DATE-TO-ISO — convert `DataObjectSummaryIO.createdAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-592)
-- **Status:** ⏳ queued
+- **Status:** 🔄 in-progress (branch: apisimp-medium-dates-to-iso, fire-593)
 - **Why:** `backend/src/main/java/de/dlr/shepard/v2/dataobject/io/DataObjectSummaryIO.java:40` has `private Date createdAt`. A `@JsonFormat(shape=STRING)` annotation is present (line 32). This IO is returned by `GET /v2/dataobjects/{appId}/predecessors` and `/successors` as the compact shape for predecessor/successor DataObject rows. Converting to `String` makes the format explicit. Fix: change field to `String`; update constructor at line 58 via `Instant.ofEpochMilli(d.getCreatedAt().getTime()).toString()` with null-guard.
 - **AC:** `GET /v2/dataobjects/{appId}/predecessors` and `/successors` carry `createdAt` as ISO 8601 UTC strings; `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/dataobject/io/DataObjectSummaryIO.java:40`; apisimp-sweep-2026-07-14-fire592.md §Finding6.
 
 ## APISIMP-GIT-CREDENTIAL-DATE-TO-ISO — convert `GitCredentialIO.createdAt` from `java.util.Date` to ISO 8601 `String` (size: XS, fire-592)
-- **Status:** ⏳ queued
+- **Status:** 🔄 in-progress (branch: apisimp-medium-dates-to-iso, fire-593)
 - **Why:** `plugins/git/src/main/java/de/dlr/shepard/v2/users/io/GitCredentialIO.java:33` has `private Date createdAt`. A `@JsonFormat(shape=STRING)` annotation is present (line 31). Constructor at line 40 assigns via `cred.getCreatedAt()`. Converting to `String` makes the ISO 8601 UTC format explicit and removes the last `java.util.Date` from the git plugin's IO surface. Fix: change field to `String`; update constructor via `Instant.ofEpochMilli(cred.getCreatedAt().getTime()).toString()` with null-guard.
 - **AC:** `GET /v2/users/me/git-credentials` returns `createdAt` as an ISO 8601 UTC string; `mvn verify -pl plugins/git` green.
 - **First refs:** `plugins/git/src/main/java/de/dlr/shepard/v2/users/io/GitCredentialIO.java:33`; apisimp-sweep-2026-07-14-fire592.md §Finding7.

--- a/backend-client/src/models/DataObjectSummary.ts
+++ b/backend-client/src/models/DataObjectSummary.ts
@@ -39,10 +39,10 @@ export interface DataObjectSummary {
     readonly status?: string;
     /**
      * PRED-V2-SHAPE: creation timestamp. Null for pre-OGM rows.
-     * @type {Date}
+     * @type {string}
      * @memberof DataObjectSummary
      */
-    readonly createdAt?: Date | null;
+    readonly createdAt?: string | null;
     /**
      * PRED-V2-SHAPE: display name of the creator.
      * @type {string}
@@ -71,7 +71,7 @@ export function DataObjectSummaryFromJSONTyped(json: any, ignoreDiscriminator: b
         'appId': json['appId'] == null ? undefined : json['appId'],
         'name': json['name'] == null ? undefined : json['name'],
         'status': json['status'] == null ? undefined : json['status'],
-        'createdAt': json['createdAt'] == null ? undefined : (new Date(json['createdAt'])),
+        'createdAt': json['createdAt'] == null ? undefined : json['createdAt'],
         'createdBy': json['createdBy'] == null ? undefined : json['createdBy'],
     };
 }

--- a/backend-client/src/models/GitCredential.ts
+++ b/backend-client/src/models/GitCredential.ts
@@ -44,11 +44,11 @@ export interface GitCredential {
      */
     username?: string;
     /**
-     * 
-     * @type {Date}
+     *
+     * @type {string}
      * @memberof GitCredential
      */
-    readonly createdAt: Date;
+    readonly createdAt: string;
 }
 
 /**
@@ -74,7 +74,7 @@ export function GitCredentialFromJSONTyped(json: any, ignoreDiscriminator: boole
         'host': json['host'] == null ? undefined : json['host'],
         'displayName': json['displayName'] == null ? undefined : json['displayName'],
         'username': json['username'] == null ? undefined : json['username'],
-        'createdAt': (new Date(json['createdAt'])),
+        'createdAt': json['createdAt'],
     };
 }
 

--- a/backend-client/src/models/InstanceAdminGrant.ts
+++ b/backend-client/src/models/InstanceAdminGrant.ts
@@ -39,10 +39,10 @@ export interface InstanceAdminGrant {
     grantedBy?: string | null;
     /**
      * When the grant was created. Null for IdP-only grants.
-     * @type {Date}
+     * @type {string}
      * @memberof InstanceAdminGrant
      */
-    grantedAt?: Date | null;
+    grantedAt?: string | null;
 }
 
 /**
@@ -67,7 +67,7 @@ export function InstanceAdminGrantFromJSONTyped(json: any, ignoreDiscriminator: 
         'username': json['username'],
         'source': json['source'],
         'grantedBy': json['grantedBy'] == null ? undefined : json['grantedBy'],
-        'grantedAt': json['grantedAt'] == null ? undefined : (new Date(json['grantedAt'])),
+        'grantedAt': json['grantedAt'] == null ? undefined : json['grantedAt'],
     };
 }
 
@@ -80,7 +80,7 @@ export function InstanceAdminGrantToJSON(value?: InstanceAdminGrant | null): any
         'username': value['username'],
         'source': value['source'],
         'grantedBy': value['grantedBy'],
-        'grantedAt': value['grantedAt'] == null ? undefined : ((value['grantedAt'] as any).toISOString()),
+        'grantedAt': value['grantedAt'] == null ? undefined : value['grantedAt'],
     };
 }
 

--- a/backend-client/src/models/NotebookReference.ts
+++ b/backend-client/src/models/NotebookReference.ts
@@ -52,10 +52,10 @@ export interface NotebookReference {
     readonly mimeType?: string | null;
     /**
      * Creation time of the parent Reference.
-     * @type {Date}
+     * @type {string}
      * @memberof NotebookReference
      */
-    readonly createdAt?: Date | null;
+    readonly createdAt?: string | null;
     /**
      * Creator of the parent Reference.
      * @type {string}
@@ -96,7 +96,7 @@ export function NotebookReferenceFromJSONTyped(json: any, ignoreDiscriminator: b
         'fileName': json['fileName'],
         'fileSize': json['fileSize'] == null ? undefined : json['fileSize'],
         'mimeType': json['mimeType'] == null ? undefined : json['mimeType'],
-        'createdAt': json['createdAt'] == null ? undefined : (new Date(json['createdAt'])),
+        'createdAt': json['createdAt'] == null ? undefined : json['createdAt'],
         'createdBy': json['createdBy'] == null ? undefined : json['createdBy'],
         'referenceKind': ReferenceKindFromJSON(json['referenceKind']),
     };

--- a/backend-client/src/models/UserGroupV2.ts
+++ b/backend-client/src/models/UserGroupV2.ts
@@ -38,23 +38,23 @@ export interface UserGroupV2 {
      */
     usernames?: Array<string>;
     /**
-     * 
-     * @type {Date}
+     *
+     * @type {string}
      * @memberof UserGroupV2
      */
-    readonly createdAt?: Date;
+    readonly createdAt?: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof UserGroupV2
      */
     readonly createdBy?: string;
     /**
-     * 
-     * @type {Date}
+     *
+     * @type {string}
      * @memberof UserGroupV2
      */
-    readonly updatedAt?: Date | null;
+    readonly updatedAt?: string | null;
     /**
      * 
      * @type {string}

--- a/backend-client/src/models/UserGroupV2.ts
+++ b/backend-client/src/models/UserGroupV2.ts
@@ -84,9 +84,9 @@ export function UserGroupV2FromJSONTyped(json: any, ignoreDiscriminator: boolean
         'appId': json['appId'] == null ? undefined : json['appId'],
         'name': json['name'],
         'usernames': json['usernames'] == null ? undefined : json['usernames'],
-        'createdAt': json['createdAt'] == null ? undefined : (new Date(json['createdAt'])),
+        'createdAt': json['createdAt'] == null ? undefined : json['createdAt'],
         'createdBy': json['createdBy'] == null ? undefined : json['createdBy'],
-        'updatedAt': json['updatedAt'] == null ? undefined : (new Date(json['updatedAt'])),
+        'updatedAt': json['updatedAt'] == null ? undefined : json['updatedAt'],
         'updatedBy': json['updatedBy'] == null ? undefined : json['updatedBy'],
     };
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/io/InstanceAdminGrantIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/io/InstanceAdminGrantIO.java
@@ -1,7 +1,5 @@
 package de.dlr.shepard.v2.admin.io;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -45,12 +43,11 @@ public class InstanceAdminGrantIO {
   )
   private String grantedBy;
 
-  @JsonFormat(shape = JsonFormat.Shape.STRING)
   @Schema(
     required = false,
     nullable = true,
     format = "date-time",
     description = "When the grant was created. Null for IdP-only grants."
   )
-  private Date grantedAt;
+  private String grantedAt;
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/services/InstanceAdminService.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/services/InstanceAdminService.java
@@ -9,6 +9,7 @@ import de.dlr.shepard.v2.admin.io.InstanceAdminGrantIO;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedHashSet;
@@ -60,7 +61,7 @@ public class InstanceAdminService {
           g.username(),
           "Neo4j",
           g.grantedBy(),
-          g.grantedAtMillis() == null ? null : new Date(g.grantedAtMillis())
+          g.grantedAtMillis() == null ? null : Instant.ofEpochMilli(g.grantedAtMillis()).toString()
         )
       );
     }
@@ -89,7 +90,7 @@ public class InstanceAdminService {
     }
     stampRoleChangedAt(user, now);
     Log.infof("Granted instance-admin role to '%s' (grantedBy=%s)", username, grantedBy);
-    return new InstanceAdminGrantIO(username, "Neo4j", grantedBy, new Date(now));
+    return new InstanceAdminGrantIO(username, "Neo4j", grantedBy, Instant.ofEpochMilli(now).toString());
   }
 
   /**

--- a/backend/src/main/java/de/dlr/shepard/v2/dataobject/io/DataObjectSummaryIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/dataobject/io/DataObjectSummaryIO.java
@@ -1,10 +1,9 @@
 package de.dlr.shepard.v2.dataobject.io;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.dlr.shepard.auth.users.services.DisplayNameResolver;
 import de.dlr.shepard.context.collection.entities.DataObject;
-import java.util.Date;
+import java.time.Instant;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -29,15 +28,14 @@ public class DataObjectSummaryIO {
    * before OGM stamped createdAt reliably.
    */
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  @JsonFormat(shape = JsonFormat.Shape.STRING)
   @Schema(
     readOnly = true,
     nullable = true,
     format = "date-time",
-    example = "2024-08-15T11:18:44.632+00:00",
+    example = "2024-08-15T11:18:44.632Z",
     description = "PRED-V2-SHAPE: creation timestamp. Null for pre-OGM rows."
   )
-  private Date createdAt;
+  private String createdAt;
 
   /**
    * PRED-V2-SHAPE: display name of the user who created this DataObject.
@@ -55,7 +53,9 @@ public class DataObjectSummaryIO {
     this.appId = d.getAppId();
     this.name = d.getName();
     this.status = d.getStatus();
-    this.createdAt = d.getCreatedAt();
+    this.createdAt = d.getCreatedAt() != null
+        ? Instant.ofEpochMilli(d.getCreatedAt().getTime()).toString()
+        : null;
     this.createdBy = d.getCreatedBy() != null
       ? DisplayNameResolver.effectiveDisplayName(d.getCreatedBy())
       : null;

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/io/NotebookReferenceIO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/io/NotebookReferenceIO.java
@@ -1,7 +1,5 @@
 package de.dlr.shepard.v2.labjournal.io;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -72,15 +70,14 @@ public class NotebookReferenceIO {
   private String mimeType;
 
   /** Wall-clock creation time of the parent Reference. */
-  @JsonFormat(shape = JsonFormat.Shape.STRING)
   @Schema(
     readOnly = true,
     nullable = true,
     format = "date-time",
-    example = "2024-08-15T11:18:44.632+00:00",
+    example = "2024-08-15T11:18:44.632Z",
     description = "Creation time of the parent Reference."
   )
-  private Date createdAt;
+  private String createdAt;
 
   /** Display name of the user who created the parent Reference. */
   @Schema(readOnly = true, nullable = true, description = "Creator of the parent Reference.")

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/NotebookRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/NotebookRest.java
@@ -11,6 +11,7 @@ import de.dlr.shepard.context.references.file.entities.FileReference;
 import de.dlr.shepard.context.references.file.services.SingletonFileReferenceService;
 import de.dlr.shepard.data.file.entities.ShepardFile;
 import de.dlr.shepard.v2.common.io.PagedResponseIO;
+import java.time.Instant;
 import de.dlr.shepard.v2.labjournal.io.NotebookReferenceIO;
 import de.dlr.shepard.v2.labjournal.io.NotebookReferenceIO.ReferenceKind;
 import jakarta.enterprise.context.RequestScoped;
@@ -167,7 +168,7 @@ public class NotebookRest {
           filename,
           file.getFileSize(),
           IPYNB_MIME_TYPE,
-          singleton.getCreatedAt(),
+          singleton.getCreatedAt() != null ? Instant.ofEpochMilli(singleton.getCreatedAt().getTime()).toString() : null,
           singleton.getCreatedBy() != null ? DisplayNameResolver.effectiveDisplayName(singleton.getCreatedBy()) : null,
           ReferenceKind.SINGLETON
         )
@@ -194,7 +195,7 @@ public class NotebookRest {
             filename,
             file.getFileSize(),
             IPYNB_MIME_TYPE,
-            bundle.getCreatedAt(),
+            bundle.getCreatedAt() != null ? Instant.ofEpochMilli(bundle.getCreatedAt().getTime()).toString() : null,
             bundle.getCreatedBy() != null
               ? DisplayNameResolver.effectiveDisplayName(bundle.getCreatedBy())
               : null,

--- a/backend/src/main/java/de/dlr/shepard/v2/users/io/UserGroupV2IO.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/users/io/UserGroupV2IO.java
@@ -1,11 +1,10 @@
 package de.dlr.shepard.v2.users.io;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import de.dlr.shepard.auth.users.entities.User;
 import de.dlr.shepard.auth.users.entities.UserGroup;
 import de.dlr.shepard.auth.users.services.DisplayNameResolver;
 import jakarta.validation.constraints.NotBlank;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -35,16 +34,14 @@ public class UserGroupV2IO {
   @Schema(description = "Usernames of group members.")
   private List<String> usernames;
 
-  @JsonFormat(shape = JsonFormat.Shape.STRING)
-  @Schema(readOnly = true, format = "date-time", example = "2024-08-15T11:18:44.632+00:00")
-  private Date createdAt;
+  @Schema(readOnly = true, format = "date-time", example = "2024-08-15T11:18:44.632Z")
+  private String createdAt;
 
   @Schema(readOnly = true)
   private String createdBy;
 
-  @JsonFormat(shape = JsonFormat.Shape.STRING)
-  @Schema(readOnly = true, nullable = true, format = "date-time", example = "2024-08-15T11:18:44.632+00:00")
-  private Date updatedAt;
+  @Schema(readOnly = true, nullable = true, format = "date-time", example = "2024-08-15T11:18:44.632Z")
+  private String updatedAt;
 
   @Schema(readOnly = true, nullable = true)
   private String updatedBy;
@@ -53,11 +50,15 @@ public class UserGroupV2IO {
     this.appId = group.getAppId();
     this.name = group.getName();
     this.usernames = group.getUsers().stream().map(User::getUsername).toList();
-    this.createdAt = group.getCreatedAt();
+    this.createdAt = group.getCreatedAt() != null
+        ? Instant.ofEpochMilli(group.getCreatedAt().getTime()).toString()
+        : null;
     this.createdBy = group.getCreatedBy() != null
       ? DisplayNameResolver.effectiveDisplayName(group.getCreatedBy())
       : null;
-    this.updatedAt = group.getUpdatedAt();
+    this.updatedAt = group.getUpdatedAt() != null
+        ? Instant.ofEpochMilli(group.getUpdatedAt().getTime()).toString()
+        : null;
     this.updatedBy = group.getUpdatedBy() != null
       ? DisplayNameResolver.effectiveDisplayName(group.getUpdatedBy())
       : null;

--- a/plugins/git/src/main/java/de/dlr/shepard/v2/users/io/GitCredentialIO.java
+++ b/plugins/git/src/main/java/de/dlr/shepard/v2/users/io/GitCredentialIO.java
@@ -1,8 +1,7 @@
 package de.dlr.shepard.v2.users.io;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import de.dlr.shepard.auth.users.entities.GitCredential;
-import java.util.Date;
+import java.time.Instant;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -28,15 +27,16 @@ public class GitCredentialIO {
   @Schema(description = "Git username this credential is valid for.")
   private String username;
 
-  @JsonFormat(shape = JsonFormat.Shape.STRING)
-  @Schema(readOnly = true, required = true, format = "date-time", example = "2026-05-12T10:00:00.000+00:00")
-  private Date createdAt;
+  @Schema(readOnly = true, required = true, format = "date-time", example = "2026-05-12T10:00:00Z")
+  private String createdAt;
 
   public GitCredentialIO(GitCredential cred) {
     this.appId = cred.getAppId();
     this.host = cred.getHost();
     this.displayName = cred.getDisplayName();
     this.username = cred.getUsername();
-    this.createdAt = cred.getCreatedAt();
+    this.createdAt = cred.getCreatedAt() != null
+        ? Instant.ofEpochMilli(cred.getCreatedAt().getTime()).toString()
+        : null;
   }
 }


### PR DESCRIPTION
## Summary

Batch conversion of 5 MEDIUM-priority APISIMP rows — all had `@JsonFormat(Shape.STRING)` on `java.util.Date` fields but still exposed `Date` as the Java type, leaving the exact serialization format implicit and the generated TS client with `new Date()` wrappers.

**Rows closed:**
- `APISIMP-INSTANCE-ADMIN-GRANT-DATE-TO-ISO` — `InstanceAdminGrantIO.grantedAt`
- `APISIMP-GIT-CREDENTIAL-DATE-TO-ISO` — `GitCredentialIO.createdAt`
- `APISIMP-DO-SUMMARY-DATE-TO-ISO` — `DataObjectSummaryIO.createdAt`
- `APISIMP-NOTEBOOK-REF-DATE-TO-ISO` — `NotebookReferenceIO.createdAt` (call-site conversion in `NotebookRest.java`)
- `APISIMP-USER-GROUP-DATE-TO-ISO` — `UserGroupV2IO.createdAt`/`updatedAt`

## Changes

**Java backend (7 files):**
- `InstanceAdminGrantIO.java` + `InstanceAdminService.java` — `Date grantedAt` → `String`; `Instant.ofEpochMilli().toString()` at both grant-build sites
- `GitCredentialIO.java` — `Date createdAt` → `String`; `Instant.ofEpochMilli(cred.getCreatedAt().getTime()).toString()` in constructor
- `DataObjectSummaryIO.java` — `Date createdAt` → `String`; `Instant.ofEpochMilli(d.getCreatedAt().getTime()).toString()` in constructor
- `NotebookReferenceIO.java` — `Date createdAt` → `String`; conversion moved to `NotebookRest.java` call sites (uses `@AllArgsConstructor`)
- `UserGroupV2IO.java` — both `Date createdAt`/`updatedAt` → `String`; `Instant.ofEpochMilli().toString()` in constructor

**Generated TS client (5 files):**
- `InstanceAdminGrant.ts`, `GitCredential.ts`, `DataObjectSummary.ts`, `NotebookReference.ts`, `UserGroupV2.ts` — `Date` → `string`; `FromJSONTyped` drops `new Date()` wrappers

**Docs:**
- `aidocs/16-dispatcher-backlog.md` — 5 rows marked `in-progress`
- `aidocs/01-doc-stage-index.md` — regenerated

## Pattern

Same as PRs #2549, #2551, #2552 (already merged): remove `@JsonFormat`, change field to `String`, convert in the factory/constructor via `Instant.ofEpochMilli(...).toString()`, update TS model.

## Test plan

- [ ] CI `mvn verify -pl backend` green (JUnit + JaCoCo + SpotBugs)
- [ ] CI `mvn verify -pl plugins/git` green
- [ ] `npm run typecheck` in `frontend/` green (TS models emit `string`, no `Date` type mismatch)
- [ ] `GET /v2/admin/instance-admins` → `grantedAt` is ISO 8601 UTC string or null
- [ ] `GET /v2/users/me/git-credentials` → `createdAt` is ISO 8601 UTC string
- [ ] `GET /v2/dataobjects/{appId}/predecessors` → `createdAt` is ISO 8601 UTC string
- [ ] `GET /v2/lab-journal/{appId}/notebooks` → `createdAt` is ISO 8601 UTC string
- [ ] `GET /v2/user-groups` → `createdAt`/`updatedAt` are ISO 8601 UTC strings

🤖 fire-593 · V2CONV+MFFD+UI dispatcher · APISIMP date-to-ISO batch

---
_Generated by [Claude Code](https://claude.ai/code/session_018DXhijXgjZZsftEDWxp3cF)_