### PR TITLE
fix(APISIMP-SNAPSHOT-LIST-SIZE-DOC): fix `size` → `pageSize` in CollectionSnapshotRest @Operation description

### DIFF
--- a/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/CollectionSnapshotRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/CollectionSnapshotRest.java
@@ -165,8 +165,8 @@ public class CollectionSnapshotRest {
       "`snapshotCapturedAtMs` (millis-epoch), `snapshotCreatedByUsername`, " +
       "and `entryCount` (number of VersionableEntities recorded in the " +
       "manifest).\n\n" +
-      "Pagination: omit `page` / `size` to get the first 50; supply both " +
-      "to paginate. `size` capped at 200 server-side.\n\n" +
+      "Pagination: omit `page` / `pageSize` to get the first 50; supply both " +
+      "to paginate. `pageSize` capped at 200 server-side.\n\n" +
       "Auth: Read on the Collection.\n\n" +
       "Next step: `GET /v2/snapshots/{appId}/manifest` for the " +
       "per-entity entries of a specific Snapshot, or " +


### PR DESCRIPTION
## Summary

- Fixes a parameter-name mismatch in the `@Operation` description for `GET /v2/collections/{appId}/snapshots`: the description said `size` in two places while the actual `@QueryParam` is `pageSize`.
- Pure documentation change — no runtime behaviour change, no wire-shape change, no migration needed.

## What changed

`CollectionSnapshotRest.java:168–169`:
```diff
-"Pagination: omit `page` / `size` to get the first 50; supply both " +
-"to paginate. `size` capped at 200 server-side.\n\n" +
+"Pagination: omit `page` / `pageSize` to get the first 50; supply both " +
+"to paginate. `pageSize` capped at 200 server-side.\n\n" +
```

## Acceptance criteria

- `@Operation` description matches the `@QueryParam("pageSize")` declared at line 191.
- `mvn verify -pl backend` green.

## Backlog row

`APISIMP-SNAPSHOT-LIST-SIZE-DOC` (XS) — filed in `aidocs/16` as part of fire-594 API-Simplification Sweep.

## Test plan

- [ ] `mvn verify -pl backend` passes (no code logic changed, only a string literal)
- [ ] OpenAPI spec emitted by `/shepard/doc/openapi/v2.json` shows `pageSize` in the snapshot list description

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYG1wPB3K67QCEiHzYQCPE)_