### PR TITLE
fix(APISIMP-MCP-PROVENANCE-EPOCH-MS): convert activity_list since/until args to ISO 8601 strings

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -86,7 +86,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-12-fire564.md`](agent-findings/apisimp-sweep-2026-07-12-fire564.md) | APISIMP sweep — fire-564 (2026-07-12) | 2026-07-12 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-13-fire582.md`](agent-findings/apisimp-sweep-2026-07-13-fire582.md) | APISIMP sweep — fire-582 (2026-07-13) | 2026-07-13 | 2026-07-13 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-13-fire586.md`](agent-findings/apisimp-sweep-2026-07-13-fire586.md) | APISIMP sweep — fire-586 (2026-07-13) | 2026-07-13 | 2026-07-13 |
-| [`aidocs/agent-findings/apisimp-sweep-2026-07-14-fire594.md`](agent-findings/apisimp-sweep-2026-07-14-fire594.md) | API-Simplification Sweep — fire-594 (2026-07-14) | 2026-07-14 | — |
+| [`aidocs/agent-findings/apisimp-sweep-2026-07-14-fire594.md`](agent-findings/apisimp-sweep-2026-07-14-fire594.md) | API-Simplification Sweep — fire-594 (2026-07-14) | 2026-07-14 | 2026-07-14 |
 | [`aidocs/agent-findings/apisimp-sweep-fire355-2026-07-02.md`](agent-findings/apisimp-sweep-fire355-2026-07-02.md) | APISIMP REST Surface Sweep — fire-355 (2026-07-02) | 2026-07-02 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-fire367-2026-07-02.md`](agent-findings/apisimp-sweep-fire367-2026-07-02.md) | APISIMP REST Surface Sweep — fire-367 (2026-07-02) | 2026-07-02 | 2026-07-12 |
 | [`aidocs/agent-findings/apisimp-sweep-fire373-2026-07-02.md`](agent-findings/apisimp-sweep-fire373-2026-07-02.md) | APISIMP REST Surface Sweep — fire-373 (2026-07-02) | 2026-07-02 | 2026-07-12 |

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5336,7 +5336,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/snapshot/resources/CollectionSnapshotRest.java:168–169`; apisimp-sweep-2026-07-14-fire594.md §F1.
 
 ## APISIMP-MCP-PROVENANCE-EPOCH-MS — convert `sinceMillis`/`untilMillis` MCP tool args to ISO 8601 strings (size: XS, sweep: fire-594)
-- **Status:** ⏳ queued
+- **Status:** ✅ shipped (fire-595)
 - **Why:** `ProvenanceMcpTools.java:169–170` declares `@ToolArg Long sinceMillis` and `@ToolArg Long untilMillis` for the `query_activity_log` MCP tool. LLM callers must know the epoch unit (milliseconds). ISO 8601 strings are self-describing and consistent with the REST wire format and the rest of the MCP surface. Lines 134, 143–144 `@Operation` description text references `sinceMillis`/`untilMillis` by name; lines 186–187 echo them back in the response dict.
 - **AC:** `query_activity_log` args renamed `since`/`until` typed `String`; parsed via `Instant.parse(since).toEpochMilli()`; `@Operation` description + response echo updated; `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/mcp/ProvenanceMcpTools.java:169–170,134,143–144,186–187`; apisimp-sweep-2026-07-14-fire594.md §F2.

--- a/backend/src/main/java/de/dlr/shepard/v2/mcp/ProvenanceMcpTools.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/mcp/ProvenanceMcpTools.java
@@ -11,6 +11,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -131,7 +132,7 @@ public class ProvenanceMcpTools {
       "Use this to:\n" +
       "  • Find all actions by a specific user: set agentUsername.\n" +
       "  • Find all mutations on a particular entity kind: set targetKind.\n" +
-      "  • Audit a time window: set sinceMillis + untilMillis.\n" +
+      "  • Audit a time window: set since + until (ISO 8601 UTC, e.g. \"2026-01-01T00:00:00Z\").\n" +
       "  • Combine filters for surgical queries (e.g. all DELETE operations on " +
       "Collections in the last hour).\n\n" +
       "The response is ordered newest-first (descending `startedAt`).\n\n" +
@@ -140,8 +141,8 @@ public class ProvenanceMcpTools {
       "  targetKind    — filter to activities whose target is this entity kind " +
       "(e.g. `Collection`, `DataObject`, `FileReference`).\n" +
       "  targetAppId   — filter to activities targeting this specific entity UUID.\n" +
-      "  sinceMillis   — inclusive lower bound on startedAt (epoch millis).\n" +
-      "  untilMillis   — inclusive upper bound on startedAt (epoch millis).\n" +
+      "  since         — inclusive lower bound on startedAt (ISO 8601 UTC, e.g. 2026-01-01T00:00:00Z).\n" +
+      "  until         — inclusive upper bound on startedAt (ISO 8601 UTC, e.g. 2026-01-01T23:59:59Z).\n" +
       "  limit         — max rows. Default " + DEFAULT_LIMIT + ", max " + MAX_LIMIT + ".\n\n" +
       "Response shape:\n" +
       "{\n" +
@@ -166,8 +167,8 @@ public class ProvenanceMcpTools {
     @ToolArg(required = false, description = "Filter to activities by this agent username.") String agentUsername,
     @ToolArg(required = false, description = "Filter to activities whose target is this entity kind (e.g. `DataObject`).") String targetKind,
     @ToolArg(required = false, description = "Filter to activities targeting this specific entity UUID.") String targetAppId,
-    @ToolArg(required = false, description = "Inclusive lower bound on startedAtMillis (epoch milliseconds).") Long sinceMillis,
-    @ToolArg(required = false, description = "Inclusive upper bound on startedAtMillis (epoch milliseconds).") Long untilMillis,
+    @ToolArg(required = false, description = "Inclusive lower bound on startedAt (ISO 8601 UTC, e.g. 2026-01-01T00:00:00Z).") String since,
+    @ToolArg(required = false, description = "Inclusive upper bound on startedAt (ISO 8601 UTC, e.g. 2026-01-01T23:59:59Z).") String until,
     @ToolArg(required = false, description = "Max rows (default " + DEFAULT_LIMIT + ", max " + MAX_LIMIT + ").") Integer limit
   ) {
     return support.run("activity_list", () -> {
@@ -177,14 +178,16 @@ public class ProvenanceMcpTools {
       String tAppId = blankToNull(targetAppId);
       int effectiveLimit = clamp(limit);
 
-      List<Activity> rows = activityDAO.list(agent, kind, tAppId, sinceMillis, untilMillis, effectiveLimit);
+      Long sinceMs = parseIso(since);
+      Long untilMs = parseIso(until);
+      List<Activity> rows = activityDAO.list(agent, kind, tAppId, sinceMs, untilMs, effectiveLimit);
 
       Map<String, Object> body = new LinkedHashMap<>();
       if (agent != null) body.put("agentUsername", agent);
       if (kind != null) body.put("targetKind", kind);
       if (tAppId != null) body.put("targetAppId", tAppId);
-      if (sinceMillis != null) body.put("sinceMillis", sinceMillis);
-      if (untilMillis != null) body.put("untilMillis", untilMillis);
+      if (sinceMs != null) body.put("since", since.trim());
+      if (untilMs != null) body.put("until", until.trim());
       body.put("limit", effectiveLimit);
       body.put("count", rows.size());
       body.put("activities", toActivityMaps(rows));
@@ -201,6 +204,15 @@ public class ProvenanceMcpTools {
 
   private static String blankToNull(String s) {
     return (s == null || s.isBlank()) ? null : s;
+  }
+
+  private static Long parseIso(String iso) {
+    if (iso == null || iso.isBlank()) return null;
+    try {
+      return Instant.parse(iso.trim()).toEpochMilli();
+    } catch (DateTimeParseException e) {
+      throw McpToolSupport.invalidParams("Invalid ISO 8601 date: \"" + iso.trim() + "\". Expected format: 2026-01-01T00:00:00Z");
+    }
   }
 
   private static String toIso(Long ms) {

--- a/backend/src/test/java/de/dlr/shepard/v2/mcp/ProvenanceMcpToolsTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/mcp/ProvenanceMcpToolsTest.java
@@ -172,7 +172,7 @@ class ProvenanceMcpToolsTest {
     when(activityDAO.list("flo", "Collection", ENTITY_APP_ID, 1000L, 2000L, 10))
       .thenReturn(List.of());
 
-    tools.activityList("flo", "Collection", ENTITY_APP_ID, 1000L, 2000L, 10);
+    tools.activityList("flo", "Collection", ENTITY_APP_ID, "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", 10);
 
     verify(activityDAO).list("flo", "Collection", ENTITY_APP_ID, 1000L, 2000L, 10);
   }
@@ -253,12 +253,20 @@ class ProvenanceMcpToolsTest {
     when(activityDAO.list(eq("flo"), any(), any(), any(), any(), anyInt()))
       .thenReturn(List.of());
 
-    String json = tools.activityList("flo", null, null, 100L, 200L, 5);
+    String json = tools.activityList("flo", null, null, "1970-01-01T00:00:00.100Z", "1970-01-01T00:00:00.200Z", 5);
 
     JsonNode root = new ObjectMapper().readTree(json);
     assertEquals("flo", root.get("agentUsername").asText());
-    assertEquals(100L, root.get("sinceMillis").asLong());
-    assertEquals(200L, root.get("untilMillis").asLong());
+    assertEquals("1970-01-01T00:00:00.100Z", root.get("since").asText());
+    assertEquals("1970-01-01T00:00:00.200Z", root.get("until").asText());
     assertEquals(5, root.get("limit").asInt());
+  }
+
+  @Test
+  void activityListRejectsInvalidIsoDate() {
+    McpException ex = assertThrows(McpException.class,
+      () -> tools.activityList(null, null, null, "not-a-date", null, null));
+    assertEquals(-32602, ex.getJsonRpcErrorCode());
+    assertTrue(ex.getMessage().contains("not-a-date"));
   }
 }


### PR DESCRIPTION
## Summary

- `activity_list` MCP tool `sinceMillis`/`untilMillis` args (`Long`, epoch ms) renamed `since`/`until` (`String`, ISO 8601 UTC) — self-describing, consistent with REST wire format and the rest of the MCP surface.
- New private `parseIso(String)` helper at the tool layer converts to epoch millis for the DAO; throws `McpException -32602` on malformed input.
- Response envelope echoes applied `since`/`until` filters as ISO strings instead of raw millis.
- `@Tool` description and `@ToolArg` descriptions updated accordingly.
- Tests updated: two existing tests revised, one new test for invalid ISO input (`activityListRejectsInvalidIsoDate`).

**Row:** `APISIMP-MCP-PROVENANCE-EPOCH-MS` (XS) — now ✅ shipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLMsBtzFtZhLGz8EzEEQ43)_