### PR TITLE
feat(APISIMP-REFANNOT-GET-PATCH-CREATE-SCHEMA): add @Content schema to annotation POST/GET/{id}/PATCH responses

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5710,7 +5710,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/timeseries/resources/CrossDoBulkDataRest.java:201`; apisimp-sweep-2026-07-16-fire623.md §Finding F2.
 
 ## APISIMP-REFANNOT-GET-PATCH-CREATE-SCHEMA — ReferenceAnnotationRest POST/GET/{id}/PATCH missing @Content schema declaration (size: S, sweep: fire-623)
-- **Status:** 🔲 queued
+- **Status:** 🔧 in-PR (fire-626)
 - **Why:** `ReferenceAnnotationRest.java` `create()` (line 188), `get()` (line 213), and `patch()` (line 241) all carry success `@APIResponse` annotations without a `content = @Content(schema = @Schema(...))` clause. The `list()` method at line 150 has the full annotation (added in WAVE3). The three other success responses document as `{}` in the generated OpenAPI spec. All return `Map<String, Object>`.
 - **Fix:** Option A: Introduce `ReferenceAnnotationIO` wrapping the map fields; declare `@Content(schema = @Schema(implementation = ReferenceAnnotationIO.class))` on all three. Option B (minimal): Add `@Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT))` so the spec documents the media type.
 - **AC:** All three `@APIResponse` success blocks carry a `@Content` clause. Generated OpenAPI spec does not show blank response bodies for POST/GET/{id}/PATCH. `mvn verify -pl backend` green.

--- a/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.headers.Header;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -185,7 +186,8 @@ public class ReferenceAnnotationRest {
       "`label` (string, required, non-blank), `description` (optional), `aiGenerated`, `confidence`.\n\n" +
       "Auth: Write permission on the parent DataObject."
   )
-  @APIResponse(responseCode = "201", description = "Annotation created; body is the new annotation map.")
+  @APIResponse(responseCode = "201", description = "Annotation created; body is the new annotation map.",
+    content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.OBJECT)))
   @APIResponse(responseCode = "400", description = "Required fields missing or invalid.")
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Write permission on the parent DataObject.")
@@ -210,7 +212,8 @@ public class ReferenceAnnotationRest {
       "Returns the annotation identified by `annotationAppId` within the reference `appId`. " +
       "Auth: Read permission on the parent DataObject."
   )
-  @APIResponse(responseCode = "200", description = "Annotation map.")
+  @APIResponse(responseCode = "200", description = "Annotation map.",
+    content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.OBJECT)))
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Read permission on the parent DataObject.")
   @APIResponse(responseCode = "404", description = "No reference or annotation with those appIds.")
@@ -238,7 +241,8 @@ public class ReferenceAnnotationRest {
       "absent keys leave the stored values unchanged. `aiGenerated` cannot be patched — it is " +
       "set at creation time only. Auth: Write permission on the parent DataObject."
   )
-  @APIResponse(responseCode = "200", description = "Post-patch annotation map.")
+  @APIResponse(responseCode = "200", description = "Post-patch annotation map.",
+    content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.OBJECT)))
   @APIResponse(responseCode = "400", description = "Invalid field value (e.g. blank label).")
   @APIResponse(responseCode = "401", description = "Authentication required.")
   @APIResponse(responseCode = "403", description = "Caller lacks Write permission on the parent DataObject.")


### PR DESCRIPTION
## Summary

`ReferenceAnnotationRest` (the unified annotation sub-resource at `/v2/references/{appId}/annotations`) had three success `@APIResponse` annotations without a `content = @Content(...)` clause:

- `create()` — `201 Annotation created` — body undocumented
- `get()` — `200 Annotation map` — body undocumented  
- `patch()` — `200 Post-patch annotation map` — body undocumented

The `list()` endpoint already had the full annotation with `@Content` + `X-Total-Count` (added in WAVE3). This PR adds Option B (minimal) fix for the other three: `@Content(mediaType=APPLICATION_JSON, schema=@Schema(type=SchemaType.OBJECT))`.

Also adds the missing `import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;`.

**Backlog row:** `APISIMP-REFANNOT-GET-PATCH-CREATE-SCHEMA` (fire-626, size S)  
**AC:** All three `@APIResponse` success blocks now carry a `@Content` clause. Generated OpenAPI spec no longer shows blank response bodies for POST/GET/{id}/PATCH.

## Changes

- `backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferenceAnnotationRest.java` — add `SchemaType` import + `@Content` to `create()`, `get()`, `patch()` success responses
- `aidocs/16-dispatcher-backlog.md` — mark row as in-PR (fire-626)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnZtfRM3ZKpmEfHF8MP3Lh)_