### PR TITLE
APISIMP-REFS-HANDLER-PAGING-TAIL: push COUNT+SKIP/LIMIT to Neo4j for 5 remaining handlers

### DIFF
--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5782,14 +5782,14 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/containers/spi/ContainerKindHandler.java:155`; `backend/src/main/java/de/dlr/shepard/v2/containers/resources/ContainersV2Rest.java:474`.
 
 ## APISIMP-REFS-HANDLER-PAGING-TAIL — 5 concrete ReferenceKindHandlers still use SPI in-memory paging defaults (size: S, sweep: fire-634)
-- **Status:** queued.
+- **Status:** in-PR (fire-636).
 - **Why:** PR #2603 (fire-633/634) added DB-backed `countByDataObject` + `listByDataObject(skip, limit)` overrides to `FileReferenceKindHandler` and `UriReferenceKindHandler` only. The five remaining in-tree handlers (`TimeseriesReferenceKindHandler`, `FileBundleReferenceKindHandler`, `StructuredDataReferenceKindHandler`, `CollectionReferenceKindHandler`, `DataObjectReferenceKindHandler`) fall through to the SPI defaults: `count` calls `listByDataObject(all).size()` (unbounded Cypher load → `.size()` in Java); `list(skip,limit)` calls `listByDataObject(all)` then `.subList()`. For a DataObject with 100 TimeSeries references, every paged `GET /v2/references?kind=timeseries` request performs two full O(N) Neo4j scans.
 - **Fix:** Add `countByDataObject(appId, subKind)` and `listByDataObject(appId, subKind, skip, limit)` overrides to each of the 5 handlers, delegating to the underlying service (e.g. `timeseriesReferenceService.countByDataObjectAppId(appId)` / `timeseriesReferenceService.listByDataObjectAppId(appId, skip, limit)`). The service methods may need `skip+limit` overloads if they don't already exist.
 - **AC:** `GET /v2/references?kind=timeseries&dataObjectAppId=...&pageSize=10&page=1` Neo4j log shows `SKIP 10 LIMIT 10` and a separate `count(r)` query. `mvn verify -pl backend` green.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/references/spi/ReferenceKindHandler.java:141`; `backend/src/main/java/de/dlr/shepard/v2/references/handlers/TimeseriesReferenceKindHandler.java:223`; `backend/src/main/java/de/dlr/shepard/v2/references/resources/ReferencesV2Rest.java:550`; apisimp-sweep-2026-07-16-fire634.md §Finding F1.
 
 ## APISIMP-MCP-ANNOT-INMEM — list_annotations MCP tool loads all SemanticAnnotations in memory before paging (size: XS, sweep: fire-634)
-- **Status:** done (fire-635, PR pending).
+- **Status:** done (fire-636, PR #2605 merged sha aa799de).
 - **Why:** `ContentMcpTools.list_annotations` calls `semanticAnnotationService.getAllAnnotationsByShepardId(ogmId)` (unbounded Cypher, loads ALL SemanticAnnotations) then paginates in Java with `subList`. Low practical impact (annotations bounded per DO), but inconsistent with the APISIMP mandate and a latency risk on AI-bulk-annotated DataObjects with 200+ annotations.
 - **Fix:** Added `countAnnotationsByShepardId(shepardId)` and `findAnnotationsByShepardId(shepardId, skip, limit)` to `SemanticAnnotationDAO` using parameterized `SKIP $skip LIMIT $lim` Cypher. Added paged service overloads. Wired through `ContentMcpTools.listAnnotations()` replacing the load-all+subList pattern. Two tests added to `SemanticAnnotationServiceTest`; `ContentMcpToolsTest` updated to stub paged overloads.
 - **AC:** `list_annotations` with `page=1, pageSize=10` issues at most two DAO queries; no `getAllAnnotationsByShepardId` (unbounded) call.

--- a/backend/src/main/java/de/dlr/shepard/context/references/dataobject/daos/CollectionReferenceDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/context/references/dataobject/daos/CollectionReferenceDAO.java
@@ -74,6 +74,49 @@ public class CollectionReferenceDAO extends VersionableEntityDAO<CollectionRefer
     return it.hasNext() ? it.next() : null;
   }
 
+  /**
+   * APISIMP-REFS-HANDLER-PAGING-TAIL — count of non-deleted CollectionReferences under a
+   * DataObject (resolved by appId). Pushes the predicate to Neo4j so the caller never loads all
+   * rows just to count them.
+   *
+   * @param dataObjectAppId the parent DataObject's appId.
+   * @return total count of matching, non-deleted CollectionReferences.
+   */
+  public int countByDataObjectAppId(String dataObjectAppId) {
+    String query =
+      "MATCH (d:DataObject {appId: $aid})-[:has_reference]->(r:CollectionReference) " +
+      "WHERE (r.deleted IS NULL OR r.deleted = false) " +
+      "RETURN count(r) AS cnt";
+    for (var row : session.query(query, Map.of("aid", dataObjectAppId))) {
+      Object cnt = row.get("cnt");
+      return cnt instanceof Number n ? n.intValue() : 0;
+    }
+    return 0;
+  }
+
+  /**
+   * APISIMP-REFS-HANDLER-PAGING-TAIL — paginated list of non-deleted CollectionReferences under a
+   * DataObject (resolved by appId). Pushes SKIP/LIMIT to Neo4j.
+   *
+   * @param dataObjectAppId the parent DataObject's appId.
+   * @param skip 0-based offset.
+   * @param limit maximum rows (must be &gt; 0).
+   * @return the CollectionReferences for the requested page; never null.
+   */
+  public List<CollectionReference> findByDataObjectAppId(String dataObjectAppId, int skip, int limit) {
+    String query =
+      "MATCH (d:DataObject {appId: $aid})-[hr:has_reference]->(r:CollectionReference) " +
+      "WHERE (r.deleted IS NULL OR r.deleted = false) " +
+      "RETURN r, d, hr " +
+      "ORDER BY r.createdAt ASC " +
+      "SKIP $skip LIMIT $limit";
+    var queryResult = findByQuery(
+      query,
+      Map.of("aid", dataObjectAppId, "skip", (long) skip, "limit", (long) limit)
+    );
+    return StreamSupport.stream(queryResult.spliterator(), false).toList();
+  }
+
   @Override
   public Class<CollectionReference> getEntityType() {
     return CollectionReference.class;

--- a/backend/src/main/java/de/dlr/shepard/context/references/dataobject/daos/DataObjectReferenceDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/context/references/dataobject/daos/DataObjectReferenceDAO.java
@@ -81,6 +81,49 @@ public class DataObjectReferenceDAO extends VersionableEntityDAO<DataObjectRefer
     return it.hasNext() ? it.next() : null;
   }
 
+  /**
+   * APISIMP-REFS-HANDLER-PAGING-TAIL — count of non-deleted DataObjectReferences under a
+   * DataObject (resolved by appId). Pushes the predicate to Neo4j so the caller never loads all
+   * rows just to count them.
+   *
+   * @param dataObjectAppId the parent DataObject's appId.
+   * @return total count of matching, non-deleted DataObjectReferences.
+   */
+  public int countByDataObjectAppId(String dataObjectAppId) {
+    String query =
+      "MATCH (d:DataObject {appId: $aid})-[:has_reference]->(r:DataObjectReference) " +
+      "WHERE (r.deleted IS NULL OR r.deleted = false) " +
+      "RETURN count(r) AS cnt";
+    for (var row : session.query(query, Map.of("aid", dataObjectAppId))) {
+      Object cnt = row.get("cnt");
+      return cnt instanceof Number n ? n.intValue() : 0;
+    }
+    return 0;
+  }
+
+  /**
+   * APISIMP-REFS-HANDLER-PAGING-TAIL — paginated list of non-deleted DataObjectReferences under a
+   * DataObject (resolved by appId). Pushes SKIP/LIMIT to Neo4j.
+   *
+   * @param dataObjectAppId the parent DataObject's appId.
+   * @param skip 0-based offset.
+   * @param limit maximum rows (must be &gt; 0).
+   * @return the DataObjectReferences for the requested page; never null.
+   */
+  public List<DataObjectReference> findByDataObjectAppId(String dataObjectAppId, int skip, int limit) {
+    String query =
+      "MATCH (d:DataObject {appId: $aid})-[hr:has_reference]->(r:DataObjectReference) " +
+      "WHERE (r.deleted IS NULL OR r.deleted = false) " +
+      "RETURN r, d, hr " +
+      "ORDER BY r.createdAt ASC " +
+      "SKIP $skip LIMIT $limit";
+    var queryResult = findByQuery(
+      query,
+      Map.of("aid", dataObjectAppId, "skip", (long) skip, "limit", (long) limit)
+    );
+    return StreamSupport.stream(queryResult.spliterator(), false).toList();
+  }
+
   @Override
   public Class<DataObjectReference> getEntityType() {
     return DataObjectReference.class;

--- a/backend/src/main/java/de/dlr/shepard/context/references/file/daos/FileBundleReferenceDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/context/references/file/daos/FileBundleReferenceDAO.java
@@ -136,6 +136,49 @@ public class FileBundleReferenceDAO extends VersionableEntityDAO<FileBundleRefer
     return SingletonFileReferenceDAO.mapNotebookProjections(rows);
   }
 
+  /**
+   * APISIMP-REFS-HANDLER-PAGING-TAIL — count of non-deleted FileBundleReferences under a
+   * DataObject (resolved by appId). Uses the {@code :FileBundleReference} label so singletons
+   * (which only carry {@code :FileReference}) are naturally excluded.
+   *
+   * @param dataObjectAppId the parent DataObject's appId.
+   * @return total count of matching, non-deleted FileBundleReferences.
+   */
+  public int countByDataObjectAppId(String dataObjectAppId) {
+    String query =
+      "MATCH (d:DataObject {appId: $aid})-[:has_reference]->(r:FileBundleReference) " +
+      "WHERE (r.deleted IS NULL OR r.deleted = false) " +
+      "RETURN count(r) AS cnt";
+    for (var row : session.query(query, Map.of("aid", dataObjectAppId))) {
+      Object cnt = row.get("cnt");
+      return cnt instanceof Number n ? n.intValue() : 0;
+    }
+    return 0;
+  }
+
+  /**
+   * APISIMP-REFS-HANDLER-PAGING-TAIL — paginated list of non-deleted FileBundleReferences under a
+   * DataObject (resolved by appId). Pushes SKIP/LIMIT to Neo4j.
+   *
+   * @param dataObjectAppId the parent DataObject's appId.
+   * @param skip 0-based offset.
+   * @param limit maximum rows (must be &gt; 0).
+   * @return the FileBundleReferences for the requested page; never null.
+   */
+  public List<FileBundleReference> findByDataObjectAppId(String dataObjectAppId, int skip, int limit) {
+    String query =
+      "MATCH (d:DataObject {appId: $aid})-[hr:has_reference]->(r:FileBundleReference) " +
+      "WHERE (r.deleted IS NULL OR r.deleted = false) " +
+      "RETURN r, d, hr " +
+      "ORDER BY r.createdAt ASC " +
+      "SKIP $skip LIMIT $limit";
+    var queryResult = findByQuery(
+      query,
+      Map.of("aid", dataObjectAppId, "skip", (long) skip, "limit", (long) limit)
+    );
+    return StreamSupport.stream(queryResult.spliterator(), false).toList();
+  }
+
   @Override
   public Class<FileBundleReference> getEntityType() {
     return FileBundleReference.class;

--- a/backend/src/main/java/de/dlr/shepard/context/references/structureddata/daos/StructuredDataReferenceDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/context/references/structureddata/daos/StructuredDataReferenceDAO.java
@@ -140,6 +140,49 @@ public class StructuredDataReferenceDAO extends VersionableEntityDAO<StructuredD
     return result;
   }
 
+  /**
+   * APISIMP-REFS-HANDLER-PAGING-TAIL — count of non-deleted StructuredDataReferences under a
+   * DataObject (resolved by appId). Pushes the predicate to Neo4j so the caller never loads all
+   * rows just to count them.
+   *
+   * @param dataObjectAppId the parent DataObject's appId.
+   * @return total count of matching, non-deleted StructuredDataReferences.
+   */
+  public int countByDataObjectAppId(String dataObjectAppId) {
+    String query =
+      "MATCH (d:DataObject {appId: $aid})-[:has_reference]->(r:StructuredDataReference) " +
+      "WHERE (r.deleted IS NULL OR r.deleted = false) " +
+      "RETURN count(r) AS cnt";
+    for (var row : session.query(query, Map.of("aid", dataObjectAppId))) {
+      Object cnt = row.get("cnt");
+      return cnt instanceof Number n ? n.intValue() : 0;
+    }
+    return 0;
+  }
+
+  /**
+   * APISIMP-REFS-HANDLER-PAGING-TAIL — paginated list of non-deleted StructuredDataReferences
+   * under a DataObject (resolved by appId). Pushes SKIP/LIMIT to Neo4j.
+   *
+   * @param dataObjectAppId the parent DataObject's appId.
+   * @param skip 0-based offset.
+   * @param limit maximum rows (must be &gt; 0).
+   * @return the StructuredDataReferences for the requested page; never null.
+   */
+  public List<StructuredDataReference> findByDataObjectAppId(String dataObjectAppId, int skip, int limit) {
+    String query =
+      "MATCH (d:DataObject {appId: $aid})-[hr:has_reference]->(r:StructuredDataReference) " +
+      "WHERE (r.deleted IS NULL OR r.deleted = false) " +
+      "RETURN r, d, hr " +
+      "ORDER BY r.createdAt ASC " +
+      "SKIP $skip LIMIT $limit";
+    var queryResult = findByQuery(
+      query,
+      Map.of("aid", dataObjectAppId, "skip", (long) skip, "limit", (long) limit)
+    );
+    return StreamSupport.stream(queryResult.spliterator(), false).toList();
+  }
+
   @Override
   public Class<StructuredDataReference> getEntityType() {
     return StructuredDataReference.class;

--- a/backend/src/main/java/de/dlr/shepard/context/references/timeseriesreference/daos/TimeseriesReferenceDAO.java
+++ b/backend/src/main/java/de/dlr/shepard/context/references/timeseriesreference/daos/TimeseriesReferenceDAO.java
@@ -99,6 +99,49 @@ public class TimeseriesReferenceDAO extends VersionableEntityDAO<TimeseriesRefer
     return iter.hasNext() ? iter.next() : null;
   }
 
+  /**
+   * APISIMP-REFS-HANDLER-PAGING-TAIL — count of non-deleted TimeseriesReferences under a
+   * DataObject (resolved by appId). Pushes the predicate to Neo4j so the caller never loads all
+   * rows just to count them.
+   *
+   * @param dataObjectAppId the parent DataObject's appId.
+   * @return total count of matching, non-deleted TimeseriesReferences.
+   */
+  public int countByDataObjectAppId(String dataObjectAppId) {
+    String query =
+      "MATCH (d:DataObject {appId: $aid})-[:has_reference]->(r:TimeseriesReference) " +
+      "WHERE (r.deleted IS NULL OR r.deleted = false) " +
+      "RETURN count(r) AS cnt";
+    for (var row : session.query(query, Map.of("aid", dataObjectAppId))) {
+      Object cnt = row.get("cnt");
+      return cnt instanceof Number n ? n.intValue() : 0;
+    }
+    return 0;
+  }
+
+  /**
+   * APISIMP-REFS-HANDLER-PAGING-TAIL — paginated list of non-deleted TimeseriesReferences under a
+   * DataObject (resolved by appId). Pushes SKIP/LIMIT to Neo4j.
+   *
+   * @param dataObjectAppId the parent DataObject's appId.
+   * @param skip 0-based offset.
+   * @param limit maximum rows (must be &gt; 0).
+   * @return the TimeseriesReferences for the requested page; never null.
+   */
+  public List<TimeseriesReference> findByDataObjectAppId(String dataObjectAppId, int skip, int limit) {
+    String query =
+      "MATCH (d:DataObject {appId: $aid})-[hr:has_reference]->(r:TimeseriesReference) " +
+      "WHERE (r.deleted IS NULL OR r.deleted = false) " +
+      "RETURN r, d, hr " +
+      "ORDER BY r.createdAt ASC " +
+      "SKIP $skip LIMIT $limit";
+    var queryResult = findByQuery(
+      query,
+      Map.of("aid", dataObjectAppId, "skip", (long) skip, "limit", (long) limit)
+    );
+    return StreamSupport.stream(queryResult.spliterator(), false).toList();
+  }
+
   @Override
   public Class<TimeseriesReference> getEntityType() {
     return TimeseriesReference.class;

--- a/backend/src/main/java/de/dlr/shepard/v2/references/handlers/CollectionReferenceKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/handlers/CollectionReferenceKindHandler.java
@@ -5,6 +5,7 @@ import de.dlr.shepard.context.collection.daos.DataObjectDAO;
 import de.dlr.shepard.context.collection.entities.Collection;
 import de.dlr.shepard.context.collection.entities.DataObject;
 import de.dlr.shepard.context.references.basicreference.entities.BasicReference;
+import de.dlr.shepard.context.references.dataobject.daos.CollectionReferenceDAO;
 import de.dlr.shepard.context.references.dataobject.entities.CollectionReference;
 import de.dlr.shepard.context.references.dataobject.io.CollectionReferenceIO;
 import de.dlr.shepard.context.references.dataobject.services.CollectionReferenceService;
@@ -33,6 +34,9 @@ public class CollectionReferenceKindHandler implements ReferenceKindHandler {
 
   @Inject
   CollectionReferenceService collectionReferenceService;
+
+  @Inject
+  CollectionReferenceDAO collectionReferenceDAO;
 
   @Inject
   DataObjectDAO dataObjectDAO;
@@ -124,6 +128,27 @@ public class CollectionReferenceKindHandler implements ReferenceKindHandler {
       parent.getShepardId(),
       null
     );
+    List<ReferenceV2IO> out = new ArrayList<>(refs.size());
+    for (CollectionReference ref : refs) {
+      if (ref != null && !ref.isDeleted()) out.add(toIO(ref));
+    }
+    return out;
+  }
+
+  @Override
+  public int countByDataObject(String dataObjectAppId, String subKind) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
+      throw new BadRequestException("dataObjectAppId is required");
+    }
+    return collectionReferenceDAO.countByDataObjectAppId(dataObjectAppId);
+  }
+
+  @Override
+  public List<ReferenceV2IO> listByDataObject(String dataObjectAppId, String subKind, int skip, int limit) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
+      throw new BadRequestException("dataObjectAppId is required");
+    }
+    List<CollectionReference> refs = collectionReferenceDAO.findByDataObjectAppId(dataObjectAppId, skip, limit);
     List<ReferenceV2IO> out = new ArrayList<>(refs.size());
     for (CollectionReference ref : refs) {
       if (ref != null && !ref.isDeleted()) out.add(toIO(ref));

--- a/backend/src/main/java/de/dlr/shepard/v2/references/handlers/DataObjectReferenceKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/handlers/DataObjectReferenceKindHandler.java
@@ -4,6 +4,7 @@ import de.dlr.shepard.context.collection.daos.DataObjectDAO;
 import de.dlr.shepard.context.collection.entities.Collection;
 import de.dlr.shepard.context.collection.entities.DataObject;
 import de.dlr.shepard.context.references.basicreference.entities.BasicReference;
+import de.dlr.shepard.context.references.dataobject.daos.DataObjectReferenceDAO;
 import de.dlr.shepard.context.references.dataobject.entities.DataObjectReference;
 import de.dlr.shepard.context.references.dataobject.io.DataObjectReferenceIO;
 import de.dlr.shepard.context.references.dataobject.services.DataObjectReferenceService;
@@ -35,6 +36,9 @@ public class DataObjectReferenceKindHandler implements ReferenceKindHandler {
 
   @Inject
   DataObjectReferenceService dataObjectReferenceService;
+
+  @Inject
+  DataObjectReferenceDAO dataObjectReferenceDAO;
 
   @Inject
   DataObjectDAO dataObjectDAO;
@@ -134,6 +138,27 @@ public class DataObjectReferenceKindHandler implements ReferenceKindHandler {
       parent.getShepardId(),
       null
     );
+    List<ReferenceV2IO> out = new ArrayList<>(refs.size());
+    for (DataObjectReference ref : refs) {
+      if (ref != null && !ref.isDeleted()) out.add(toIO(ref));
+    }
+    return out;
+  }
+
+  @Override
+  public int countByDataObject(String dataObjectAppId, String subKind) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
+      throw new BadRequestException("dataObjectAppId is required");
+    }
+    return dataObjectReferenceDAO.countByDataObjectAppId(dataObjectAppId);
+  }
+
+  @Override
+  public List<ReferenceV2IO> listByDataObject(String dataObjectAppId, String subKind, int skip, int limit) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
+      throw new BadRequestException("dataObjectAppId is required");
+    }
+    List<DataObjectReference> refs = dataObjectReferenceDAO.findByDataObjectAppId(dataObjectAppId, skip, limit);
     List<ReferenceV2IO> out = new ArrayList<>(refs.size());
     for (DataObjectReference ref : refs) {
       if (ref != null && !ref.isDeleted()) out.add(toIO(ref));

--- a/backend/src/main/java/de/dlr/shepard/v2/references/handlers/FileBundleReferenceKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/handlers/FileBundleReferenceKindHandler.java
@@ -169,6 +169,27 @@ public class FileBundleReferenceKindHandler implements ReferenceKindHandler {
     return out;
   }
 
+  @Override
+  public int countByDataObject(String dataObjectAppId, String subKind) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
+      throw new BadRequestException("dataObjectAppId is required");
+    }
+    return fileBundleReferenceDAO.countByDataObjectAppId(dataObjectAppId);
+  }
+
+  @Override
+  public List<ReferenceV2IO> listByDataObject(String dataObjectAppId, String subKind, int skip, int limit) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
+      throw new BadRequestException("dataObjectAppId is required");
+    }
+    List<FileBundleReference> refs = fileBundleReferenceDAO.findByDataObjectAppId(dataObjectAppId, skip, limit);
+    List<ReferenceV2IO> out = new ArrayList<>(refs.size());
+    for (FileBundleReference ref : refs) {
+      if (ref != null) out.add(toIO(ref));
+    }
+    return out;
+  }
+
   private DataObject resolveParent(String dataObjectAppId) {
     if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
       throw new BadRequestException("dataObjectAppId is required");

--- a/backend/src/main/java/de/dlr/shepard/v2/references/handlers/StructuredDataReferenceKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/handlers/StructuredDataReferenceKindHandler.java
@@ -273,6 +273,27 @@ public class StructuredDataReferenceKindHandler implements ReferenceKindHandler 
     return out;
   }
 
+  @Override
+  public int countByDataObject(String dataObjectAppId, String subKind) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
+      throw new BadRequestException("dataObjectAppId is required");
+    }
+    return structuredDataReferenceDAO.countByDataObjectAppId(dataObjectAppId);
+  }
+
+  @Override
+  public List<ReferenceV2IO> listByDataObject(String dataObjectAppId, String subKind, int skip, int limit) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
+      throw new BadRequestException("dataObjectAppId is required");
+    }
+    List<StructuredDataReference> refs = structuredDataReferenceDAO.findByDataObjectAppId(dataObjectAppId, skip, limit);
+    List<ReferenceV2IO> out = new ArrayList<>(refs.size());
+    for (StructuredDataReference ref : refs) {
+      if (ref != null) out.add(toIO(ref));
+    }
+    return out;
+  }
+
   private DataObject resolveParent(String dataObjectAppId) {
     if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
       throw new BadRequestException("dataObjectAppId is required");

--- a/backend/src/main/java/de/dlr/shepard/v2/references/handlers/TimeseriesReferenceKindHandler.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/references/handlers/TimeseriesReferenceKindHandler.java
@@ -235,6 +235,27 @@ public class TimeseriesReferenceKindHandler implements ReferenceKindHandler {
     return out;
   }
 
+  @Override
+  public int countByDataObject(String dataObjectAppId, String subKind) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
+      throw new BadRequestException("dataObjectAppId is required");
+    }
+    return timeseriesReferenceDAO.countByDataObjectAppId(dataObjectAppId);
+  }
+
+  @Override
+  public List<ReferenceV2IO> listByDataObject(String dataObjectAppId, String subKind, int skip, int limit) {
+    if (dataObjectAppId == null || dataObjectAppId.isBlank()) {
+      throw new BadRequestException("dataObjectAppId is required");
+    }
+    List<TimeseriesReference> refs = timeseriesReferenceDAO.findByDataObjectAppId(dataObjectAppId, skip, limit);
+    List<ReferenceV2IO> out = new ArrayList<>(refs.size());
+    for (TimeseriesReference ref : refs) {
+      if (ref != null) out.add(toIO(ref));
+    }
+    return out;
+  }
+
   // ─── annotation sub-resource (APISIMP-ANNOTATION-SUBRESOURCE-COLLISION) ──
 
   @Override


### PR DESCRIPTION
## Summary

- **What:** The five remaining in-tree `ReferenceKindHandler` implementations (`timeseries`, `bundle`, `structured-data`, `collection`, `dataobject`) fell through to the SPI in-memory paging defaults. Every paged `GET /v2/references?kind=…` request loaded the full unbounded Neo4j result set into Java memory, then sliced it with `.subList()` and counted with `.size()`.
- **Fix:** Add `countByDataObjectAppId(String)` + `findByDataObjectAppId(String, int, int)` (raw Cypher `SKIP $skip LIMIT $limit`) to each handler's DAO. Override `countByDataObject` + `listByDataObject(skip, limit)` in each handler to call those DAO methods directly — no intermediate service layer.
- **Pattern:** Follows `URIReferenceDAO` (fire-633) and `SingletonFileReferenceDAO` (fire-634). `FileBundleReferenceDAO` count/paged queries use the `:FileBundleReference` label so singletons (only `:FileReference`) are excluded without relying on OGM class discrimination. `CollectionReferenceKindHandler` and `DataObjectReferenceKindHandler` now inject their DAOs directly for the paged path (previously only needed the service layer).

## Files changed

**DAOs** (new `countByDataObjectAppId` + `findByDataObjectAppId(skip,limit)`):
- `TimeseriesReferenceDAO`
- `FileBundleReferenceDAO`
- `StructuredDataReferenceDAO`
- `CollectionReferenceDAO`
- `DataObjectReferenceDAO`

**Handlers** (new `countByDataObject` + `listByDataObject(skip,limit)` overrides):
- `TimeseriesReferenceKindHandler`
- `FileBundleReferenceKindHandler`
- `StructuredDataReferenceKindHandler`
- `CollectionReferenceKindHandler` (+ `@Inject CollectionReferenceDAO`)
- `DataObjectReferenceKindHandler` (+ `@Inject DataObjectReferenceDAO`)

**Backlog:**
- `aidocs/16`: `APISIMP-REFS-HANDLER-PAGING-TAIL` → in-PR; `APISIMP-MCP-ANNOT-INMEM` → done (PR #2605 sha aa799de)

## AC

`GET /v2/references?kind=timeseries&dataObjectAppId=…&pageSize=10&page=1` issues a `count(r)` Cypher query and a `SKIP 10 LIMIT 10` Cypher query; no unbounded load. Same for `kind=bundle`, `kind=structured-data`, `kind=collection`, `kind=dataobject`. `mvn verify -DnoPlugins -DbootstrapTestjar` green (5 727 tests, 2 pre-existing `PluginRegistryTest` failures from absent plugin JARs + 1 `MigrationChainInspectorIT` Docker error, all unrelated to this PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsvuuK4yUcGA5JME1RckPo)_