### PR TITLE
fix(APISIMP-LINKED-DO-IN-MEMORY-PAGE): push DAO-level SKIP/LIMIT into getLinkedDataObjects

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -464,11 +464,11 @@ section and the `upgrade-overlay` section.
 | [`aidocs/00-index.md`](00-index.md) | aidocs — Index | 2026-05-23 | 2026-07-13 |
 | [`aidocs/100-ui-annoyances.md`](100-ui-annoyances.md) | 100 — Shepard UI annoyances (live captured) | 2026-05-23 | 2026-07-13 |
 | [`aidocs/16-dispatcher-backlog.md`](16-dispatcher-backlog.md) | 16 — Dispatcher Backlog | 2026-05-23 | 2026-07-14 |
-| [`aidocs/34-upstream-upgrade-path.md`](34-upstream-upgrade-path.md) | Upstream upgrade path — `dlr-shepard/shepard 5.2.0` → `noheton/shepard main` | 2026-05-23 | 2026-07-13 |
+| [`aidocs/34-upstream-upgrade-path.md`](34-upstream-upgrade-path.md) | Upstream upgrade path — `dlr-shepard/shepard 5.2.0` → `noheton/shepard main` | 2026-05-23 | 2026-07-14 |
 | [`aidocs/40-ecosystem.md`](40-ecosystem.md) | 40 — Shepard ecosystem | 2026-05-23 | 2026-07-13 |
 | [`aidocs/41-synergy-sweep.md`](41-synergy-sweep.md) | 41 — Synergy sweep: collapse-where-generalisation-helps | 2026-05-23 | 2026-07-13 |
 | [`aidocs/42-vision.md`](42-vision.md) | shepard — Vision (for researchers) | 2026-05-23 | 2026-07-13 |
-| [`aidocs/44-fork-vs-upstream-feature-matrix.md`](44-fork-vs-upstream-feature-matrix.md) | Fork vs Upstream — Feature Matrix | 2026-05-23 | 2026-07-13 |
+| [`aidocs/44-fork-vs-upstream-feature-matrix.md`](44-fork-vs-upstream-feature-matrix.md) | Fork vs Upstream — Feature Matrix | 2026-05-23 | 2026-07-14 |
 | [`aidocs/97-shepard-pipelines.md`](97-shepard-pipelines.md) | 97 — Shepard-pipelines: modern REBAR, Shepard-native | 2026-05-23 | 2026-07-13 |
 | [`aidocs/99-api-annoyances.md`](99-api-annoyances.md) | 99 — Shepard API annoyances (structural clunkiness) | 2026-05-23 | 2026-07-13 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-06-13-fire15.md`](agent-findings/apisimp-sweep-2026-06-13-fire15.md) | APISIMP Sweep — 2026-06-13 (fire #N+15) | 2026-06-13 | 2026-07-13 |

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5366,7 +5366,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java`; apisimp-sweep-2026-07-14-fire594.md §F6.
 
 ## APISIMP-LINKED-DO-IN-MEMORY-PAGE — push DAO-level SKIP/LIMIT into `getLinkedDataObjects` (size: M, sweep: fire-594)
-- **Status:** ⏳ queued
+- **Status:** 🚧 in-progress (PR #TBD, fire-598)
 - **Why:** `ContainersV2Rest.getLinkedDataObjects` (wired by APISIMP-CONTAINER-LINKED-DO-FAKE-PAGED) fetches ALL linked DataObjects from the DAO then slices with `subList(fromIdx, toIdx)` in memory. At MFFD scale a single CFRP container may link to hundreds of DataObjects; each page request materialises the full list in JVM heap.
 - **AC:** DAO-layer `listLinkedDataObjects(appId, skip, limit)` issues `SKIP $skip LIMIT $limit` Cypher; `ContainersV2Rest` removes the in-memory `subList`; existing pagination test still passes; `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java` (`getLinkedDataObjects` method); apisimp-sweep-2026-07-14-fire594.md §F7.

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5366,7 +5366,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/provenance/resources/ProvenanceRest.java`; apisimp-sweep-2026-07-14-fire594.md §F6.
 
 ## APISIMP-LINKED-DO-IN-MEMORY-PAGE — push DAO-level SKIP/LIMIT into `getLinkedDataObjects` (size: M, sweep: fire-594)
-- **Status:** 🚧 in-progress (PR #TBD, fire-598)
+- **Status:** 🚧 in-progress (PR #2560, fire-598)
 - **Why:** `ContainersV2Rest.getLinkedDataObjects` (wired by APISIMP-CONTAINER-LINKED-DO-FAKE-PAGED) fetches ALL linked DataObjects from the DAO then slices with `subList(fromIdx, toIdx)` in memory. At MFFD scale a single CFRP container may link to hundreds of DataObjects; each page request materialises the full list in JVM heap.
 - **AC:** DAO-layer `listLinkedDataObjects(appId, skip, limit)` issues `SKIP $skip LIMIT $limit` Cypher; `ContainersV2Rest` removes the in-memory `subList`; existing pagination test still passes; `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java` (`getLinkedDataObjects` method); apisimp-sweep-2026-07-14-fire594.md §F7.

--- a/backend/src/main/java/de/dlr/shepard/data/file/daos/FileContainerDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/data/file/daos/FileContainerDAO.java
@@ -83,6 +83,37 @@ public class FileContainerDAO extends GenericDAO<FileContainer> {
     return result;
   }
 
+  public long countLinkedDataObjectsByContainerAppId(String containerAppId) {
+    String query =
+      "MATCH (do:DataObject)-[:has_reference]->()-[:is_in_container]->(c:FileContainer) " +
+      "WHERE c.appId = $containerAppId " +
+      "  AND (do.deleted IS NULL OR do.deleted = false) " +
+      "RETURN count(DISTINCT do) AS total";
+    var iter = session.query(query, Map.of("containerAppId", containerAppId)).iterator();
+    if (!iter.hasNext()) return 0L;
+    Object val = iter.next().get("total");
+    return val instanceof Number n ? n.longValue() : 0L;
+  }
+
+  public List<DataObject> findLinkedDataObjectsByContainerAppIdPaged(
+      String containerAppId, int skip, int limit) {
+    String query =
+      "MATCH (do:DataObject)-[:has_reference]->()-[:is_in_container]->(c:FileContainer) " +
+      "WHERE c.appId = $containerAppId " +
+      "  AND (do.deleted IS NULL OR do.deleted = false) " +
+      "RETURN DISTINCT id(do) AS neo4jId, do.appId AS appId " +
+      "ORDER BY appId SKIP $skip LIMIT $limit";
+    var result = new ArrayList<DataObject>();
+    for (var row : session.query(query,
+        Map.of("containerAppId", containerAppId, "skip", skip, "limit", limit))) {
+      Long neo4jId = (Long) row.get("neo4jId");
+      if (neo4jId == null) continue;
+      DataObject loaded = session.load(DataObject.class, neo4jId, DEPTH_ENTITY);
+      if (loaded != null) result.add(loaded);
+    }
+    return result;
+  }
+
   @Override
   public Class<FileContainer> getEntityType() {
     return FileContainer.class;

--- a/backend/src/main/java/de/dlr/shepard/data/file/services/FileContainerService.java
+++ b/backend/src/main/java/de/dlr/shepard/data/file/services/FileContainerService.java
@@ -577,6 +577,14 @@ public class FileContainerService extends AbstractContainerService<FileContainer
     return fileContainerDAO.findLinkedDataObjectsByContainerAppId(containerAppId);
   }
 
+  public long countLinkedDataObjectsByAppId(String containerAppId) {
+    return fileContainerDAO.countLinkedDataObjectsByContainerAppId(containerAppId);
+  }
+
+  public List<DataObject> findLinkedDataObjectsByAppIdPaged(String containerAppId, int skip, int limit) {
+    return fileContainerDAO.findLinkedDataObjectsByContainerAppIdPaged(containerAppId, skip, limit);
+  }
+
   /**
    * FS1c — generate a presigned GET URL so the caller can download
    * bytes directly from the storage backend.

--- a/backend/src/main/java/de/dlr/shepard/data/structureddata/daos/StructuredDataContainerDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/data/structureddata/daos/StructuredDataContainerDAO.java
@@ -82,6 +82,37 @@ public class StructuredDataContainerDAO extends GenericDAO<StructuredDataContain
     return result;
   }
 
+  public long countLinkedDataObjectsByContainerAppId(String containerAppId) {
+    String query =
+      "MATCH (do:DataObject)-[:has_reference]->()-[:is_in_container]->(c:StructuredDataContainer) " +
+      "WHERE c.appId = $containerAppId " +
+      "  AND (do.deleted IS NULL OR do.deleted = false) " +
+      "RETURN count(DISTINCT do) AS total";
+    var iter = session.query(query, Map.of("containerAppId", containerAppId)).iterator();
+    if (!iter.hasNext()) return 0L;
+    Object val = iter.next().get("total");
+    return val instanceof Number n ? n.longValue() : 0L;
+  }
+
+  public List<DataObject> findLinkedDataObjectsByContainerAppIdPaged(
+      String containerAppId, int skip, int limit) {
+    String query =
+      "MATCH (do:DataObject)-[:has_reference]->()-[:is_in_container]->(c:StructuredDataContainer) " +
+      "WHERE c.appId = $containerAppId " +
+      "  AND (do.deleted IS NULL OR do.deleted = false) " +
+      "RETURN DISTINCT id(do) AS neo4jId, do.appId AS appId " +
+      "ORDER BY appId SKIP $skip LIMIT $limit";
+    var result = new ArrayList<DataObject>();
+    for (var row : session.query(query,
+        Map.of("containerAppId", containerAppId, "skip", skip, "limit", limit))) {
+      Long neo4jId = (Long) row.get("neo4jId");
+      if (neo4jId == null) continue;
+      DataObject loaded = session.load(DataObject.class, neo4jId, DEPTH_ENTITY);
+      if (loaded != null) result.add(loaded);
+    }
+    return result;
+  }
+
   @Override
   public Class<StructuredDataContainer> getEntityType() {
     return StructuredDataContainer.class;

--- a/backend/src/main/java/de/dlr/shepard/data/structureddata/services/StructuredDataContainerService.java
+++ b/backend/src/main/java/de/dlr/shepard/data/structureddata/services/StructuredDataContainerService.java
@@ -319,4 +319,12 @@ public class StructuredDataContainerService
   public List<DataObject> findLinkedDataObjectsByAppId(String containerAppId) {
     return structuredDataContainerDAO.findLinkedDataObjectsByContainerAppId(containerAppId);
   }
+
+  public long countLinkedDataObjectsByAppId(String containerAppId) {
+    return structuredDataContainerDAO.countLinkedDataObjectsByContainerAppId(containerAppId);
+  }
+
+  public List<DataObject> findLinkedDataObjectsByAppIdPaged(String containerAppId, int skip, int limit) {
+    return structuredDataContainerDAO.findLinkedDataObjectsByContainerAppIdPaged(containerAppId, skip, limit);
+  }
 }

--- a/backend/src/main/java/de/dlr/shepard/data/timeseries/daos/TimeseriesContainerDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/data/timeseries/daos/TimeseriesContainerDAO.java
@@ -82,6 +82,37 @@ public class TimeseriesContainerDAO extends GenericDAO<TimeseriesContainer> {
     return result;
   }
 
+  public long countLinkedDataObjectsByContainerAppId(String containerAppId) {
+    String query =
+      "MATCH (do:DataObject)-[:has_reference]->()-[:is_in_container]->(c:TimeseriesContainer) " +
+      "WHERE c.appId = $containerAppId " +
+      "  AND (do.deleted IS NULL OR do.deleted = false) " +
+      "RETURN count(DISTINCT do) AS total";
+    var iter = session.query(query, Map.of("containerAppId", containerAppId)).iterator();
+    if (!iter.hasNext()) return 0L;
+    Object val = iter.next().get("total");
+    return val instanceof Number n ? n.longValue() : 0L;
+  }
+
+  public List<DataObject> findLinkedDataObjectsByContainerAppIdPaged(
+      String containerAppId, int skip, int limit) {
+    String query =
+      "MATCH (do:DataObject)-[:has_reference]->()-[:is_in_container]->(c:TimeseriesContainer) " +
+      "WHERE c.appId = $containerAppId " +
+      "  AND (do.deleted IS NULL OR do.deleted = false) " +
+      "RETURN DISTINCT id(do) AS neo4jId, do.appId AS appId " +
+      "ORDER BY appId SKIP $skip LIMIT $limit";
+    var result = new ArrayList<DataObject>();
+    for (var row : session.query(query,
+        Map.of("containerAppId", containerAppId, "skip", skip, "limit", limit))) {
+      Long neo4jId = (Long) row.get("neo4jId");
+      if (neo4jId == null) continue;
+      DataObject loaded = session.load(DataObject.class, neo4jId, DEPTH_ENTITY);
+      if (loaded != null) result.add(loaded);
+    }
+    return result;
+  }
+
   @Override
   public Class<TimeseriesContainer> getEntityType() {
     return TimeseriesContainer.class;

--- a/backend/src/main/java/de/dlr/shepard/data/timeseries/services/TimeseriesContainerService.java
+++ b/backend/src/main/java/de/dlr/shepard/data/timeseries/services/TimeseriesContainerService.java
@@ -149,6 +149,14 @@ public class TimeseriesContainerService extends AbstractContainerService<Timeser
     return timeseriesContainerDAO.findLinkedDataObjectsByContainerAppId(containerAppId);
   }
 
+  public long countLinkedDataObjectsByAppId(String containerAppId) {
+    return timeseriesContainerDAO.countLinkedDataObjectsByContainerAppId(containerAppId);
+  }
+
+  public List<DataObject> findLinkedDataObjectsByAppIdPaged(String containerAppId, int skip, int limit) {
+    return timeseriesContainerDAO.findLinkedDataObjectsByContainerAppIdPaged(containerAppId, skip, limit);
+  }
+
   /**
    * Deletes a TimeseriesContainer in Neo4j
    *

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/handlers/FileContainerKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/handlers/FileContainerKindHandler.java
@@ -158,6 +158,20 @@ public class FileContainerKindHandler implements ContainerKindHandler {
       service.findLinkedDataObjectsByAppId(appId).stream().map(DataObjectIO::new).toList()
     );
   }
+
+  @Override
+  public Optional<Long> countLinkedDataObjects(String appId) {
+    return Optional.of(service.countLinkedDataObjectsByAppId(appId));
+  }
+
+  @Override
+  public Optional<List<DataObjectIO>> listLinkedDataObjectsPaged(
+      String appId, int skip, int limit) {
+    return Optional.of(
+      service.findLinkedDataObjectsByAppIdPaged(appId, skip, limit)
+             .stream().map(DataObjectIO::new).toList()
+    );
+  }
   // ─── APISIMP-CONT-NS-COLLAPSE-5 ──────────────────────────────────────────
 
   private static final int DEFAULT_SIZE = 400;

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/handlers/StructuredDataContainerKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/handlers/StructuredDataContainerKindHandler.java
@@ -130,6 +130,20 @@ public class StructuredDataContainerKindHandler implements ContainerKindHandler 
   }
 
   @Override
+  public Optional<Long> countLinkedDataObjects(String appId) {
+    return Optional.of(service.countLinkedDataObjectsByAppId(appId));
+  }
+
+  @Override
+  public Optional<List<DataObjectIO>> listLinkedDataObjectsPaged(
+      String appId, int skip, int limit) {
+    return Optional.of(
+      service.findLinkedDataObjectsByAppIdPaged(appId, skip, limit)
+             .stream().map(DataObjectIO::new).toList()
+    );
+  }
+
+  @Override
   public Optional<ContainerStatsIO> getStats(String appId) {
     StructuredDataContainer c = dao.findByAppId(appId).filter(x -> !x.isDeleted()).orElse(null);
     if (c == null) return Optional.empty();

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/handlers/TimeseriesContainerKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/handlers/TimeseriesContainerKindHandler.java
@@ -228,6 +228,20 @@ public class TimeseriesContainerKindHandler implements ContainerKindHandler {
     );
   }
 
+  @Override
+  public Optional<Long> countLinkedDataObjects(String appId) {
+    return Optional.of(service.countLinkedDataObjectsByAppId(appId));
+  }
+
+  @Override
+  public Optional<List<DataObjectIO>> listLinkedDataObjectsPaged(
+      String appId, int skip, int limit) {
+    return Optional.of(
+      service.findLinkedDataObjectsByAppIdPaged(appId, skip, limit)
+             .stream().map(DataObjectIO::new).toList()
+    );
+  }
+
   // ── APISIMP-CONT-NS-COLLAPSE-2: channel overrides ─────────────────────────
 
   /**

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java
@@ -605,18 +605,18 @@ public class ContainersV2Rest {
     Response gate = gate(resolved.get().container(), AccessType.Read, caller);
     if (gate != null) return gate;
 
-    var linkedOpt = resolved.get().handler().listLinkedDataObjects(appId);
-    if (linkedOpt.isEmpty()) {
+    var countOpt = resolved.get().handler().countLinkedDataObjects(appId);
+    if (countOpt.isEmpty()) {
       return problem("/problems/containers.linked-data-objects-unsupported",
           "Container kind does not support linked DataObjects",
           Response.Status.UNSUPPORTED_MEDIA_TYPE,
           "Container kind '" + resolved.get().handler().kind() + "' has no linked-DataObject concept");
     }
-    List<DataObjectIO> linkedList = linkedOpt.get();
-    int total = linkedList.size();
-    int fromIdx = Math.min((int) Math.min((long) page * pageSize, Integer.MAX_VALUE), total);
-    int toIdx = Math.min(fromIdx + pageSize, total);
-    List<DataObjectIO> pageItems = linkedList.subList(fromIdx, toIdx);
+    long total = countOpt.get();
+    int skip = (int) Math.min((long) page * pageSize, Integer.MAX_VALUE);
+    List<DataObjectIO> pageItems = resolved.get().handler()
+        .listLinkedDataObjectsPaged(appId, skip, pageSize)
+        .orElse(List.of());
     return Response.ok(new PagedResponseIO<>(pageItems, total, page, pageSize)).build();
   }
 

--- a/backend/src/main/java/de/dlr/shepard/v2/containers/spi/ContainerKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/containers/spi/ContainerKindHandler.java
@@ -273,6 +273,47 @@ public interface ContainerKindHandler {
     return Optional.empty();
   }
 
+  /**
+   * APISIMP-LINKED-DO-IN-MEMORY-PAGE — total count of linked DataObjects for
+   * this container, used to build the {@code total} field in a paged response
+   * without materialising the full list.
+   *
+   * <p>The default falls back to {@link #listLinkedDataObjects(String)} so that
+   * plugin handlers that have not yet overridden this method still work correctly
+   * (at the cost of the full-list materialisation). Core kinds override with a
+   * dedicated {@code COUNT(DISTINCT do)} Cypher query.
+   *
+   * @return the total count, or {@link Optional#empty()} when this kind has no
+   *         linked-DataObject concept (→ 415).
+   */
+  default Optional<Long> countLinkedDataObjects(String appId) {
+    return listLinkedDataObjects(appId).map(list -> (long) list.size());
+  }
+
+  /**
+   * APISIMP-LINKED-DO-IN-MEMORY-PAGE — one page of linked DataObjects, ordered
+   * by {@code do.appId} and sliced at the DAO level via Cypher
+   * {@code SKIP $skip LIMIT $limit}.
+   *
+   * <p>The default falls back to {@link #listLinkedDataObjects(String)} +
+   * in-memory {@code subList} for backward-compatible plugin handlers. Core
+   * kinds override with an efficient paged Cypher query.
+   *
+   * @param skip   number of rows to skip (= {@code page × pageSize})
+   * @param limit  maximum rows to return (= {@code pageSize})
+   * @return one page of DataObjectIO, or {@link Optional#empty()} when this kind
+   *         has no linked-DataObject concept (→ 415).
+   */
+  default Optional<List<DataObjectIO>> listLinkedDataObjectsPaged(
+      String appId, int skip, int limit) {
+    return listLinkedDataObjects(appId).map(all -> {
+      int total = all.size();
+      int fromIdx = Math.min(skip, total);
+      int toIdx = Math.min(fromIdx + limit, total);
+      return all.subList(fromIdx, toIdx);
+    });
+  }
+
   // ── APISIMP-CONT-NS-COLLAPSE-2: channel endpoints ──────────────────────────
 
   /**

--- a/backend/src/test/java/de/dlr/shepard/v2/containers/handlers/ContainerKindHandlersTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/containers/handlers/ContainerKindHandlersTest.java
@@ -211,6 +211,25 @@ class ContainerKindHandlersTest {
     verify(fileService).findLinkedDataObjectsByAppId("file-1");
   }
 
+  @Test
+  void file_countLinkedDataObjects_delegatesToService() {
+    when(fileService.countLinkedDataObjectsByAppId("file-1")).thenReturn(3L);
+    var out = fileHandler.countLinkedDataObjects("file-1");
+    assertTrue(out.isPresent());
+    assertEquals(3L, out.get());
+    verify(fileService).countLinkedDataObjectsByAppId("file-1");
+  }
+
+  @Test
+  void file_listLinkedDataObjectsPaged_delegatesToService() {
+    var d = linkedDataObject("do-1");
+    when(fileService.findLinkedDataObjectsByAppIdPaged("file-1", 0, 10)).thenReturn(List.of(d));
+    var out = fileHandler.listLinkedDataObjectsPaged("file-1", 0, 10);
+    assertTrue(out.isPresent());
+    assertEquals(1, out.get().size());
+    verify(fileService).findLinkedDataObjectsByAppIdPaged("file-1", 0, 10);
+  }
+
   // ─── timeseries handler ────────────────────────────────────────────────────
 
   @Test
@@ -283,6 +302,25 @@ class ContainerKindHandlersTest {
     assertTrue(out.isPresent());
     assertEquals(1, out.get().size());
     verify(tsService).findLinkedDataObjectsByAppId("ts-1");
+  }
+
+  @Test
+  void ts_countLinkedDataObjects_delegatesToService() {
+    when(tsService.countLinkedDataObjectsByAppId("ts-1")).thenReturn(7L);
+    var out = tsHandler.countLinkedDataObjects("ts-1");
+    assertTrue(out.isPresent());
+    assertEquals(7L, out.get());
+    verify(tsService).countLinkedDataObjectsByAppId("ts-1");
+  }
+
+  @Test
+  void ts_listLinkedDataObjectsPaged_delegatesToService() {
+    var d = linkedDataObject("do-2");
+    when(tsService.findLinkedDataObjectsByAppIdPaged("ts-1", 5, 10)).thenReturn(List.of(d));
+    var out = tsHandler.listLinkedDataObjectsPaged("ts-1", 5, 10);
+    assertTrue(out.isPresent());
+    assertEquals(1, out.get().size());
+    verify(tsService).findLinkedDataObjectsByAppIdPaged("ts-1", 5, 10);
   }
 
   // ─── structured-data handler ────────────────────────────────────────────────
@@ -361,6 +399,25 @@ class ContainerKindHandlersTest {
     assertTrue(out.isPresent());
     assertEquals(1, out.get().size());
     verify(sdService).findLinkedDataObjectsByAppId("sd-1");
+  }
+
+  @Test
+  void sd_countLinkedDataObjects_delegatesToService() {
+    when(sdService.countLinkedDataObjectsByAppId("sd-1")).thenReturn(2L);
+    var out = sdHandler.countLinkedDataObjects("sd-1");
+    assertTrue(out.isPresent());
+    assertEquals(2L, out.get());
+    verify(sdService).countLinkedDataObjectsByAppId("sd-1");
+  }
+
+  @Test
+  void sd_listLinkedDataObjectsPaged_delegatesToService() {
+    var d = linkedDataObject("do-3");
+    when(sdService.findLinkedDataObjectsByAppIdPaged("sd-1", 10, 5)).thenReturn(List.of(d));
+    var out = sdHandler.listLinkedDataObjectsPaged("sd-1", 10, 5);
+    assertTrue(out.isPresent());
+    assertEquals(1, out.get().size());
+    verify(sdService).findLinkedDataObjectsByAppIdPaged("sd-1", 10, 5);
   }
 
   // ─── findLinkedDataObjectAppIds ────────────────────────────────────────────

--- a/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/containers/resources/ContainersV2RestTest.java
@@ -611,7 +611,8 @@ class ContainersV2RestTest {
     dataObject.setAppId("do-app-1");
     dataObject.setCollection(col);
     var doIo = new de.dlr.shepard.context.collection.io.DataObjectIO(dataObject);
-    when(handler.listLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.of(List.of(doIo)));
+    when(handler.countLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.of(1L));
+    when(handler.listLinkedDataObjectsPaged(eq(APP_ID), eq(0), eq(50))).thenReturn(Optional.of(List.of(doIo)));
     var r = resource.getLinkedDataObjects(APP_ID, 0, 50, securityContext);
     assertEquals(200, r.getStatus());
     var page = (PagedResponseIO<?>) r.getEntity();
@@ -622,7 +623,8 @@ class ContainersV2RestTest {
   @Test
   void getLinkedDataObjects_returns200WithEmptyList() {
     allowRead();
-    when(handler.listLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.of(List.of()));
+    when(handler.countLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.of(0L));
+    when(handler.listLinkedDataObjectsPaged(eq(APP_ID), eq(0), eq(50))).thenReturn(Optional.of(List.of()));
     var r = resource.getLinkedDataObjects(APP_ID, 0, 50, securityContext);
     assertEquals(200, r.getStatus());
     var page = (PagedResponseIO<?>) r.getEntity();
@@ -642,8 +644,12 @@ class ContainersV2RestTest {
       do_.setCollection(col);
       items.add(new de.dlr.shepard.context.collection.io.DataObjectIO(do_));
     }
-    when(handler.listLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.of(items));
-    // page 0, size 2 → items 0–1, total 5
+    when(handler.countLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.of(5L));
+    when(handler.listLinkedDataObjectsPaged(eq(APP_ID), eq(0), eq(2)))
+        .thenReturn(Optional.of(items.subList(0, 2)));
+    when(handler.listLinkedDataObjectsPaged(eq(APP_ID), eq(4), eq(2)))
+        .thenReturn(Optional.of(items.subList(4, 5)));
+    // page 0, size 2 → skip=0, limit=2 → items 0–1, total 5
     var r = resource.getLinkedDataObjects(APP_ID, 0, 2, securityContext);
     assertEquals(200, r.getStatus());
     var page = (PagedResponseIO<?>) r.getEntity();
@@ -651,7 +657,7 @@ class ContainersV2RestTest {
     assertEquals(2, page.items().size());
     assertEquals(0, page.page());
     assertEquals(2, page.pageSize());
-    // page 2, size 2 → items 4–4, total 5
+    // page 2, size 2 → skip=4, limit=2 → item 4, total 5
     var r2 = resource.getLinkedDataObjects(APP_ID, 2, 2, securityContext);
     var page2 = (PagedResponseIO<?>) r2.getEntity();
     assertEquals(5, page2.total());
@@ -662,7 +668,7 @@ class ContainersV2RestTest {
   void getLinkedDataObjects_returns415WhenKindHasNoLinkedConcept() {
     allowRead();
     when(handler.kind()).thenReturn("hdf");
-    when(handler.listLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.empty());
+    when(handler.countLinkedDataObjects(eq(APP_ID))).thenReturn(Optional.empty());
     var r = resource.getLinkedDataObjects(APP_ID, 0, 50, securityContext);
     assertEquals(415, r.getStatus());
     assertEquals("application/problem+json", r.getMediaType().toString());


### PR DESCRIPTION
## Summary

- **Root cause:** `ContainersV2Rest.getLinkedDataObjects` called `handler.listLinkedDataObjects(appId)` which materialised ALL linked DataObjects into JVM heap, then sliced a page with `subList()`. At MFFD scale (hundreds of DataObjects per CFRP container) every page request serialised the full list.
- **Fix:** Two new `ContainerKindHandler` SPI methods — `countLinkedDataObjects(appId)` and `listLinkedDataObjectsPaged(appId, skip, limit)` — each with backward-compatible defaults (falling through to the existing `listLinkedDataObjects` so plugin handlers keep working). All three in-tree handlers (file, timeseries, structured-data) override both methods with DAO-level Cypher `SKIP $skip LIMIT $limit` queries. `ContainersV2Rest` now calls `count` + `paged` instead of `listAll` + `subList`.
- **Scope:** backend only; no v1 wire shape changes; no frontend changes needed.

## Changes

| Layer | Change |
|---|---|
| `FileContainerDAO` | `countLinkedDataObjectsByContainerAppId` + `findLinkedDataObjectsByContainerAppIdPaged` |
| `StructuredDataContainerDAO` | same two methods |
| `TimeseriesContainerDAO` | same two methods |
| `*ContainerService` × 3 | delegate wrappers for the new DAO methods |
| `ContainerKindHandler` SPI | `countLinkedDataObjects` + `listLinkedDataObjectsPaged` default methods |
| `*ContainerKindHandler` × 3 | override both with DAO-native pagination |
| `ContainersV2Rest` | replaces `subList` with `count` + `paged` calls |
| Tests | 4 updated mocks in `ContainersV2RestTest`; 6 new handler delegation tests in `ContainerKindHandlersTest` |

## Test plan

- [ ] `ContainersV2RestTest` — 4 updated tests: 200+list, 200+empty, paginated, 415-unsupported-kind
- [ ] `ContainerKindHandlersTest` — 6 new: `file/ts/sd_countLinkedDataObjects_delegatesToService`, `file/ts/sd_listLinkedDataObjectsPaged_delegatesToService`
- [ ] CI `mvn verify -pl backend` green (full JaCoCo + SpotBugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rrw9AoKJbeVK7PYcPffLLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rrw9AoKJbeVK7PYcPffLLm)_