### PR TITLE
fix(APISIMP-LJE-NUMERIC-PARENT-ID): use appId-based permission check in lab-journal resources

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5342,7 +5342,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/mcp/ProvenanceMcpTools.java:169–170,134,143–144,186–187`; apisimp-sweep-2026-07-14-fire594.md §F2.
 
 ## APISIMP-LJE-NUMERIC-PARENT-ID — replace `isAccessTypeAllowedForUser(dataObject.getId(), …)` with `isAccessAllowedForDataObjectAppId` in lab-journal resources (size: S, sweep: fire-594)
-- **Status:** ⏳ queued
+- **Status:** 🚧 in-progress (branch: `APISIMP-LJE-NUMERIC-PARENT-ID-fire596`)
 - **Why:** Five call sites in `LabJournalEntryRest` (lines 94, 135, 171), `LabJournalHistoryRest` (line 128), and `LabJournalRenderRest` (line 117) pass `dataObject.getId()` (Neo4j numeric id) to `permissionsService.isAccessTypeAllowedForUser()`. The v2 permission method keyed on `appId` is `isAccessAllowedForDataObjectAppId(dataObject.getAppId(), accessType, caller)`. Using the numeric id is the v1 pattern and couples the permission check to Neo4j internal node ids.
 - **AC:** All five call sites use `isAccessAllowedForDataObjectAppId(dataObject.getAppId(), …)`; existing behaviour preserved; `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalEntryRest.java:94,135,171`; `LabJournalHistoryRest.java:128`; `LabJournalRenderRest.java:117`; apisimp-sweep-2026-07-14-fire594.md §F3.

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalEntryRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalEntryRest.java
@@ -91,7 +91,7 @@ public class LabJournalEntryRest {
 
     var dataObject = entry.getDataObject();
     if (dataObject == null) return problem(PT_NOT_FOUND, "Not found", Response.Status.NOT_FOUND, "LabJournalEntry has no parent DataObject.");
-    if (!permissionsService.isAccessTypeAllowedForUser(dataObject.getId(), AccessType.Read, caller)) {
+    if (!permissionsService.isAccessAllowedForDataObjectAppId(dataObject.getAppId(), AccessType.Read, caller)) {
       return problem(PT_FORBIDDEN, "Forbidden", Response.Status.FORBIDDEN, "Caller lacks Read permission on the parent DataObject.");
     }
 
@@ -132,7 +132,7 @@ public class LabJournalEntryRest {
 
     var dataObject = entry.getDataObject();
     if (dataObject == null) return problem(PT_NOT_FOUND, "Not found", Response.Status.NOT_FOUND, "LabJournalEntry has no parent DataObject.");
-    if (!permissionsService.isAccessTypeAllowedForUser(dataObject.getId(), AccessType.Write, caller)) {
+    if (!permissionsService.isAccessAllowedForDataObjectAppId(dataObject.getAppId(), AccessType.Write, caller)) {
       return problem(PT_FORBIDDEN, "Forbidden", Response.Status.FORBIDDEN, "Caller lacks Write permission on the parent DataObject.");
     }
 
@@ -168,7 +168,7 @@ public class LabJournalEntryRest {
 
     var dataObject = entry.getDataObject();
     if (dataObject == null) return problem(PT_NOT_FOUND, "Not found", Response.Status.NOT_FOUND, "LabJournalEntry has no parent DataObject.");
-    if (!permissionsService.isAccessTypeAllowedForUser(dataObject.getId(), AccessType.Write, caller)) {
+    if (!permissionsService.isAccessAllowedForDataObjectAppId(dataObject.getAppId(), AccessType.Write, caller)) {
       return problem(PT_FORBIDDEN, "Forbidden", Response.Status.FORBIDDEN, "Caller lacks Write permission on the parent DataObject.");
     }
 

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRest.java
@@ -125,7 +125,7 @@ public class LabJournalHistoryRest {
     // Permission check via parent DataObject
     var dataObject = entry.getDataObject();
     if (dataObject == null) return problem(PT_NOT_FOUND, "Not found", Response.Status.NOT_FOUND, "LabJournalEntry has no parent DataObject.");
-    if (!permissionsService.isAccessTypeAllowedForUser(dataObject.getId(), AccessType.Read, caller)) {
+    if (!permissionsService.isAccessAllowedForDataObjectAppId(dataObject.getAppId(), AccessType.Read, caller)) {
       return problem(PT_FORBIDDEN, "Forbidden", Response.Status.FORBIDDEN, "Caller lacks Read permission on the parent DataObject.");
     }
 

--- a/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalRenderRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/labjournal/resources/LabJournalRenderRest.java
@@ -114,7 +114,7 @@ public class LabJournalRenderRest {
     // Permission check via parent DataObject
     var dataObject = entry.getDataObject();
     if (dataObject == null) return problem(PT_NOT_FOUND, "Not found", Response.Status.NOT_FOUND, "LabJournalEntry has no parent DataObject.");
-    if (!permissionsService.isAccessTypeAllowedForUser(dataObject.getId(), AccessType.Read, caller)) {
+    if (!permissionsService.isAccessAllowedForDataObjectAppId(dataObject.getAppId(), AccessType.Read, caller)) {
       return problem(PT_FORBIDDEN, "Forbidden", Response.Status.FORBIDDEN, "Caller lacks Read permission on the parent DataObject.");
     }
 

--- a/backend/src/test/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/labjournal/resources/LabJournalHistoryRestTest.java
@@ -34,6 +34,7 @@ class LabJournalHistoryRestTest {
 
   static final String ENTRY_APP_ID = "01957000-0000-7000-8000-000000000010";
   static final long DO_OGM_ID = 55L;
+  static final String DO_APP_ID = "01957000-0000-7000-8000-000000000055";
   static final long ENTRY_OGM_ID = 101L;
   static final String CALLER = "bob";
 
@@ -68,6 +69,7 @@ class LabJournalHistoryRestTest {
 
     dataObject = new DataObject();
     dataObject.setId(DO_OGM_ID);
+    dataObject.setAppId(DO_APP_ID);
 
     entry = new LabJournalEntry();
     entry.setId(ENTRY_OGM_ID);
@@ -78,7 +80,7 @@ class LabJournalHistoryRestTest {
     when(sc.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn(CALLER);
     when(labJournalEntryDAO.findByAppId(ENTRY_APP_ID)).thenReturn(entry);
-    when(permissionsService.isAccessTypeAllowedForUser(DO_OGM_ID, AccessType.Read, CALLER)).thenReturn(true);
+    when(permissionsService.isAccessAllowedForDataObjectAppId(DO_APP_ID, AccessType.Read, CALLER)).thenReturn(true);
     // Default: entry has no revisions
     when(labJournalEntryRevisionDAO.countByEntry(ENTRY_OGM_ID)).thenReturn(0L);
     when(labJournalEntryRevisionDAO.findByEntry(ENTRY_OGM_ID, 0, 50)).thenReturn(List.of());
@@ -147,7 +149,7 @@ class LabJournalHistoryRestTest {
 
   @Test
   void history_returns403_whenCallerLacksReadPermission() {
-    when(permissionsService.isAccessTypeAllowedForUser(DO_OGM_ID, AccessType.Read, CALLER)).thenReturn(false);
+    when(permissionsService.isAccessAllowedForDataObjectAppId(DO_APP_ID, AccessType.Read, CALLER)).thenReturn(false);
 
     assertThat(resource.history(ENTRY_APP_ID, 0, 50, sc).getStatus()).isEqualTo(403);
   }

--- a/backend/src/test/java/de/dlr/shepard/v2/labjournal/resources/LabJournalRenderRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/labjournal/resources/LabJournalRenderRestTest.java
@@ -27,6 +27,7 @@ class LabJournalRenderRestTest {
 
   static final String APP_ID = "01957000-0000-7000-8000-000000000001";
   static final long DO_OGM_ID = 42L;
+  static final String DO_APP_ID = "01957000-0000-7000-8000-000000000042";
   static final String CALLER = "alice";
   static final String MARKDOWN = "**hello**";
 
@@ -60,6 +61,7 @@ class LabJournalRenderRestTest {
 
     dataObject = new DataObject();
     dataObject.setId(DO_OGM_ID);
+    dataObject.setAppId(DO_APP_ID);
 
     entry = new LabJournalEntry();
     entry.setAppId(APP_ID);
@@ -69,7 +71,7 @@ class LabJournalRenderRestTest {
     when(sc.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn(CALLER);
     when(labJournalEntryDAO.findByAppId(APP_ID)).thenReturn(entry);
-    when(permissionsService.isAccessTypeAllowedForUser(DO_OGM_ID, AccessType.Read, CALLER)).thenReturn(true);
+    when(permissionsService.isAccessAllowedForDataObjectAppId(DO_APP_ID, AccessType.Read, CALLER)).thenReturn(true);
     when(renderService.renderToHtml(MARKDOWN)).thenReturn("<p><strong>hello</strong></p>\n");
   }
 
@@ -96,7 +98,7 @@ class LabJournalRenderRestTest {
 
   @Test
   void render_returns403_whenCallerLacksReadPermission() {
-    when(permissionsService.isAccessTypeAllowedForUser(DO_OGM_ID, AccessType.Read, CALLER)).thenReturn(false);
+    when(permissionsService.isAccessAllowedForDataObjectAppId(DO_APP_ID, AccessType.Read, CALLER)).thenReturn(false);
     assertThat(resource.render(APP_ID, sc).getStatus()).isEqualTo(403);
   }
 


### PR DESCRIPTION
## Summary

Replace five `isAccessTypeAllowedForUser(dataObject.getId(), …)` (numeric Neo4j id) call sites with `isAccessAllowedForDataObjectAppId(dataObject.getAppId(), …)` (UUID appId) in the v2 lab-journal REST layer.

**Files changed:**
- `LabJournalEntryRest.java` — GET (line 94), PUT (line 135), DELETE (line 171)
- `LabJournalRenderRest.java` — GET render (line 117)
- `LabJournalHistoryRest.java` — GET history (line 128)
- `LabJournalRenderRestTest.java` — Mockito stubs updated to appId-keyed method
- `LabJournalHistoryRestTest.java` — Mockito stubs updated to appId-keyed method

**Why:** The v2 surface addresses all entities by `appId` (UUID v7), not by Neo4j internal numeric ids. Passing `dataObject.getId()` (a Neo4j node id) to the `isAccessTypeAllowedForUser(long, …)` overload couples the permission gate to v1 internals. The correct v2 method `isAccessAllowedForDataObjectAppId(String, AccessType, String)` resolves the `:Permissions` node via the entity's `appId`. Five of the six lab-journal REST call sites had this wrong; `CollectionLabJournalEntriesRest` correctly uses the numeric id for a Collection (different :Permissions node shape, not touched).

Backlog row: `APISIMP-LJE-NUMERIC-PARENT-ID` (aidocs/16, fire-594 sweep §F3)

---
_Generated by [Claude Code](https://claude.ai/code/session_018PaCzZ8hPURW3gSjQ4Z8wN)_