### PR TITLE
fix(APISIMP-CONT-NS-COLLAPSE-6): FILE+STRUCTUREDDATA bulk safe-delete uses wire-cast appId

### DIFF
--- a/frontend/components/container/ContainerListPage.vue
+++ b/frontend/components/container/ContainerListPage.vue
@@ -161,8 +161,11 @@ async function deleteContainerByType(container: BasicContainer): Promise<void> {
   // excluded above by the orphan-check rule, but be defensive here too.
   switch (container.type as ContainerType) {
     case "FILE": {
-      // V2-SWEEP-003: v2 safe-delete (replaces v1 FileContainerApi.deleteFileContainer)
-      const r = await safeDeleteContainer("file", container.id);
+      // APISIMP-CONT-NS-COLLAPSE-6: the unified DELETE /v2/containers/{appId} is
+      // appId-keyed; appId is carried by the wire even though BasicContainer's TS
+      // type omits it. Passing the numeric id here 404s (DAO lookup is appId-strict).
+      const containerAppId = (container as unknown as { appId?: string | null }).appId ?? container.id;
+      const r = await safeDeleteContainer("file", containerAppId);
       if (!r.ok) throw new Error(`${r.conflict.referenceCount} active reference(s)`);
       return;
     }
@@ -175,8 +178,10 @@ async function deleteContainerByType(container: BasicContainer): Promise<void> {
       return;
     }
     case "STRUCTUREDDATA": {
-      // V2-SWEEP-003: v2 safe-delete (replaces v1 StructuredDataContainerApi.deleteStructuredDataContainer)
-      const r = await safeDeleteContainer("structured-data", container.id);
+      // APISIMP-CONT-NS-COLLAPSE-6: appId-keyed for the unified DELETE — see FILE
+      // case above; numeric id would 404 against the appId-strict resolver.
+      const containerAppId = (container as unknown as { appId?: string | null }).appId ?? container.id;
+      const r = await safeDeleteContainer("structured-data", containerAppId);
       if (!r.ok) throw new Error(`${r.conflict.referenceCount} active reference(s)`);
       return;
     }


### PR DESCRIPTION
## What this is

The **surviving residue** of the orphaned dispatcher branch `APISIMP-CONT-NS-COLLAPSE-6-safe-delete-unify` (commit `d25340f42`, 2026-06-15). During the revive pass, both orphaned CONT-NS-COLLAPSE branches turned out to be almost entirely **superseded by main's July APISIMP wave**:

- DI1 safe-delete (`?force` + 409 `SafeDeleteConflict`) on `DELETE /v2/containers/{appId}` — re-landed by #1950
- Deletion of the 3 per-kind `*LinkedDataObjectsRest` files + tests — re-landed by #1950/#1951
- `safeDeleteContainer.ts` unified path + `useFetchPayloadVersions.ts` migration — re-landed by #1951/#1956

The one hunk that never re-landed is this fix.

## The bug (live on main today)

`ContainerListPage.deleteContainerByType` still passes the numeric `BasicContainer.id` for **FILE** and **STRUCTUREDDATA** containers into the unified `DELETE /v2/containers/{appId}`. The resolver chain is appId-strict — `FileContainerDAO.findByAppId` / `StructuredDataContainerDAO.findByAppId` match `{appId: $appId}` only — so bulk-deleting those two kinds from the containers list page **404s**. The TIMESERIES case already wire-casts the `appId` (it is on the wire via `BasicEntityIO.appId` even though the generated TS type omits it); this PR applies the identical pattern to FILE and STRUCTUREDDATA.

## Gate results

- `npm run lint` — pass (0 errors; 18 pre-existing warnings)
- `npm run test` — pass (233 files, 2678 tests)
- `npm run typecheck` — 4 errors, all pre-existing on main (verified via stash + re-run: `mapPermissions.ts` x2, `AdminProvenanceDashboardPane.vue`, `ActivitySparklineCard.vue`); none in the changed file
- `mvn verify -pl backend` — N/A (no backend files touched)

## Revive-pass verdict on the two orphaned branches

- `APISIMP-CONT-NS-COLLAPSE-6-safe-delete-unify`: premise dead (per-kind LinkedDataObjectsRest files already deleted on main; DI1 already shipped) — **not revived**, except this hunk.
- `APISIMP-CONT-NS-COLLAPSE-7-stats-chartview-unify`: premise dead (stats + chart-view already live at `/v2/containers/{appId}/stats` and `/{appId}/chart-view` via #1944/#1947; old per-kind REST files deleted; frontend composables already migrated) — **not revived**, nothing salvageable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYcnq1eRUY7RX6VSbMnmQw