### PR TITLE
fix(APISIMP-TEMPLATE-TAGS-INMEM): push template-tags pagination to DB

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5738,14 +5738,14 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:791,829` (bulk); `:1040` (channel-annotations); `:1162` (temporal-annotations); apisimp-sweep-2026-07-16-fire627.md §Finding F1.
 
 ## APISIMP-NOTIF-TRANSPORT-INMEM — NotificationTransportRest.list() loads all transports then subList-slices in memory (size: S, sweep: fire-627)
-- **Status:** 🔧 in-PR (fire-628, branch APISIMP-NOTIF-TRANSPORT-INMEM)
+- **Status:** ✅ done (fire-628, merged PR #2598, squash SHA b44c2911)
 - **Why:** `GET /v2/admin/notifications/transports` (`NotificationTransportRest.java:98`) calls `service.listAll()` which delegates to `dao.findAll()` with no SKIP/LIMIT, materialises the full list of notification transports, then slices with `.subList(...)`. Same load-all + subList pattern as NOTEBOOK-INMEM-PAGE / VOCAB-USED-BY-INMEM. The collection is naturally bounded per deployment (few transports), so severity is low — but the technical debt shape is identical.
 - **Fix:** Add `countAll()` + `listPaged(skip, limit)` to `NotificationTransportDAO` (Cypher SKIP/LIMIT), expose them via `NotificationTransportService`, and replace the `listAll + subList` block in the REST handler with the two-query pattern.
 - **AC:** `list()` issues at most two DAO queries per page regardless of transport count. No full list materialised. `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/notifications/transport/resources/NotificationTransportRest.java:98`; `backend/src/main/java/de/dlr/shepard/v2/notifications/transport/services/NotificationTransportService.java:33`; apisimp-sweep-2026-07-16-fire627.md §Finding F2.
 
 ## APISIMP-TEMPLATE-TAGS-INMEM — ShepardTemplateRest.tags() loads all distinct tags then subList-slices in memory (size: S, sweep: fire-627)
-- **Status:** ⏳ queued
+- **Status:** 🔧 in-PR (fire-629, branch APISIMP-TEMPLATE-TAGS-INMEM)
 - **Why:** `GET /v2/templates/tags` (`ShepardTemplateRest.java:318`) calls `dao.listDistinctTags(kind)` (Cypher DISTINCT, no LIMIT) to load all distinct tag strings, then slices with `all.subList(skip, end)`. On deployments with many templates and diverse tagging, this loads O(N) tag strings on every tag-autocomplete keystroke.
 - **Fix:** Add `countDistinctTags(kind)` + `listDistinctTagsPaged(kind, skip, limit)` to `ShepardTemplateDAO`, add `SKIP $skip LIMIT $limit` to the Cypher, and remove the in-memory slice from the REST handler.
 - **AC:** `tags()` issues at most two DAO queries per page regardless of tag count. `mvn verify -pl backend` green.

--- a/backend/src/main/java/de/dlr/shepard/template/daos/ShepardTemplateDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/template/daos/ShepardTemplateDAO.java
@@ -221,16 +221,11 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
     }
   }
 
-  /** Hard cap on distinct tags returned by {@link #listDistinctTags}. */
-  static final int TAGS_MAX = 500;
-
   /**
-   * Distinct list of tags across all non-retired templates, sorted
-   * ascending. Used by the picker UI's tag-autocomplete dropdown.
+   * Count of distinct tags across all non-retired templates.
    * Optionally narrows to one {@code templateKind}.
-   * Capped at {@value #TAGS_MAX} entries.
    */
-  public List<String> listDistinctTags(String templateKind) {
+  public long countDistinctTags(String templateKind) {
     StringBuilder cypher = new StringBuilder(
       "MATCH (t:ShepardTemplate) WHERE (t.retired IS NULL OR t.retired = false)"
     );
@@ -239,7 +234,31 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
       cypher.append(" AND t.templateKind = $kind");
       params.put("kind", templateKind);
     }
-    cypher.append(" UNWIND coalesce(t.tags, []) AS tag RETURN DISTINCT tag ORDER BY tag LIMIT " + TAGS_MAX);
+    cypher.append(" UNWIND coalesce(t.tags, []) AS tag RETURN count(DISTINCT tag) AS total");
+    var result = session.query(cypher.toString(), params);
+    var it = result.queryResults().iterator();
+    if (!it.hasNext()) return 0L;
+    Object v = it.next().get("total");
+    return v instanceof Number n ? n.longValue() : 0L;
+  }
+
+  /**
+   * Paged distinct tag list across all non-retired templates, sorted
+   * ascending. Used by the picker UI's tag-autocomplete dropdown.
+   * Optionally narrows to one {@code templateKind}.
+   */
+  public List<String> listDistinctTagsPaged(String templateKind, int page, int pageSize) {
+    StringBuilder cypher = new StringBuilder(
+      "MATCH (t:ShepardTemplate) WHERE (t.retired IS NULL OR t.retired = false)"
+    );
+    Map<String, Object> params = new HashMap<>();
+    if (templateKind != null) {
+      cypher.append(" AND t.templateKind = $kind");
+      params.put("kind", templateKind);
+    }
+    cypher.append(" UNWIND coalesce(t.tags, []) AS tag RETURN DISTINCT tag ORDER BY tag SKIP $skip LIMIT $limit");
+    params.put("skip", (long) page * pageSize);
+    params.put("limit", (long) pageSize);
     var result = session.query(cypher.toString(), params);
     List<String> out = new ArrayList<>();
     for (Map<String, Object> row : result.queryResults()) {
@@ -247,6 +266,17 @@ public class ShepardTemplateDAO extends GenericDAO<ShepardTemplate> {
       if (tag != null) out.add(tag.toString());
     }
     return out;
+  }
+
+  /**
+   * @deprecated Use {@link #countDistinctTags(String)} +
+   *   {@link #listDistinctTagsPaged(String, int, int)} instead.
+   *   Retained for any callers outside the REST layer; will be removed
+   *   when no callers remain.
+   */
+  @Deprecated
+  public List<String> listDistinctTags(String templateKind) {
+    return listDistinctTagsPaged(templateKind, 0, 500);
   }
 
   /**

--- a/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRest.java
@@ -312,10 +312,8 @@ public class ShepardTemplateRest {
     @Context SecurityContext securityContext
   ) {
     if (securityContext.getUserPrincipal() == null) return problem(PT_UNAUTHORIZED, "Authentication required", Response.Status.UNAUTHORIZED, null);
-    List<String> all = dao.listDistinctTags(kind);
-    long total = all.size();
-    int skip = (int) Math.min((long) page * pageSize, total);
-    List<String> slice = all.subList(skip, (int) Math.min((long) skip + pageSize, total));
+    long total = dao.countDistinctTags(kind);
+    List<String> slice = dao.listDistinctTagsPaged(kind, page, pageSize);
     return Response.ok(new PagedResponseIO<>(slice, total, page, pageSize))
         .header("X-Total-Count", total)
         .build();

--- a/backend/src/test/java/de/dlr/shepard/template/daos/ShepardTemplateDAOIconKeyTest.java
+++ b/backend/src/test/java/de/dlr/shepard/template/daos/ShepardTemplateDAOIconKeyTest.java
@@ -12,9 +12,6 @@ import org.junit.jupiter.api.Test;
  * canonical edit shape per aidocs/54 §7; without an explicit
  * pass-through, an admin editing a description would silently strip
  * the icon — the failure mode aidocs/integrations/122 §5.1 calls out.
- *
- * Also covers APISIMP-TEMPLATE-TAGS-CAP: verifies the TAGS_MAX constant
- * is 500 (the value baked into the LIMIT clause of listDistinctTags).
  */
 class ShepardTemplateDAOIconKeyTest {
 
@@ -45,9 +42,18 @@ class ShepardTemplateDAOIconKeyTest {
   }
 
   @Test
-  void tagsCapConstantIs500() {
-    // APISIMP-TEMPLATE-TAGS-CAP: the constant must stay 500.
-    // Changing it without updating this test is intentional — bump the test.
-    assertEquals(500, ShepardTemplateDAO.TAGS_MAX);
+  void deprecatedListDistinctTagsDelegatesTo500Limit() {
+    // The deprecated listDistinctTags(kind) must delegate to listDistinctTagsPaged(kind, 0, 500).
+    // Guard that the fallback cap has not silently changed.
+    int[] capturedPageSize = {-1};
+    ShepardTemplateDAO dao = new ShepardTemplateDAO() {
+      @Override
+      public java.util.List<String> listDistinctTagsPaged(String templateKind, int page, int pageSize) {
+        capturedPageSize[0] = pageSize;
+        return java.util.Collections.emptyList();
+      }
+    };
+    dao.listDistinctTags(null);
+    assertEquals(500, capturedPageSize[0]);
   }
 }

--- a/backend/src/test/java/de/dlr/shepard/template/daos/ShepardTemplateDAOTagsPaginationTest.java
+++ b/backend/src/test/java/de/dlr/shepard/template/daos/ShepardTemplateDAOTagsPaginationTest.java
@@ -1,0 +1,87 @@
+package de.dlr.shepard.template.daos;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.dlr.shepard.BaseTestCase;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.neo4j.ogm.session.Session;
+
+/**
+ * APISIMP-TEMPLATE-TAGS-INMEM — unit tests for the DB-side pagination
+ * methods added to {@link ShepardTemplateDAO}: {@code countDistinctTags}
+ * and {@code listDistinctTagsPaged}. The methods must delegate to the
+ * Neo4j session; the REST layer must not materialise all tags in memory.
+ */
+class ShepardTemplateDAOTagsPaginationTest extends BaseTestCase {
+
+  @Mock
+  Session session;
+
+  @InjectMocks
+  ShepardTemplateDAO dao;
+
+  // ── countDistinctTags ────────────────────────────────────────────────
+
+  @Test
+  void countDistinctTagsReturnsZeroWhenQueryResultEmpty() {
+    var result = mock(org.neo4j.ogm.model.Result.class);
+    when(result.queryResults()).thenReturn(List.of());
+    when(session.query(any(String.class), anyMap())).thenReturn(result);
+
+    long count = dao.countDistinctTags(null);
+
+    assertEquals(0L, count);
+  }
+
+  @Test
+  void countDistinctTagsReturnsValueFromDb() {
+    var result = mock(org.neo4j.ogm.model.Result.class);
+    when(result.queryResults()).thenReturn(List.of(Map.of("total", 17L)));
+    when(session.query(any(String.class), anyMap())).thenReturn(result);
+
+    long count = dao.countDistinctTags(null);
+
+    assertEquals(17L, count);
+    verify(session).query(any(String.class), anyMap());
+  }
+
+  // ── listDistinctTagsPaged ────────────────────────────────────────────
+
+  @Test
+  void listDistinctTagsPagedReturnsEmptyListWhenNoRows() {
+    var result = mock(org.neo4j.ogm.model.Result.class);
+    when(result.queryResults()).thenReturn(List.of());
+    when(session.query(any(String.class), anyMap())).thenReturn(result);
+
+    List<String> tags = dao.listDistinctTagsPaged(null, 0, 50);
+
+    assertNotNull(tags);
+    assertEquals(0, tags.size());
+  }
+
+  @Test
+  void listDistinctTagsPagedReturnsTagsFromDb() {
+    var result = mock(org.neo4j.ogm.model.Result.class);
+    when(result.queryResults()).thenReturn(
+        List.of(Map.of("tag", "calibration"), Map.of("tag", "hot-fire"), Map.of("tag", "lumen")));
+    when(session.query(any(String.class), anyMap())).thenReturn(result);
+
+    List<String> tags = dao.listDistinctTagsPaged(null, 0, 50);
+
+    assertEquals(3, tags.size());
+    assertEquals("calibration", tags.get(0));
+    assertEquals("hot-fire", tags.get(1));
+    assertEquals("lumen", tags.get(2));
+    verify(session).query(any(String.class), anyMap());
+  }
+}

--- a/backend/src/test/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/template/resources/ShepardTemplateRestTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -244,12 +245,14 @@ class ShepardTemplateRestTest {
     when(securityContext.getUserPrincipal()).thenReturn(null);
     Response r = resource.tags(null, 0, 50, securityContext);
     assertEquals(401, r.getStatus());
-    verify(dao, never()).listDistinctTags(any());
+    verify(dao, never()).countDistinctTags(any());
+    verify(dao, never()).listDistinctTagsPaged(any(), anyInt(), anyInt());
   }
 
   @Test
   void tagsReturnsDistinctList() {
-    when(dao.listDistinctTags(null)).thenReturn(List.of("calibration", "hot-fire", "lumen"));
+    when(dao.countDistinctTags(null)).thenReturn(3L);
+    when(dao.listDistinctTagsPaged(null, 0, 50)).thenReturn(List.of("calibration", "hot-fire", "lumen"));
     Response r = resource.tags(null, 0, 50, securityContext);
     assertEquals(200, r.getStatus());
     @SuppressWarnings("unchecked")
@@ -262,15 +265,18 @@ class ShepardTemplateRestTest {
 
   @Test
   void tagsHonoursKindFilter() {
-    when(dao.listDistinctTags("EXPERIMENT_RECIPE")).thenReturn(List.of("hot-fire"));
+    when(dao.countDistinctTags("EXPERIMENT_RECIPE")).thenReturn(1L);
+    when(dao.listDistinctTagsPaged("EXPERIMENT_RECIPE", 0, 50)).thenReturn(List.of("hot-fire"));
     Response r = resource.tags("EXPERIMENT_RECIPE", 0, 50, securityContext);
     assertEquals(200, r.getStatus());
-    verify(dao).listDistinctTags("EXPERIMENT_RECIPE");
+    verify(dao).countDistinctTags("EXPERIMENT_RECIPE");
+    verify(dao).listDistinctTagsPaged("EXPERIMENT_RECIPE", 0, 50);
   }
 
   @Test
-  void tagsPaginatesInMemory() {
-    when(dao.listDistinctTags(null)).thenReturn(List.of("a", "b", "c"));
+  void tagsPaginatesViaDb() {
+    when(dao.countDistinctTags(null)).thenReturn(3L);
+    when(dao.listDistinctTagsPaged(null, 0, 2)).thenReturn(List.of("a", "b"));
     Response page0 = resource.tags(null, 0, 2, securityContext);
     assertEquals(200, page0.getStatus());
     @SuppressWarnings("unchecked")
@@ -279,14 +285,32 @@ class ShepardTemplateRestTest {
     assertEquals(3L, p0.total());
     assertEquals(2, p0.items().size());
     assertEquals("a", p0.items().get(0));
+    verify(dao).countDistinctTags(null);
+    verify(dao).listDistinctTagsPaged(null, 0, 2);
+  }
 
-    when(dao.listDistinctTags(null)).thenReturn(List.of("a", "b", "c"));
+  @Test
+  void tags_page1_usesCorrectDbParams() {
+    when(dao.countDistinctTags(null)).thenReturn(3L);
+    when(dao.listDistinctTagsPaged(null, 1, 2)).thenReturn(List.of("c"));
     Response page1 = resource.tags(null, 1, 2, securityContext);
+    assertEquals(200, page1.getStatus());
     @SuppressWarnings("unchecked")
     de.dlr.shepard.v2.common.io.PagedResponseIO<String> p1 =
         (de.dlr.shepard.v2.common.io.PagedResponseIO<String>) page1.getEntity();
+    assertEquals(3L, p1.total());
     assertEquals(1, p1.items().size());
     assertEquals("c", p1.items().get(0));
+    verify(dao).listDistinctTagsPaged(null, 1, 2);
+  }
+
+  @Test
+  void tags_xTotalCountHeaderMatchesTotal() {
+    when(dao.countDistinctTags(null)).thenReturn(42L);
+    when(dao.listDistinctTagsPaged(null, 0, 50)).thenReturn(List.of());
+    Response r = resource.tags(null, 0, 50, securityContext);
+    assertEquals(200, r.getStatus());
+    assertEquals("42", r.getHeaders().getFirst("X-Total-Count").toString());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- `GET /v2/templates/tags` was calling `dao.listDistinctTags(kind)` (no SKIP/LIMIT), pulling all distinct tag strings into JVM heap, then slicing with `subList()` in the REST layer — the same load-all + subList anti-pattern as NOTEBOOK-INMEM-PAGE / VOCAB-USED-BY-INMEM / APISIMP-NOTIF-TRANSPORT-INMEM.
- Add `ShepardTemplateDAO.countDistinctTags(kind)` and `listDistinctTagsPaged(kind, page, pageSize)` with Cypher `UNWIND … RETURN DISTINCT tag ORDER BY tag SKIP $skip LIMIT $limit`.
- Update `ShepardTemplateRest.tags()` to issue two DB queries per page (count + page) — O(1) memory regardless of tag population.
- Mark old `listDistinctTags(kind)` `@Deprecated`; it delegates to `listDistinctTagsPaged(kind, 0, 500)` for any legacy callers.

## Changed files

| File | Change |
|---|---|
| `ShepardTemplateDAO.java` | Add `countDistinctTags`, `listDistinctTagsPaged`; deprecate `listDistinctTags` |
| `ShepardTemplateRest.java` | Replace in-memory subList with two-query DB pattern |
| `ShepardTemplateDAOTagsPaginationTest.java` | New — 4 unit tests for new DAO methods |
| `ShepardTemplateRestTest.java` | Update 4 tags tests; add `tags_page1_usesCorrectDbParams` + `tags_xTotalCountHeaderMatchesTotal` |
| `ShepardTemplateDAOIconKeyTest.java` | Replace removed `TAGS_MAX` constant check with delegation guard |
| `aidocs/16-dispatcher-backlog.md` | Mark APISIMP-NOTIF-TRANSPORT-INMEM done; set APISIMP-TEMPLATE-TAGS-INMEM in-PR |

## Slice

`APISIMP-TEMPLATE-TAGS-INMEM` (size: S) — fire-629

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHeVSuX3QkH6452AmxWyrm)_