### PR TITLE
perf(APISIMP-ADMINCONFIG-INMEM-PAGE): fix in-memory pagination in AdminConfigRest + PluginsAdminRest

### DIFF
--- a/aidocs/01-doc-stage-index.md
+++ b/aidocs/01-doc-stage-index.md
@@ -91,7 +91,7 @@ section and the `upgrade-overlay` section.
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-15-fire613.md`](agent-findings/apisimp-sweep-2026-07-15-fire613.md) | APISIMP Sweep — fire-613 (2026-07-15) | 2026-07-15 | 2026-07-15 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-15-fire620.md`](agent-findings/apisimp-sweep-2026-07-15-fire620.md) | APISIMP Sweep — fire-620 (2026-07-15) | 2026-07-15 | 2026-07-15 |
 | [`aidocs/agent-findings/apisimp-sweep-2026-07-15-fire621.md`](agent-findings/apisimp-sweep-2026-07-15-fire621.md) | APISIMP Sweep — fire-621 (2026-07-15) | 2026-07-15 | 2026-07-15 |
-| [`aidocs/agent-findings/apisimp-sweep-2026-07-17-fire647.md`](agent-findings/apisimp-sweep-2026-07-17-fire647.md) | APISIMP sweep — fire-647 / 2026-07-17 | 2026-07-17 | — |
+| [`aidocs/agent-findings/apisimp-sweep-2026-07-17-fire647.md`](agent-findings/apisimp-sweep-2026-07-17-fire647.md) | APISIMP sweep — fire-647 / 2026-07-17 | 2026-07-17 | 2026-07-17 |
 | [`aidocs/agent-findings/apisimp-sweep-fire355-2026-07-02.md`](agent-findings/apisimp-sweep-fire355-2026-07-02.md) | APISIMP REST Surface Sweep — fire-355 (2026-07-02) | 2026-07-02 | 2026-07-15 |
 | [`aidocs/agent-findings/apisimp-sweep-fire367-2026-07-02.md`](agent-findings/apisimp-sweep-fire367-2026-07-02.md) | APISIMP REST Surface Sweep — fire-367 (2026-07-02) | 2026-07-02 | 2026-07-15 |
 | [`aidocs/agent-findings/apisimp-sweep-fire373-2026-07-02.md`](agent-findings/apisimp-sweep-fire373-2026-07-02.md) | APISIMP REST Surface Sweep — fire-373 (2026-07-02) | 2026-07-02 | 2026-07-15 |

--- a/aidocs/16-dispatcher-backlog.md
+++ b/aidocs/16-dispatcher-backlog.md
@@ -5886,7 +5886,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/labjournal/io/LabJournalEntryV2IO.java`; `backend/src/test/java/de/dlr/shepard/v2/labjournal/io/LabJournalEntryV2IOTest.java`.
 
 ## APISIMP-ADMINCONFIG-INMEM-PAGE — AdminConfigRest.listFeatures() subLists full registry on every page request (size: S, sweep: fire-647)
-- **Status:** 📋 queued.
+- **Status:** 🚧 PR open (fire-648, branch `APISIMP-ADMINCONFIG-INMEM-PAGE`).
 - **Why:** `AdminConfigRest.listFeatures()` at `AdminConfigRest.java:96` calls `registry.all()` to materialise every `ConfigDescriptor` in the JVM-resident SPI registry, converts them all to `ConfigFeatureIO` rows, takes `rows.size()` as total, then slices with `rows.subList((int)from, ...)`. The full list is allocated on every request even when the caller asks for a single page. Harmless at current registry size but will regress as the plugin ecosystem grows.
 - **Fix:** Add `ConfigFeatureRegistry.count()` and `ConfigFeatureRegistry.list(long skip, int limit)` that slice the backing list internally. In `listFeatures()`, call `count()` for total and `list(page * pageSize, pageSize)` for the slice — no `subList` on the outer list.
 - **AC:** `GET /v2/admin/config/features?page=1&pageSize=1` returns exactly 1 item and `X-Total-Count` equals the full registry size; a registry with 200 features does not allocate a 200-element list on a page-1 request; `mvn verify -pl backend` green.
@@ -5900,7 +5900,7 @@ picks these up. Terse by design.
 - **First refs:** `backend/src/main/java/de/dlr/shepard/v2/admin/semantic/SemanticAdminRest.java:289`; `aidocs/agent-findings/apisimp-sweep-2026-07-17-fire647.md §Finding2`.
 
 ## APISIMP-PLUGINS-INMEM-PAGE — PluginsAdminRest.list() calls isEnabled() on all plugins before subList page slice (size: S, sweep: fire-647)
-- **Status:** 📋 queued.
+- **Status:** 🚧 PR open (fire-648, branch `APISIMP-ADMINCONFIG-INMEM-PAGE`).
 - **Why:** `PluginsAdminRest.list()` at `PluginsAdminRest.java:141` calls `registry.list()` to get all registered `PluginEntry` objects, maps them all to `PluginEntryIO` (including an `isEnabled()` call per entry), then computes `rows.size()` for total and slices with `rows.subList()`. All plugins are fully evaluated and mapped on every paginated request regardless of page size.
 - **Fix:** Add `PluginRegistry.count()` and `PluginRegistry.list(long skip, int limit)`. In `list()`, call `count()` for total, then call `list(page * pageSize, pageSize)` and map only the slice — avoids calling `isEnabled()` for all plugins when only a page is needed.
 - **AC:** `GET /v2/admin/plugins?page=0&pageSize=10` with 200 registered plugins only calls `isEnabled()` 10 times; `X-Total-Count` is 200; `mvn verify -pl backend` green.

--- a/backend/src/main/java/de/dlr/shepard/plugin/PluginRegistry.java
+++ b/backend/src/main/java/de/dlr/shepard/plugin/PluginRegistry.java
@@ -946,6 +946,19 @@ public class PluginRegistry {
     return List.copyOf(entries.values());
   }
 
+  /** Count of discovered plugins. O(1). */
+  public int count() {
+    return entries.size();
+  }
+
+  /**
+   * Slice of discovered plugin entries, in insertion order.
+   * Allocates only the requested slice — does NOT call {@link #isEnabled}.
+   */
+  public List<PluginEntry> list(long skip, int limit) {
+    return entries.values().stream().skip(skip).limit(limit).toList();
+  }
+
   /** Look up a plugin by its declared id. */
   public Optional<PluginEntry> get(String id) {
     return Optional.ofNullable(entries.get(id));

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/config/resources/AdminConfigRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/config/resources/AdminConfigRest.java
@@ -93,13 +93,11 @@ public class AdminConfigRest {
     @QueryParam("page") @DefaultValue("0") @Min(0) int page,
     @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize
   ) {
-    List<ConfigFeatureIO> rows = registry.all()
+    long total = registry.count();
+    List<ConfigFeatureIO> slice = registry.list((long) page * pageSize, pageSize)
       .stream()
       .map(d -> new ConfigFeatureIO(d.featureName(), d.description()))
       .toList();
-    long total = rows.size();
-    long from = Math.min((long) page * pageSize, total);
-    List<ConfigFeatureIO> slice = rows.subList((int) from, (int) Math.min(from + pageSize, total));
     return Response.ok(new PagedResponseIO<>(slice, total, page, pageSize))
       .header("X-Total-Count", total)
       .build();

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/config/spi/ConfigRegistry.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/config/spi/ConfigRegistry.java
@@ -88,4 +88,17 @@ public class ConfigRegistry {
   public List<ConfigDescriptor<?>> all() {
     return Collections.unmodifiableList(List.copyOf(byFeature.values()));
   }
+
+  /** Count of registered features. O(1). */
+  public int count() {
+    return byFeature.size();
+  }
+
+  /**
+   * Slice of registered descriptors, in registration order.
+   * Allocates only the requested slice, not the full list.
+   */
+  public List<ConfigDescriptor<?>> list(long skip, int limit) {
+    return byFeature.values().stream().skip(skip).limit(limit).toList();
+  }
 }

--- a/backend/src/main/java/de/dlr/shepard/v2/admin/plugins/PluginsAdminRest.java
+++ b/backend/src/main/java/de/dlr/shepard/v2/admin/plugins/PluginsAdminRest.java
@@ -29,7 +29,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -138,17 +137,12 @@ public class PluginsAdminRest {
     @Parameter(description = "Page size 1–200 (default 50).")
     @QueryParam("pageSize") @DefaultValue("50") @Min(1) @Max(200) int pageSize
   ) {
-    List<PluginEntry> entries = registry.list();
-    List<PluginEntryIO> rows = new ArrayList<>(entries.size());
-    for (PluginEntry entry : entries) {
-      rows.add(PluginEntryIO.from(entry, registry.isEnabled(entry.id())));
-    }
-    long from = (long) page * pageSize;
-    List<PluginEntryIO> slice = from >= rows.size()
-        ? List.of()
-        : rows.subList((int) from, (int) Math.min(from + pageSize, rows.size()));
-    return Response.ok(new PagedResponseIO<>(slice, rows.size(), page, pageSize))
-        .header("X-Total-Count", (long) rows.size())
+    long total = registry.count();
+    List<PluginEntryIO> slice = registry.list((long) page * pageSize, pageSize).stream()
+        .map(entry -> PluginEntryIO.from(entry, registry.isEnabled(entry.id())))
+        .toList();
+    return Response.ok(new PagedResponseIO<>(slice, total, page, pageSize))
+        .header("X-Total-Count", total)
         .build();
   }
 

--- a/backend/src/test/java/de/dlr/shepard/v2/admin/config/resources/AdminConfigRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/admin/config/resources/AdminConfigRestTest.java
@@ -3,6 +3,8 @@ package de.dlr.shepard.v2.admin.config.resources;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -87,7 +89,9 @@ class AdminConfigRestTest {
 
   @Test
   void listFeaturesReturnsRegisteredRows() {
-    Mockito.when(registry.all()).thenReturn(List.of(new FakeDescriptor()));
+    FakeDescriptor d = new FakeDescriptor();
+    Mockito.when(registry.count()).thenReturn(1);
+    Mockito.when(registry.list(anyLong(), anyInt())).thenReturn(List.of(d));
     Response resp = rest.listFeatures(0, 50);
     assertEquals(200, resp.getStatus());
     @SuppressWarnings("unchecked")
@@ -102,7 +106,8 @@ class AdminConfigRestTest {
 
   @Test
   void listFeaturesReturnsSizeInBody() {
-    Mockito.when(registry.all()).thenReturn(List.of(new FakeDescriptor(), new FakeDescriptor()));
+    Mockito.when(registry.count()).thenReturn(2);
+    Mockito.when(registry.list(anyLong(), anyInt())).thenReturn(List.of(new FakeDescriptor(), new FakeDescriptor()));
     Response resp = rest.listFeatures(0, 50);
     assertEquals(200, resp.getStatus());
     @SuppressWarnings("unchecked")
@@ -113,7 +118,8 @@ class AdminConfigRestTest {
 
   @Test
   void listFeaturesEmptyWhenRegistryEmpty() {
-    Mockito.when(registry.all()).thenReturn(List.of());
+    Mockito.when(registry.count()).thenReturn(0);
+    Mockito.when(registry.list(anyLong(), anyInt())).thenReturn(List.of());
     Response resp = rest.listFeatures(0, 50);
     assertEquals(200, resp.getStatus());
     @SuppressWarnings("unchecked")
@@ -124,7 +130,8 @@ class AdminConfigRestTest {
 
   @Test
   void listFeaturesXTotalCountHeader() {
-    Mockito.when(registry.all()).thenReturn(List.of(new FakeDescriptor(), new FakeDescriptor()));
+    Mockito.when(registry.count()).thenReturn(2);
+    Mockito.when(registry.list(anyLong(), anyInt())).thenReturn(List.of(new FakeDescriptor(), new FakeDescriptor()));
     Response resp = rest.listFeatures(0, 50);
     assertEquals(200, resp.getStatus());
     assertEquals("2", resp.getHeaderString("X-Total-Count"));
@@ -132,13 +139,28 @@ class AdminConfigRestTest {
 
   @Test
   void listFeaturesCustomPageParams() {
-    Mockito.when(registry.all()).thenReturn(List.of(new FakeDescriptor()));
+    Mockito.when(registry.count()).thenReturn(1);
+    Mockito.when(registry.list(anyLong(), anyInt())).thenReturn(List.of());
     Response resp = rest.listFeatures(1, 10);
     assertEquals(200, resp.getStatus());
     @SuppressWarnings("unchecked")
     PagedResponseIO<ConfigFeatureIO> body = (PagedResponseIO<ConfigFeatureIO>) resp.getEntity();
     assertEquals(1, body.page());
     assertEquals(10, body.pageSize());
+  }
+
+  @Test
+  void listFeaturesSlicePassesCorrectSkipAndLimit() {
+    FakeDescriptor d = new FakeDescriptor();
+    Mockito.when(registry.count()).thenReturn(25);
+    Mockito.when(registry.list(10L, 10)).thenReturn(List.of(d));
+    Response resp = rest.listFeatures(1, 10);
+    assertEquals(200, resp.getStatus());
+    Mockito.verify(registry).list(10L, 10);
+    @SuppressWarnings("unchecked")
+    PagedResponseIO<ConfigFeatureIO> body = (PagedResponseIO<ConfigFeatureIO>) resp.getEntity();
+    assertEquals(25L, body.total());
+    assertEquals(1, body.items().size());
   }
 
   @Test

--- a/backend/src/test/java/de/dlr/shepard/v2/admin/plugins/PluginsAdminRestTest.java
+++ b/backend/src/test/java/de/dlr/shepard/v2/admin/plugins/PluginsAdminRestTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 
 import de.dlr.shepard.common.exceptions.ProblemJson;
 import de.dlr.shepard.plugin.PluginContext;
@@ -77,7 +79,8 @@ class PluginsAdminRestTest {
 
   @Test
   void listEmptyReturns200WithEmptyArray() {
-    Mockito.when(registry.list()).thenReturn(List.of());
+    Mockito.when(registry.count()).thenReturn(0);
+    Mockito.when(registry.list(anyLong(), anyInt())).thenReturn(List.of());
 
     Response r = resource.list(0, 50);
 
@@ -99,7 +102,8 @@ class PluginsAdminRestTest {
       Paths.get("/deployments/plugins/shepard-plugin-hdf-hsds-0.3.0.jar"),
       true
     );
-    Mockito.when(registry.list()).thenReturn(List.of(unhide, hdf));
+    Mockito.when(registry.count()).thenReturn(2);
+    Mockito.when(registry.list(0L, 50)).thenReturn(List.of(unhide, hdf));
     Mockito.when(registry.isEnabled("unhide")).thenReturn(false);
     Mockito.when(registry.isEnabled("hdf-hsds")).thenReturn(true);
 
@@ -129,10 +133,9 @@ class PluginsAdminRestTest {
 
   @Test
   void listEnrichedManifest_surfacesPm1cFields() {
-    // A manifest that overrides every PM1c default — title / description /
-    // homepage / repository / licence / dependencies all visible in the IO.
     PluginEntry enriched = new PluginEntry(richManifest(), null, Instant.parse("2026-05-13T05:00:00Z"));
-    Mockito.when(registry.list()).thenReturn(List.of(enriched));
+    Mockito.when(registry.count()).thenReturn(1);
+    Mockito.when(registry.list(anyLong(), anyInt())).thenReturn(List.of(enriched));
     Mockito.when(registry.isEnabled("rich")).thenReturn(true);
 
     Response r = resource.list(0, 50);
@@ -157,16 +160,13 @@ class PluginsAdminRestTest {
 
   @Test
   void listBareManifest_collapsesBlankPm1cFieldsToNull() {
-    // A bare manifest takes every PM1c default. title() defaults to id();
-    // description() / licence() are empty strings; URLs are Optional.empty.
-    // The IO collapses blank strings to null so they're omitted under
-    // JsonInclude.NON_NULL — clients see only what the plugin declared.
     PluginEntry bare = new PluginEntry(
       stubManifest("bare", "0.1.0", ">=5.2.0,<6"),
       null,
       Instant.parse("2026-05-13T05:00:00Z")
     );
-    Mockito.when(registry.list()).thenReturn(List.of(bare));
+    Mockito.when(registry.count()).thenReturn(1);
+    Mockito.when(registry.list(anyLong(), anyInt())).thenReturn(List.of(bare));
     Mockito.when(registry.isEnabled("bare")).thenReturn(true);
 
     Response r = resource.list(0, 50);
@@ -180,6 +180,23 @@ class PluginsAdminRestTest {
     assertNull(io.licence(), "blank licence collapses to null");
     assertNotNull(io.dependencies(), "dependencies is always a list, never null");
     assertTrue(io.dependencies().isEmpty());
+  }
+
+  @Test
+  void listSlicePassesCorrectSkipAndLimit() {
+    PluginEntry unhide = newEntry("unhide", "1.0.0", ">=5.2.0,<6", null, false);
+    Mockito.when(registry.count()).thenReturn(25);
+    Mockito.when(registry.list(10L, 10)).thenReturn(List.of(unhide));
+    Mockito.when(registry.isEnabled("unhide")).thenReturn(false);
+
+    Response r = resource.list(1, 10);
+
+    assertEquals(200, r.getStatus());
+    Mockito.verify(registry).list(10L, 10);
+    @SuppressWarnings("unchecked")
+    PagedResponseIO<PluginEntryIO> body = (PagedResponseIO<PluginEntryIO>) r.getEntity();
+    assertEquals(25L, body.total());
+    assertEquals(1, body.items().size());
   }
 
   // ─── PATCH happy paths ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the in-memory full-list-then-subList pagination anti-pattern in two admin REST endpoints (APISIMP-ADMINCONFIG-INMEM-PAGE + APISIMP-PLUGINS-INMEM-PAGE, fire-648).

**Root cause:** Both endpoints materialised the entire registry into a `List<>`, computed `total` from `list.size()`, then called `subList()` to extract the page — O(N) allocation on every request regardless of page size.

**Fix:**

- `ConfigRegistry` — adds `count()` (O(1) `byFeature.size()`) and `list(long skip, int limit)` (stream `skip+limit`, allocates only the slice). `AdminConfigRest.listFeatures()` now calls `count()` for total and `list(page*pageSize, pageSize)` for items.
- `PluginRegistry` — adds `count()` (O(1)) and `list(long skip, int limit)` overload alongside the preserved no-arg `list()` (10+ callers, not changed). `PluginsAdminRest.list()` now calls `count()` for total and maps only the sliced entries — `isEnabled()` is called for O(pageSize) entries instead of O(N).
- Removes unused `ArrayList` import from `PluginsAdminRest`.

**Tests:** `AdminConfigRestTest` (16 tests) and `PluginsAdminRestTest` (19 tests) updated to mock the new `count()`+`list(long,int)` surface; each adds a `listSlicePassesCorrectSkipAndLimit` test verifying correct skip/limit forwarding. All pass locally.

## Backlog rows closed

- `APISIMP-ADMINCONFIG-INMEM-PAGE` (fire-647 sweep, Finding 1)
- `APISIMP-PLUGINS-INMEM-PAGE` (fire-647 sweep, Finding 3)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LqUky861tuxSKBW83DaUbq)_