### PR TITLE
feat(apisimp): push SKIP/LIMIT into Cypher for admin git-credential + instance-admin lists — APISIMP-ADMIN-INMEM-PAGING (XS)

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5769,7 +5769,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/references/spi/ReferenceKindHandler.java:141`; apisimp-sweep-2026-07-16-fire631.md §Finding F1.
 
 ## APISIMP-ADMIN-INMEM-PAGING — AdminUserGitCredentialRest + InstanceAdminRest slice in memory (size: XS, low priority, sweep: fire-631)
-- **Status:** queued
+- **Status:** done (fire-633, 2026-07-16)
 - **Why:** Both admin list endpoints load the full record set, compute `.size()` as total, then call `.subList()`. Both datasets are bounded in practice (< 20 git credentials per user, < 100 instance-admin grants) so performance impact is negligible, but the shape is inconsistent with the rest of the v2 admin surface.
 - **Fix:** Push `SKIP $skip LIMIT $limit` to the underlying Neo4j DAOs.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/admin/users/AdminUserGitCredentialRest.java:245`; `backend/src/main/java/de/dlr/shepard/v2/admin/resources/InstanceAdminRest.java:127`; apisimp-sweep-2026-07-16-fire631.md §Finding F4.

--- a/backend/src/main/java/de/dlr/shepard/auth/role/daos/RoleDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/auth/role/daos/RoleDAO.java
@@ -116,6 +116,33 @@ public class RoleDAO extends GenericDAO<Role> {
   }
 
   /**
+   * Paginated variant — pushes {@code SKIP}/{@code LIMIT} into Cypher so
+   * the full grant list is never loaded into memory.
+   *
+   * @param roleName role identifier (e.g. {@code "instance-admin"}).
+   * @param skip     rows to skip (page × pageSize).
+   * @param limit    maximum rows to return.
+   */
+  public List<RoleGrant> listGrants(String roleName, long skip, long limit) {
+    String cypher =
+      "MATCH (u:User)-[h:HAS_ROLE]->(:Role {name: $n}) " +
+      "RETURN u.username AS username, h.grantedBy AS grantedBy, h.grantedAt AS grantedAt " +
+      "ORDER BY u.username SKIP $skip LIMIT $limit";
+    var result = session.query(cypher, Map.of("n", roleName, "skip", skip, "limit", limit));
+    List<RoleGrant> out = new ArrayList<>();
+    for (Map<String, Object> row : result.queryResults()) {
+      out.add(
+        new RoleGrant(
+          Objects.toString(row.get("username"), null),
+          Objects.toString(row.get("grantedBy"), null),
+          row.get("grantedAt") instanceof Number n ? n.longValue() : null
+        )
+      );
+    }
+    return out;
+  }
+
+  /**
    * Returns the count of users who hold the given role via a
    * {@code :HAS_ROLE} edge (Neo4j-internal source only — does NOT
    * include IdP-claim grants).

--- a/backend/src/main/java/de/dlr/shepard/auth/users/daos/GitCredentialDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/auth/users/daos/GitCredentialDAO.java
@@ -46,6 +46,37 @@ public class GitCredentialDAO extends GenericDAO<GitCredential> {
   }
 
   /**
+   * Returns the total number of credentials owned by the user; used for
+   * {@code X-Total-Count} without a full load.
+   */
+  public long countByUser(String username) {
+    String cypher =
+      "MATCH (:User {username: $username})-[:OWNS_CREDENTIAL]->(c:GitCredential) RETURN count(c) AS cnt";
+    var result = session.query(cypher, Map.of("username", username));
+    var it = result.queryResults().iterator();
+    if (!it.hasNext()) return 0L;
+    Object cnt = it.next().get("cnt");
+    return cnt instanceof Number n ? n.longValue() : 0L;
+  }
+
+  /**
+   * Returns a page of credentials owned by the user, ordered by creation
+   * date ascending. Pushes {@code SKIP}/{@code LIMIT} into Cypher so
+   * the full credential set is never loaded.
+   *
+   * @param username the owning user's username.
+   * @param skip     number of rows to skip (page × pageSize).
+   * @param limit    maximum number of rows to return.
+   */
+  public List<GitCredential> findByUser(String username, long skip, long limit) {
+    String query =
+      "MATCH (u:User {username: $username})-[:OWNS_CREDENTIAL]->(c:GitCredential) " +
+      "RETURN c ORDER BY c.createdAt ASC SKIP $skip LIMIT $limit";
+    var iter = findByQuery(query, Map.of("username", username, "skip", skip, "limit", limit));
+    return StreamSupport.stream(iter.spliterator(), false).toList();
+  }
+
+  /**
    * Creates the {@code GitCredential} node and wires the
    * {@code OWNS_CREDENTIAL} relationship from the owning user in a single
    * Cypher statement. Mints {@code appId} (UUID v7) and sets

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/resources/InstanceAdminRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/resources/InstanceAdminRest.java
@@ -124,13 +124,11 @@ public class InstanceAdminRest {
     @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize
   ) {
     requireInstanceAdmin(securityContext);
-    List<InstanceAdminGrantIO> grants = instanceAdminService.listInstanceAdmins();
-    long from = (long) page * pageSize;
-    List<InstanceAdminGrantIO> slice = from >= grants.size()
-        ? List.of()
-        : grants.subList((int) from, (int) Math.min(from + pageSize, grants.size()));
-    return Response.ok(new PagedResponseIO<>(slice, grants.size(), page, pageSize))
-        .header("X-Total-Count", (long) grants.size())
+    long total = instanceAdminService.countInstanceAdmins();
+    long skip = (long) page * pageSize;
+    List<InstanceAdminGrantIO> grants = instanceAdminService.listInstanceAdmins(skip, pageSize);
+    return Response.ok(new PagedResponseIO<>(grants, total, page, pageSize))
+        .header("X-Total-Count", total)
         .build();
   }
 

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/services/InstanceAdminService.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/services/InstanceAdminService.java
@@ -69,6 +69,34 @@ public class InstanceAdminService {
   }
 
   /**
+   * Paginated variant — delegates {@code skip}/{@code limit} to the DAO so
+   * only one page of grant rows is loaded.
+   *
+   * @param skip  rows to skip (page × pageSize).
+   * @param limit maximum rows to return.
+   */
+  public List<InstanceAdminGrantIO> listInstanceAdmins(long skip, long limit) {
+    List<RoleDAO.RoleGrant> grants = roleDAO.listGrants(Constants.INSTANCE_ADMIN_ROLE, skip, limit);
+    List<InstanceAdminGrantIO> out = new ArrayList<>(grants.size());
+    for (var g : grants) {
+      out.add(
+        new InstanceAdminGrantIO(
+          g.username(),
+          "Neo4j",
+          g.grantedBy(),
+          g.grantedAtMillis() == null ? null : Instant.ofEpochMilli(g.grantedAtMillis()).toString()
+        )
+      );
+    }
+    return out;
+  }
+
+  /** Total Neo4j-side instance-admin grants for pagination headers. */
+  public long countInstanceAdmins() {
+    return roleDAO.countGrants(Constants.INSTANCE_ADMIN_ROLE);
+  }
+
+  /**
    * Grant the {@code instance-admin} role to the named user. The user
    * must exist in Neo4j (i.e. they must have logged in at least once
    * via OIDC, or been pre-created). The grantor is the calling

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/users/AdminUserGitCredentialRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/users/AdminUserGitCredentialRest.java
@@ -241,19 +241,17 @@ public class AdminUserGitCredentialRest {
       return problem(PROBLEM_TYPE_NOT_FOUND, "User not found",
           Response.Status.NOT_FOUND, "No user with username '" + targetUsername + "'.");
     }
-    List<GitCredential> stored = gitCredentialDAO.findAllByUser(targetUsername);
+    long total = gitCredentialDAO.countByUser(targetUsername);
+    long skip = (long) page * pageSize;
+    List<GitCredential> stored = gitCredentialDAO.findByUser(targetUsername, skip, pageSize);
     List<AdminGitCredentialListItemIO> items = new ArrayList<>(stored == null ? 0 : stored.size());
     if (stored != null) {
       for (GitCredential c : stored) {
         items.add(AdminGitCredentialListItemIO.from(c));
       }
     }
-    long from = (long) page * pageSize;
-    List<AdminGitCredentialListItemIO> slice = from >= items.size()
-        ? List.of()
-        : items.subList((int) from, (int) Math.min(from + pageSize, items.size()));
-    return Response.ok(new PagedResponseIO<>(slice, items.size(), page, pageSize))
-        .header("X-Total-Count", items.size())
+    return Response.ok(new PagedResponseIO<>(items, total, page, pageSize))
+        .header("X-Total-Count", total)
         .build();
   }
 

--- a/backend/src/test/java/de/dlr/shepard/v2/admin/resources/InstanceAdminListRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/admin/resources/InstanceAdminListRestTest.java
@@ -52,14 +52,15 @@ class InstanceAdminListRestTest {
 
   @Test
   void listInstanceAdmins_returnsPagedEnvelope() {
-    when(instanceAdminService.listInstanceAdmins()).thenReturn(List.of());
+    when(instanceAdminService.countInstanceAdmins()).thenReturn(0L);
+    when(instanceAdminService.listInstanceAdmins(0L, 50)).thenReturn(List.of());
 
     Response r = resource.listInstanceAdmins(securityContext, 0, 50);
 
     assertEquals(200, r.getStatus());
     Object entity = r.getEntity();
     assertInstanceOf(PagedResponseIO.class, entity,
-        "listInstanceAdmins must return PagedResponseIO (APISIMP-INSTANCE-ADMINS-BARE-LIST)");
+        "listInstanceAdmins must return PagedResponseIO (APISIMP-ADMIN-INMEM-PAGING)");
   }
 
   @Test
@@ -93,14 +94,31 @@ class InstanceAdminListRestTest {
   @Test
   void listInstanceAdmins_returnsAllItemsInEnvelope() {
     InstanceAdminGrantIO grant = new InstanceAdminGrantIO("alice", "Neo4j", "bob", null);
-    when(instanceAdminService.listInstanceAdmins()).thenReturn(List.of(grant));
+    when(instanceAdminService.countInstanceAdmins()).thenReturn(1L);
+    when(instanceAdminService.listInstanceAdmins(0L, 50)).thenReturn(List.of(grant));
 
     Response r = resource.listInstanceAdmins(securityContext, 0, 50);
 
     @SuppressWarnings("unchecked")
     PagedResponseIO<InstanceAdminGrantIO> body = (PagedResponseIO<InstanceAdminGrantIO>) r.getEntity();
     assertEquals(1, body.items().size());
-    assertEquals(1, body.total());
+    assertEquals(1L, body.total());
     assertEquals("alice", body.items().get(0).getUsername());
+  }
+
+  @Test
+  void listInstanceAdmins_paginationParamsForwardedToService() {
+    InstanceAdminGrantIO grant = new InstanceAdminGrantIO("charlie", "Neo4j", "admin", null);
+    when(instanceAdminService.countInstanceAdmins()).thenReturn(75L);
+    when(instanceAdminService.listInstanceAdmins(50L, 50)).thenReturn(List.of(grant));
+
+    Response r = resource.listInstanceAdmins(securityContext, 1, 50);
+
+    @SuppressWarnings("unchecked")
+    PagedResponseIO<InstanceAdminGrantIO> body = (PagedResponseIO<InstanceAdminGrantIO>) r.getEntity();
+    assertEquals(75L, body.total());
+    assertEquals(1, body.items().size());
+    assertEquals("charlie", body.items().get(0).getUsername());
+    assertEquals(75L, Long.parseLong(r.getHeaderString("X-Total-Count")));
   }
 }

--- a/backend/src/test/java/de/dlr/shepard/v2/admin/users/AdminUserGitCredentialRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/admin/users/AdminUserGitCredentialRestTest.java
@@ -78,13 +78,14 @@ class AdminUserGitCredentialRestTest {
   @SuppressWarnings("unchecked")
   @Test
   void list_returns200_withEmptyList_whenNoCredentials() {
-    when(dao.findAllByUser(USER)).thenReturn(List.of());
+    when(dao.countByUser(USER)).thenReturn(0L);
+    when(dao.findByUser(USER, 0L, 50)).thenReturn(List.of());
     Response r = rest.list(USER, 0, 50);
     assertThat(r.getStatus()).isEqualTo(200);
     PagedResponseIO<AdminGitCredentialListItemIO> body =
         (PagedResponseIO<AdminGitCredentialListItemIO>) r.getEntity();
     assertThat(body.items()).isEmpty();
-    assertThat(body.total()).isEqualTo(0);
+    assertThat(body.total()).isEqualTo(0L);
   }
 
   @SuppressWarnings("unchecked")
@@ -92,14 +93,15 @@ class AdminUserGitCredentialRestTest {
   void list_returns200_withItems_andOmitsPat() {
     Date rotated = new Date(2000L);
     GitCredential c = cred(CRED_APP_ID, "gitlab.com", "alice", rotated);
-    when(dao.findAllByUser(USER)).thenReturn(List.of(c));
+    when(dao.countByUser(USER)).thenReturn(1L);
+    when(dao.findByUser(USER, 0L, 50)).thenReturn(List.of(c));
 
     Response r = rest.list(USER, 0, 50);
     assertThat(r.getStatus()).isEqualTo(200);
     PagedResponseIO<AdminGitCredentialListItemIO> body =
         (PagedResponseIO<AdminGitCredentialListItemIO>) r.getEntity();
     assertThat(body.items()).hasSize(1);
-    assertThat(body.total()).isEqualTo(1);
+    assertThat(body.total()).isEqualTo(1L);
     var item = body.items().get(0);
     assertThat(item.appId()).isEqualTo(CRED_APP_ID);
     assertThat(item.host()).isEqualTo("gitlab.com");
@@ -118,7 +120,8 @@ class AdminUserGitCredentialRestTest {
   @Test
   void list_returns200_withNullLastRotatedAt_forLegacyRows() {
     GitCredential legacy = cred(CRED_APP_ID, "github.com", "bob", null);
-    when(dao.findAllByUser(USER)).thenReturn(List.of(legacy));
+    when(dao.countByUser(USER)).thenReturn(1L);
+    when(dao.findByUser(USER, 0L, 50)).thenReturn(List.of(legacy));
     Response r = rest.list(USER, 0, 50);
     assertThat(r.getStatus()).isEqualTo(200);
     PagedResponseIO<AdminGitCredentialListItemIO> body =
@@ -131,6 +134,23 @@ class AdminUserGitCredentialRestTest {
     when(userService.getUserOptional(USER)).thenReturn(Optional.empty());
     Response r = rest.list(USER, 0, 50);
     assertThat(r.getStatus()).isEqualTo(404);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void list_paginationParamsForwardedToDao() {
+    GitCredential c = cred(CRED_APP_ID, "bitbucket.org", "eve", new Date(3000L));
+    when(dao.countByUser(USER)).thenReturn(25L);
+    when(dao.findByUser(USER, 20L, 10)).thenReturn(List.of(c));
+
+    Response r = rest.list(USER, 2, 10);
+
+    assertThat(r.getStatus()).isEqualTo(200);
+    PagedResponseIO<AdminGitCredentialListItemIO> body =
+        (PagedResponseIO<AdminGitCredentialListItemIO>) r.getEntity();
+    assertThat(body.total()).isEqualTo(25L);
+    assertThat(body.items()).hasSize(1);
+    assertThat(r.getHeaderString("X-Total-Count")).isEqualTo("25");
   }
 
   // ── POST rotate ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `AdminUserGitCredentialRest.list()` and `InstanceAdminRest.listInstanceAdmins()` previously loaded all records, then computed `.size()` as total and called Java `.subList()` for the page slice.
- Both now delegate `SKIP $skip LIMIT $limit` to dedicated DAO methods, matching the paging shape of the rest of the v2 admin surface.
- `X-Total-Count` header was already declared but wired to the in-memory `.size()`; now it reflects the actual DB count.

## Changes

| Layer | Change |
|---|---|
| `GitCredentialDAO` | Add `countByUser(username)` + `findByUser(username, skip, limit)` (Cypher-side paging) |
| `RoleDAO` | Add `listGrants(roleName, skip, limit)` overload |
| `InstanceAdminService` | Add `countInstanceAdmins()` + `listInstanceAdmins(skip, limit)` overload |
| `AdminUserGitCredentialRest` | `list()` now calls count + paged DAO; old `findAllByUser` path kept for POST idempotency check |
| `InstanceAdminRest` | `listInstanceAdmins()` now calls service count + paged list |
| Tests | Existing `list_*` tests updated; new `*_paginationParamsForwardedTo*` tests added (19 tests, 0 failures) |

## Test plan

- [ ] `mvn -DnoPlugins -P bootstrap-testjar -Dtest="AdminUserGitCredentialRestTest,InstanceAdminListRestTest" test` → 19 tests, 0 failures ✓
- [ ] CI `backend-ci` passes (JUnit + JaCoCo ≥ 60% + SpotBugs)
- [ ] `GET /v2/admin/users/{username}/git-credentials?page=0&pageSize=10` returns `PagedResponseIO` with correct `total` and `X-Total-Count`
- [ ] `GET /v2/admin/instance-admins?page=1&pageSize=50` skips first 50 rows (verifiable via Cypher PROFILE)

Backlog: APISIMP-ADMIN-INMEM-PAGING → done (fire-633, 2026-07-16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhjBnma7zWBdvYgXM36FDp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhjBnma7zWBdvYgXM36FDp)_