### PR TITLE
feat(APISIMP-CROSSDO-PAGED-MISUSE): add real page/pageSize params + X-Total-Count to cross-DO bulk endpoint

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -514,7 +514,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-14-fire599.md`](agent-findings/apisimp-sweep-2026-07-14-fire599.md) | APISIMP Sweep — 2026-07-14 (fire-599) | 2026-07-14 | 2026-07-14 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-14-fire604.md`](agent-findings/apisimp-sweep-2026-07-14-fire604.md) | APISIMP Sweep — 2026-07-14 (fire-604) | 2026-07-14 | 2026-07-14 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-14-fire605.md`](agent-findings/apisimp-sweep-2026-07-14-fire605.md) | APISIMP Sweep — 2026-07-14 (fire-605) | 2026-07-14 | 2026-07-14 |
-| [`aidocs/agent-findings/apisimp-sweep-2026-07-16-fire623.md`](agent-findings/apisimp-sweep-2026-07-16-fire623.md) | APISIMP Sweep — 2026-07-16 (fire-623) | 2026-07-16 | — |
+| [`aidocs/agent-findings/apisimp-sweep-2026-07-16-fire623.md`](agent-findings/apisimp-sweep-2026-07-16-fire623.md) | APISIMP Sweep — 2026-07-16 (fire-623) | 2026-07-16 | 2026-07-16 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-16.md`](agent-findings/apisimp-sweep-2026-07-16.md) | APISIMP Sweep — 2026-07-16 (fire-622) | 2026-07-16 | 2026-07-16 |
 | [`aidocs/agent-findings/apisimp-sweep-fire341-2026-07-01.md`](agent-findings/apisimp-sweep-fire341-2026-07-01.md) | API Simplification Sweep — fire-341 (2026-07-01) | 2026-07-01 | 2026-07-14 |
 | [`aidocs/agent-findings/apisimp-sweep-fire342-2026-07-01.md`](agent-findings/apisimp-sweep-fire342-2026-07-01.md) | APISIMP Sweep — 2026-07-01 (fire-342) | 2026-07-01 | 2026-07-14 |

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5703,7 +5703,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/quality/resources/CollectionDQRRest.java:88,101`; `backend/src/main/java/de/dlr/shepard/v2/publish/resources/FlatPublicationsRest.java:89,137`; `backend/src/main/java/de/dlr/shepard/v2/semantic/resources/VocabularyBrowseRest.java:114,166,220,228`; `backend/src/main/java/de/dlr/shepard/v2/semantic/resources/SemanticTermSearchRest.java:244`; apisimp-sweep-2026-07-16-fire623.md §Finding F1.
 
 ## APISIMP-CROSSDO-PAGED-MISUSE — CrossDoBulkDataRest wraps non-paged result in PagedResponseIO (size: XS, sweep: fire-623)
-- **Status:** 🔲 queued
+- **Status:** 🔧 in-PR (fire-625)
 - **Why:** `POST /v2/data-objects/cross-bulk` (`CrossDoBulkDataRest.java:201`) returns `new PagedResponseIO<>(out, out.size(), 0, out.size())` — always `page=0, pageSize=N`. There are no `page`/`pageSize` query params, so callers see a paging envelope with no way to page. The `@APIResponse(200)` declares `@Schema(implementation = PagedResponseIO.class)` but the semantic is misleading: total == pageSize == items.size().
 - **Fix (Option A, preferred):** Add `@QueryParam("page") @DefaultValue("0") int page` and `@QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(100) int pageSize` to `getCrossDoBulkData()`; slice `out` accordingly; chain `.header("X-Total-Count", out.size())`. Option B: return plain `List<CrossDoSeriesIO>` + update `@APIResponse(200)` schema.
 - **AC:** `@APIResponse(200)` schema matches the actual JSON shape. No degenerate `{total=N, page=0, pageSize=N}` envelope when paging is not offered. `mvn verify -pl backend` green.

--- a/backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRest.java
@@ -14,8 +14,12 @@ import de.dlr.shepard.v2.timeseries.services.CrossDoChannelResolver;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -33,6 +37,7 @@ import java.util.Set;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
@@ -113,6 +118,7 @@ public class CrossDoBulkDataRest {
   @APIResponse(
     responseCode = "200",
     description = "Resolved series across the requested DataObjects.",
+    headers = @Header(name = "X-Total-Count", description = "Total resolved DataObjects before page-slicing.", schema = @Schema(type = SchemaType.INTEGER)),
     content = @Content(schema = @Schema(implementation = PagedResponseIO.class)))
   @APIResponse(responseCode = "400", description = "Validation error on request body, or unsupported/missing `kind`.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
@@ -123,6 +129,8 @@ public class CrossDoBulkDataRest {
       schema = @Schema(enumeration = {"timeseries"}, defaultValue = "timeseries")
     )
     @QueryParam("kind") String kind,
+    @QueryParam("page") @DefaultValue("0") @PositiveOrZero int page,
+    @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(100) int pageSize,
     @NotNull @Valid CrossDoBulkDataRequestIO body,
     @Context SecurityContext sc
   ) {
@@ -198,7 +206,11 @@ public class CrossDoBulkDataRest {
       out.add(new CrossDoSeriesIO(doAppId, doName, predicate, pick.symbolicName(), points));
     }
 
-    return Response.ok(new PagedResponseIO<>(out, out.size(), 0, out.size()))
+    int fromIndex = page * pageSize;
+    int toIndex = Math.min(fromIndex + pageSize, out.size());
+    List<CrossDoSeriesIO> pageData = fromIndex >= out.size() ? List.of() : out.subList(fromIndex, toIndex);
+    return Response.ok(new PagedResponseIO<>(pageData, out.size(), page, pageSize))
+        .header("X-Total-Count", (long) out.size())
         .build();
   }
 

--- a/backend/src/test/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRestTest.java
@@ -93,7 +93,7 @@ public class CrossDoBulkDataRestTest {
   @Test
   void missingKind_returns400() {
     Response resp = resource.getCrossDoBulkData(
-      null,
+      null, 0, 50,
       new CrossDoBulkDataRequestIO(List.of(DO_A), PREDICATE, START_ISO, END_ISO, 500),
       securityContext
     );
@@ -104,7 +104,7 @@ public class CrossDoBulkDataRestTest {
   @Test
   void unknownKind_returns400() {
     Response resp = resource.getCrossDoBulkData(
-      "file",
+      "file", 0, 50,
       new CrossDoBulkDataRequestIO(List.of(DO_A), PREDICATE, START_ISO, END_ISO, 500),
       securityContext
     );
@@ -117,7 +117,7 @@ public class CrossDoBulkDataRestTest {
   @Test
   void badIsoTimestamp_returns400() {
     Response resp = resource.getCrossDoBulkData(
-      "timeseries",
+      "timeseries", 0, 50,
       new CrossDoBulkDataRequestIO(List.of(DO_A), PREDICATE, "not-a-timestamp", END_ISO, 500),
       securityContext
     );
@@ -133,7 +133,7 @@ public class CrossDoBulkDataRestTest {
     when(anon.getUserPrincipal()).thenReturn(null);
 
     Response resp = resource.getCrossDoBulkData(
-      "timeseries",
+      "timeseries", 0, 50,
       new CrossDoBulkDataRequestIO(List.of(DO_A), PREDICATE, START_ISO, END_ISO, 500),
       anon
     );
@@ -161,7 +161,7 @@ public class CrossDoBulkDataRestTest {
       .thenReturn(points);
 
     Response resp = resource.getCrossDoBulkData(
-      "timeseries",
+      "timeseries", 0, 50,
       new CrossDoBulkDataRequestIO(List.of(DO_A), PREDICATE, START_ISO, END_ISO, 500),
       securityContext
     );
@@ -188,7 +188,7 @@ public class CrossDoBulkDataRestTest {
     when(resolverMock.resolveChannelsByPredicate(DO_B, PREDICATE)).thenReturn(List.of());
 
     Response resp = resource.getCrossDoBulkData(
-      "timeseries",
+      "timeseries", 0, 50,
       new CrossDoBulkDataRequestIO(List.of(DO_B), PREDICATE, START_ISO, END_ISO, 500),
       securityContext
     );
@@ -216,7 +216,7 @@ public class CrossDoBulkDataRestTest {
     when(resolverMock.resolveChannelsByPredicate(DO_A, PREDICATE)).thenReturn(List.of());
 
     Response resp = resource.getCrossDoBulkData(
-      "timeseries",
+      "timeseries", 0, 50,
       new CrossDoBulkDataRequestIO(List.of(DO_FORBIDDEN, DO_A), PREDICATE, START_ISO, END_ISO, 500),
       securityContext
     );
@@ -238,7 +238,7 @@ public class CrossDoBulkDataRestTest {
     when(daoMock.findNamesByAppIds(any())).thenReturn(Map.of());
 
     Response resp = resource.getCrossDoBulkData(
-      "timeseries",
+      "timeseries", 0, 50,
       new CrossDoBulkDataRequestIO(List.of(DO_UNKNOWN), PREDICATE, START_ISO, END_ISO, 500),
       securityContext
     );
@@ -272,7 +272,7 @@ public class CrossDoBulkDataRestTest {
     when(resolverMock.resolveChannelsByPredicate(DO_B, PREDICATE)).thenReturn(List.of());
 
     Response resp = resource.getCrossDoBulkData(
-      "timeseries",
+      "timeseries", 0, 50,
       new CrossDoBulkDataRequestIO(
         List.of(DO_A, DO_B, DO_FORBIDDEN, DO_C),
         PREDICATE, START_ISO, END_ISO, 500
@@ -315,6 +315,73 @@ public class CrossDoBulkDataRestTest {
     assertEquals(1234, CrossDoBulkDataRest.clampDownsample(1234));
   }
 
+  // ── Pagination: page/pageSize slice the results correctly ────────────────
+
+  @Test
+  void pagination_page0PageSize1_returnsFirstItemOfThree() {
+    when(permsMock.filterAllowedDataObjectAppIds(any(), eq(AccessType.Read), eq(CALLER)))
+      .thenReturn(Set.of(DO_A, DO_B, DO_C));
+    when(daoMock.findNamesByAppIds(any())).thenReturn(Map.of(DO_A, "A", DO_B, "B", DO_C, "C"));
+    when(resolverMock.resolveChannelsByPredicate(any(), eq(PREDICATE))).thenReturn(List.of());
+
+    Response resp = resource.getCrossDoBulkData(
+      "timeseries", 0, 1,
+      new CrossDoBulkDataRequestIO(List.of(DO_A, DO_B, DO_C), PREDICATE, START_ISO, END_ISO, 500),
+      securityContext
+    );
+
+    assertEquals(200, resp.getStatus());
+    @SuppressWarnings("unchecked")
+    PagedResponseIO<CrossDoSeriesIO> body = (PagedResponseIO<CrossDoSeriesIO>) resp.getEntity();
+    assertEquals(3L, body.total(), "total must count all resolved DOs, not just the page");
+    assertEquals(1, body.pageSize());
+    assertEquals(0, body.page());
+    assertEquals(1, body.items().size());
+    assertEquals(DO_A, body.items().get(0).dataObjectAppId());
+    assertEquals(3L, resp.getHeaders().getFirst("X-Total-Count"), "X-Total-Count must equal total");
+  }
+
+  @Test
+  void pagination_page1PageSize1_returnsSecondItem() {
+    when(permsMock.filterAllowedDataObjectAppIds(any(), eq(AccessType.Read), eq(CALLER)))
+      .thenReturn(Set.of(DO_A, DO_B, DO_C));
+    when(daoMock.findNamesByAppIds(any())).thenReturn(Map.of(DO_A, "A", DO_B, "B", DO_C, "C"));
+    when(resolverMock.resolveChannelsByPredicate(any(), eq(PREDICATE))).thenReturn(List.of());
+
+    Response resp = resource.getCrossDoBulkData(
+      "timeseries", 1, 1,
+      new CrossDoBulkDataRequestIO(List.of(DO_A, DO_B, DO_C), PREDICATE, START_ISO, END_ISO, 500),
+      securityContext
+    );
+
+    assertEquals(200, resp.getStatus());
+    @SuppressWarnings("unchecked")
+    PagedResponseIO<CrossDoSeriesIO> body = (PagedResponseIO<CrossDoSeriesIO>) resp.getEntity();
+    assertEquals(3L, body.total());
+    assertEquals(1, body.items().size());
+    assertEquals(DO_B, body.items().get(0).dataObjectAppId());
+  }
+
+  @Test
+  void pagination_beyondEnd_returnsEmptyItemsWithCorrectTotal() {
+    when(permsMock.filterAllowedDataObjectAppIds(any(), eq(AccessType.Read), eq(CALLER)))
+      .thenReturn(Set.of(DO_A));
+    when(daoMock.findNamesByAppIds(any())).thenReturn(Map.of(DO_A, "A"));
+    when(resolverMock.resolveChannelsByPredicate(any(), eq(PREDICATE))).thenReturn(List.of());
+
+    Response resp = resource.getCrossDoBulkData(
+      "timeseries", 5, 10,
+      new CrossDoBulkDataRequestIO(List.of(DO_A), PREDICATE, START_ISO, END_ISO, 500),
+      securityContext
+    );
+
+    assertEquals(200, resp.getStatus());
+    @SuppressWarnings("unchecked")
+    PagedResponseIO<CrossDoSeriesIO> body = (PagedResponseIO<CrossDoSeriesIO>) resp.getEntity();
+    assertEquals(1L, body.total(), "total must still reflect all resolved DOs even when page is beyond end");
+    assertTrue(body.items().isEmpty(), "items must be empty when page is beyond last item");
+  }
+
   // ── Multi-DO LTTB-routing is called once per channel-bearing DO ──────────
 
   @Test
@@ -331,7 +398,7 @@ public class CrossDoBulkDataRestTest {
       .thenReturn(List.of());
 
     resource.getCrossDoBulkData(
-      "timeseries",
+      "timeseries", 0, 50,
       new CrossDoBulkDataRequestIO(List.of(DO_A, DO_B), PREDICATE, START_ISO, END_ISO, 500),
       securityContext
     );


### PR DESCRIPTION
## Summary

`POST /v2/data-objects/cross-bulk` previously returned a `PagedResponseIO` wrapper with a degenerate envelope — `{total=N, page=0, pageSize=N}` — but offered no `page`/`pageSize` query parameters. Callers saw a paging envelope with no way to actually page.

**Changes:**
- Add `@QueryParam("page") @DefaultValue("0") @PositiveOrZero int page` to `getCrossDoBulkData()`
- Add `@QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(100) int pageSize`
- Slice the resolved-series list: `out.subList(fromIndex, toIndex)` — `total` still reflects the full count before slicing
- Chain `.header("X-Total-Count", (long) out.size())` on the 200 `Response` builder
- Declare `@Header(name = "X-Total-Count", ...)` on the `@APIResponse(200)` annotation (OpenAPI spec parity)
- Update 10 existing test call sites to pass `0, 50` (default page/pageSize)
- Add 3 new pagination tests: page0/pageSize1 returns first item; page1/pageSize1 returns second; beyond-end returns empty items with correct `total`

**Default behaviour** (`page=0, pageSize=50`) is backward-compatible: all existing callers requesting fewer than 50 DOs see identical `items` content. The `page` and `pageSize` fields in the envelope now reflect what was actually requested.

## Test plan

- [x] `mvn compile -DnoPlugins` green (main sources)
- [ ] CI `mvn verify -pl backend` green (SpotBugs, JaCoCo ≥ 60%)
- [ ] `getCrossDoBulkData(…, 0, 1, …).items().size() == 1` and `total == N` (new tests)
- [ ] `X-Total-Count` header equals `total` for page0/pageSize1 case (new test)
- [ ] `page=5, pageSize=10` beyond end → empty `items`, correct `total` (new test)
- [ ] No v1 `/shepard/api/` paths touched

Backlog row: `APISIMP-CROSSDO-PAGED-MISUSE` (`aidocs/16-dispatcher-backlog.md`)
SSOT: `aidocs/platform/191-v2-surface-convergence.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KV6FmHy8YnBoyBwB2gWcda)_